### PR TITLE
Added basic page object pattern implementation for Windows apps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,404 @@
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+##########################################
+# File Extension Settings
+##########################################
+
+# Visual Studio Solution Files
+[*.sln]
+indent_style = tab
+
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Various XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,ts,tsx,css,sass,scss,less,svg,vue}]
+indent_size = 2
+insert_final_newline = true
+
+# Batch Files
+[*.{cmd,bat}]
+
+# Bash Files
+[*.sh]
+end_of_line = lf
+
+##########################################
+# .NET Language Conventions
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#language-conventions
+##########################################
+
+# .NET Code Style Settings
+[*.{cs,csx,cake,vb}]
+# "this." and "Me." qualifiers
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#this_and_me
+#prefer fields to be prefaced with this. in C# or Me. in Visual Basic
+dotnet_style_qualification_for_field = true:warning
+#prefer properties to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = true:warning
+#prefer methods to be prefaced with this. in C# or Me. in Visual Basic
+dotnet_style_qualification_for_method = true:warning
+#prefer events to be prefaced with this. in C# or Me. in Visual Basic
+dotnet_style_qualification_for_event = true:warning
+
+# Language keywords instead of framework type names for type references
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#language_keywords
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+#prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Modifier preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#normalize_modifiers
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async
+dotnet_style_readonly_field = true:warning
+
+# Parentheses preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#parentheses
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# Expression-level preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#expression_level
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+
+# Null-checking preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#null_checking
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+
+# C# Code Style Settings
+[*.{cs,csx,cake}]
+# Implicit and explicit types
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#implicit-and-explicit-types
+#prefer explicit type over var to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = false:suggestion
+#prefer explicit var over type when the type is already mentioned on the right-hand side of a declaration
+csharp_style_var_when_type_is_apparent = true:warning
+#prefer explicit type over var to declare variables where type is elsewhere
+csharp_style_var_elsewhere = false:warning
+
+# Expression-bodied members
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#expression_bodied_members
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:warning
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:warning
+#prefer block bodies for operators
+csharp_style_expression_bodied_operators = false:warning
+#prefer expression-bodied members for properties
+csharp_style_expression_bodied_properties = true:warning
+#prefer expression-bodied members for indexers
+csharp_style_expression_bodied_indexers = true:warning
+#prefer expression-bodied members for accessors
+csharp_style_expression_bodied_accessors = true:warning
+
+# Pattern matching
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#pattern_matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+
+# Inlined variable declarations
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#inlined_variable_declarations
+#prefer out variables to be declared inline in the argument list of a method call when possible
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Expression-level preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#expression_level_csharp
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+
+# "Null" checking preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#null_checking_csharp
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+
+# Code block preferences
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#code_block
+csharp_prefer_braces = true:warning
+
+##########################################
+# .NET Formatting Conventions
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
+##########################################
+
+# Organize usings
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#usings
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+# Using statement placement (Undocumented)
+csharp_using_directive_placement = inside_namespace:warning
+
+# C# formatting settings
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#c-formatting-settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation options
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#indent
+#indent switch case contents.
+csharp_indent_case_contents = true
+#indent switch labels
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+
+# Spacing options
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#spacing
+#require NO space between a cast and the value
+csharp_space_after_cast = false
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping options
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#wrapping
+#leave statements and member declarations on the same line
+csharp_preserve_single_line_statements = true
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+
+# More Indentation options (Undocumented)
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+
+# Spacing Options (Undocumented)
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_square_brackets = false
+
+##########################################
+# .NET Naming Conventions
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions
+##########################################
+
+[*.{cs,csx,cake,vb}]
+
+##########################################
+# Styles
+##########################################
+
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the Pascal_case style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization  = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it's indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization  = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index
+##########################################
+
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
+
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols              = element_group
+dotnet_naming_rule.element_rule.style                = pascal_case_style
+dotnet_naming_rule.element_rule.severity             = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols              = interface_group
+dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity             = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity             = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols              = parameters_group
+dotnet_naming_rule.parameters_rule.style                = camel_case_style
+dotnet_naming_rule.parameters_rule.severity             = warning

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve Legerity
+title: "[Bug] "
+labels: bug
+assignees: ''
+
+---
+
+## Steps to reproduce
+<!-- Please describe below the details of the issue and steps taken to reproduce -->
+
+## Which package version are you using?
+<!-- Please provide the versions affected -->
+
+## What is the expected behaviour?
+<!-- Please describe below the expected behaviour -->
+
+## What is the actual behaviour?
+<!-- Please describe below the actual behaviour -->
+
+## What platform(s) does this affect?
+<!-- Please provide enough applicable information -->
+
+## Other information
+<!-- Please provide any additional information, links, screenshots or projects with reproduced issues below if applicable -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for Legerity
+title: "[Feature] "
+labels: feature-request
+assignees: ''
+
+---
+
+## Description
+<!-- Please describe the idea you'd like to see implemented -->
+
+## How will this benefit you and others?
+<!-- Please describe what benefit the introduction of the feature will bring to your project -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,13 @@
+## PR summary
+<!-- Please provide a description below of the changes made and how it was tested -->
+
+## PR checklist
+
+- [ ] Sample tests have been added/updated and pass
+- [ ] Code styling has been run on all new source file changes
+- [ ] Contains **NO** breaking changes
+
+<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->
+
+## References
+<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## PR summary
+<!-- Please provide a description below of the changes made and how it was tested -->
+
+## PR checklist
+
+- [ ] Sample tests have been added/updated and pass
+- [ ] Code styling has been run on all new source file changes
+- [ ] Contains **NO** breaking changes
+
+<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->
+
+## References
+<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# legerity
-A framework for speeding up the development of automated UI tests with Appium with .NET
+# Legerity
+
+A framework for speeding up the development of automated UI tests with Appium and .NET!
+
+## Package status
+
+| Source | Build | Current | Preview |
+| ------ | ------ | ------ | ------ |
+| NuGet | Coming soon! | Coming soon! | Coming soon! |

--- a/samples/WindowsAlarmsAndClock/BaseTestClass.cs
+++ b/samples/WindowsAlarmsAndClock/BaseTestClass.cs
@@ -1,0 +1,26 @@
+namespace WindowsAlarmsAndClock
+{
+    using Legerity;
+    using Legerity.Windows;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    public abstract class BaseTestClass
+    {
+        [TestInitialize]
+        public virtual void Initialize()
+        {
+            AppManager.StartApp(
+                new WindowsAppManagerOptions("Microsoft.WindowsAlarms_8wekyb3d8bbwe!App")
+                {
+                    AppiumDriverUrl = "http://127.0.0.1:4723"
+                });
+        }
+
+        [TestCleanup]
+        public virtual void Cleanup()
+        {
+            AppManager.StopApp();
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/Elements/CustomTimePicker.cs
+++ b/samples/WindowsAlarmsAndClock/Elements/CustomTimePicker.cs
@@ -1,0 +1,64 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the custom TimePicker control.
+    /// </summary>
+    public class CustomTimePicker : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomTimePicker"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference..
+        /// </param>
+        public CustomTimePicker(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the query for the hour looping selector.
+        /// </summary>
+        public By HourSelector => ByExtensions.AutomationId("HourLoopingSelector");
+
+        /// <summary>
+        /// Gets the query for the minute looping selector.
+        /// </summary>
+        public By MinuteSelector => ByExtensions.AutomationId("MinuteLoopingSelector");
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="CustomTimePicker"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomTimePicker"/>.
+        /// </returns>
+        public static implicit operator CustomTimePicker(WindowsElement element)
+        {
+            return new CustomTimePicker(element);
+        }
+
+        /// <summary>
+        /// Sets the time to the specified time.
+        /// </summary>
+        /// <param name="time">
+        /// The time to set.
+        /// </param>
+        public void SetTime(TimeSpan time)
+        {
+            this.Element.FindElement(this.HourSelector).FindElementByName(time.ToString("%h")).Click();
+            this.Element.FindElement(this.MinuteSelector).FindElementByName(time.ToString("mm")).Click();
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
@@ -1,0 +1,107 @@
+namespace WindowsAlarmsAndClock.Pages
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+
+    using Legerity.Pages;
+    using Legerity.Windows.Extensions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+
+    /// <summary>
+    /// Defines the alarm page of the Windows Alarms & Clock application.
+    /// </summary>
+    public class AlarmPage : BasePage
+    {
+        private readonly By addAlarmButton;
+
+        private readonly By selectAlarmsButton;
+
+        private readonly By alarmList;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AlarmPage"/> class.
+        /// </summary>
+        public AlarmPage()
+        {
+            this.addAlarmButton = ByExtensions.AutomationId("AddAlarmButton");
+            this.selectAlarmsButton = ByExtensions.AutomationId("SelectAlarmsButton");
+            this.alarmList = ByExtensions.AutomationId("AlarmListView");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => ByExtensions.AutomationId("AddAlarmButton");
+
+        /// <summary>
+        /// Navigates to adding an alarm.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="EditAlarmPage"/>.
+        /// </returns>
+        public EditAlarmPage GoToAddAlarm()
+        {
+            this.WindowsApp.FindElement(this.addAlarmButton).Click();
+            return new EditAlarmPage();
+        }
+
+        /// <summary>
+        /// Navigates to editing an alarm with the specified alarm name.
+        /// </summary>
+        /// <param name="alarmName">
+        /// The name of the alarm to edit.
+        /// </param>
+        /// <returns>
+        /// The <see cref="EditAlarmPage"/>.
+        /// </returns>
+        public EditAlarmPage GoToEditAlarm(string alarmName)
+        {
+            this.GetListAlarmElement(alarmName).Click();
+            return new EditAlarmPage();
+        }
+
+        /// <summary>
+        /// Verifies that an alarm exists within the alarm list.
+        /// </summary>
+        /// <param name="alarmName">
+        /// The name of the alarm to verify exists.
+        /// </param>
+        /// <param name="time">
+        /// The time of the alarm to verify exists.
+        /// </param>
+        public void VerifyAlarmExists(string alarmName, TimeSpan time)
+        {
+            string timeString = time.ToString(@"hh\:mm");
+            Assert.IsNotNull(this.GetListAlarmElement($"{alarmName}, {timeString}"));
+        }
+
+        /// <summary>
+        /// Verifies that an alarm does not exist within the alarm list.
+        /// </summary>
+        /// <param name="alarmName">
+        /// The name of the alarm to verify does not exist.
+        /// </param>
+        /// <param name="time">
+        /// The time of the alarm to verify does not exist.
+        /// </param>
+        public void VerifyAlarmDoesNotExist(string alarmName, TimeSpan time)
+        {
+            string timeString = time.ToString(@"hh\:mm");
+            Assert.IsNull(this.GetListAlarmElement($"{alarmName}, {timeString}"));
+        }
+
+        private AppiumWebElement GetListAlarmElement(string name)
+        {
+            ReadOnlyCollection<AppiumWebElement> listElements =
+                this.WindowsApp.FindElement(this.alarmList).FindElements(By.ClassName("ListViewItem"));
+
+            return listElements.FirstOrDefault(
+                element => element.GetAttribute("Name").Contains(name, StringComparison.CurrentCulture));
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
@@ -13,7 +13,7 @@ namespace WindowsAlarmsAndClock.Pages
     using OpenQA.Selenium.Appium;
 
     /// <summary>
-    /// Defines the alarm page of the Windows Alarms & Clock application.
+    /// Defines the alarm page of the Windows Alarms &amp; Clock application.
     /// </summary>
     public class AlarmPage : BasePage
     {

--- a/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
@@ -1,0 +1,114 @@
+namespace WindowsAlarmsAndClock.Pages
+{
+    using System;
+
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines the add/edit alarm page of the Windows Alarms & Clock application.
+    /// </summary>
+    public class EditAlarmPage : BasePage
+    {
+        private readonly By alarmTimePicker;
+
+        private readonly By alarmNameTextBox;
+
+        private readonly By alarmRepeatButton;
+
+        private readonly By alarmSoundButton;
+
+        private readonly By alarmSnoozeComboBox;
+
+        private readonly By alarmSaveButton;
+
+        private readonly By alarmCancelButton;
+
+        private readonly By alarmDeleteButton;
+
+        private readonly By alarmDeleteDialog;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EditAlarmPage"/> class.
+        /// </summary>
+        public EditAlarmPage()
+        {
+            this.alarmTimePicker = ByExtensions.AutomationId("AlarmTimePicker");
+            this.alarmNameTextBox = ByExtensions.AutomationId("AlarmNameTextBox");
+            this.alarmRepeatButton = ByExtensions.AutomationId("AlarmRepeatsToggleButton");
+            this.alarmSoundButton = ByExtensions.AutomationId("AlarmSoundButton");
+            this.alarmSnoozeComboBox = ByExtensions.AutomationId("AlarmSnoozeCombobox");
+            this.alarmSaveButton = ByExtensions.AutomationId("AlarmSaveButton");
+            this.alarmCancelButton = ByExtensions.AutomationId("CancelButton");
+            this.alarmDeleteButton = ByExtensions.AutomationId("AlarmDeleteButton");
+            this.alarmDeleteDialog = ByExtensions.AutomationId("DeleteConfirmationDialog");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => ByExtensions.AutomationId("EditAlarmHeader");
+
+        /// <summary>
+        /// Sets the time of the alarm being edited.
+        /// </summary>
+        /// <param name="time">
+        /// The time to set the alarm to.
+        /// </param>
+        /// <returns>
+        /// The <see cref="EditAlarmPage"/>.
+        /// </returns>
+        public EditAlarmPage SetAlarmTime(TimeSpan time)
+        {
+            TimePicker timePicker = this.WindowsApp.FindElement(this.alarmTimePicker);
+            timePicker.SetTime(time);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the name of the alarm being edited.
+        /// </summary>
+        /// <param name="name">
+        /// The name to set the alarm to.
+        /// </param>
+        /// <returns>
+        /// The <see cref="EditAlarmPage"/>.
+        /// </returns>
+        public EditAlarmPage SetAlarmName(string name)
+        {
+            WindowsElement textBox = this.WindowsApp.FindElement(this.alarmNameTextBox);
+            textBox.Click();
+            textBox.SendKeys(name);
+            return this;
+        }
+
+        /// <summary>
+        /// Saves the alarm and navigates back to the <see cref="AlarmPage"/>.
+        /// </summary>
+        public void SaveAlarm()
+        {
+            this.WindowsApp.FindElement(this.alarmSaveButton).Click();
+        }
+
+        /// <summary>
+        /// Deletes the alarm and navigates back to the <see cref="AlarmPage"/>.
+        /// </summary>
+        public void DeleteAlarm()
+        {
+            this.WindowsApp.FindElement(this.alarmDeleteButton).Click();
+            this.WindowsApp.FindElement(this.alarmDeleteDialog).FindElementByName("Delete").Click();
+        }
+
+        /// <summary>
+        /// Cancels editing the alarm and navigates back to the <see cref="AlarmPage"/>.
+        /// </summary>
+        public void CancelEditAlarm()
+        {
+            this.WindowsApp.FindElement(this.alarmCancelButton).Click();
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
@@ -64,8 +64,8 @@ namespace WindowsAlarmsAndClock.Pages
         /// </returns>
         public EditAlarmPage SetAlarmTime(TimeSpan time)
         {
-            TimePicker timePicker = this.WindowsApp.FindElement(this.alarmTimePicker);
-            timePicker.SetTime(time);
+            CustomTimePicker customTimePicker = this.WindowsApp.FindElement(this.alarmTimePicker);
+            customTimePicker.SetTime(time);
             return this;
         }
 

--- a/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
@@ -10,7 +10,7 @@ namespace WindowsAlarmsAndClock.Pages
     using OpenQA.Selenium.Appium.Windows;
 
     /// <summary>
-    /// Defines the add/edit alarm page of the Windows Alarms & Clock application.
+    /// Defines the add/edit alarm page of the Windows Alarms &amp; Clock application.
     /// </summary>
     public class EditAlarmPage : BasePage
     {

--- a/samples/WindowsAlarmsAndClock/Tests/AlarmTests.cs
+++ b/samples/WindowsAlarmsAndClock/Tests/AlarmTests.cs
@@ -1,0 +1,45 @@
+namespace WindowsAlarmsAndClock.Tests
+{
+    using System;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using WindowsAlarmsAndClock.Pages;
+
+    [TestClass]
+    public class AlarmTests : BaseTestClass
+    {
+        [TestMethod]
+        public void AddAlarm()
+        {
+            // Arrange
+            const string ExpectedAlarmName = "Test Add Alarm";
+            var expectedAlarmTime = new TimeSpan(7, 5, 0);
+
+            var alarmPage = new AlarmPage();
+
+            // Act
+            alarmPage.GoToAddAlarm().SetAlarmTime(expectedAlarmTime).SetAlarmName(ExpectedAlarmName).SaveAlarm();
+
+            // Assert
+            alarmPage.VerifyAlarmExists(ExpectedAlarmName, expectedAlarmTime);
+        }
+
+        [TestMethod]
+        public void EditAlarm()
+        {
+            // Arrange
+            const string ExpectedAlarmName = "Test Edit Alarm";
+            var expectedAlarmTime = new TimeSpan(12, 30, 0);
+
+            var alarmPage = new AlarmPage();
+            alarmPage.GoToAddAlarm().SetAlarmTime(new TimeSpan(7, 5, 0)).SetAlarmName(ExpectedAlarmName).SaveAlarm();
+
+            // Act
+            alarmPage.GoToEditAlarm(ExpectedAlarmName).SetAlarmTime(expectedAlarmTime).SaveAlarm();
+
+            // Assert
+            alarmPage.VerifyAlarmExists(ExpectedAlarmName, expectedAlarmTime);
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
+++ b/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Legerity\Legerity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/XamlControlsGallery/BaseTestClass.cs
+++ b/samples/XamlControlsGallery/BaseTestClass.cs
@@ -1,0 +1,26 @@
+namespace XamlControlsGallery
+{
+    using Legerity;
+    using Legerity.Windows;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    public abstract class BaseTestClass
+    {
+        [TestInitialize]
+        public virtual void Initialize()
+        {
+            AppManager.StartApp(
+                new WindowsAppManagerOptions("Microsoft.XAMLControlsGallery_8wekyb3d8bbwe!App")
+                {
+                    AppiumDriverUrl = "http://127.0.0.1:4723"
+                });
+        }
+
+        [TestCleanup]
+        public virtual void Cleanup()
+        {
+            AppManager.StopApp();
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/DateAndTimePage.cs
+++ b/samples/XamlControlsGallery/Pages/DateAndTimePage.cs
@@ -1,0 +1,41 @@
+namespace XamlControlsGallery.Pages
+{
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the Date and Time page of the XAML Controls Gallery application.
+    /// </summary>
+    public class DateAndTimePage : BasePage
+    {
+        private readonly By controlList;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateAndTimePage"/> class.
+        /// </summary>
+        public DateAndTimePage()
+        {
+            this.controlList = By.Name("Items In Group");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='Date and Time'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Navigates to the time picker page.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="TimePickerPage"/>.
+        /// </returns>
+        public TimePickerPage GoToTimePicker()
+        {
+            GridView gridView = this.WindowsApp.FindElement(this.controlList);
+            gridView.ClickItem("TimePicker");
+            return new TimePickerPage();
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/NavigationMenu.cs
+++ b/samples/XamlControlsGallery/Pages/NavigationMenu.cs
@@ -1,0 +1,42 @@
+namespace XamlControlsGallery.Pages
+{
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines a helper for navigating the application's menu.
+    /// </summary>
+    public class NavigationMenu : BasePage
+    {
+        private readonly By menuList;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NavigationMenu"/> class.
+        /// </summary>
+        public NavigationMenu()
+        {
+            this.menuList = ByExtensions.AutomationId("MenuItemsHost");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => ByExtensions.AutomationId("NavigationViewControl");
+
+        /// <summary>
+        /// Navigates to the basic input page.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="DateAndTimePage"/>.
+        /// </returns>
+        public DateAndTimePage GoToDateAndTime()
+        {
+            ListView listView = this.WindowsApp.FindElement(this.menuList);
+            listView.ClickItem("Date and Time");
+            return new DateAndTimePage();
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/TimePickerPage.cs
+++ b/samples/XamlControlsGallery/Pages/TimePickerPage.cs
@@ -1,0 +1,64 @@
+namespace XamlControlsGallery.Pages
+{
+    using System;
+
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines the TimePicker page of the XAML Controls Gallery application.
+    /// </summary>
+    public class TimePickerPage : BasePage
+    {
+        private readonly By simpleTimePicker;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimePickerPage"/> class.
+        /// </summary>
+        public TimePickerPage()
+        {
+            this.simpleTimePicker = By.Name("time picker");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='TimePicker'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Sets the simple time picker's time with the specified time.
+        /// </summary>
+        /// <param name="time">
+        /// The time to set.
+        /// </param>
+        /// <returns>
+        /// The <see cref="TimePickerPage"/>.
+        /// </returns>
+        public TimePickerPage SetSimpleTimePickerTime(TimeSpan time)
+        {
+            TimePicker timePicker = this.WindowsApp.FindElement(this.simpleTimePicker);
+            timePicker.SetTime(time);
+            return this;
+        }
+
+        /// <summary>
+        /// Verifies that the simple time picker time has been updated.
+        /// </summary>
+        /// <param name="time">
+        /// The time of the time picker to verify updated.
+        /// </param>
+        public void VerifySimpleTimePickerTime(TimeSpan time)
+        {
+            string timeString = time.ToString(@"hh\:mm");
+
+            WindowsElement updatedTimePicker = this.WindowsApp.FindElement(By.Name($" {timeString} time picker"));
+            Assert.IsNotNull(updatedTimePicker);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Tests/TimePickerTests.cs
+++ b/samples/XamlControlsGallery/Tests/TimePickerTests.cs
@@ -1,0 +1,33 @@
+namespace XamlControlsGallery.Tests
+{
+    using System;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using XamlControlsGallery.Pages;
+
+    [TestClass]
+    public class TimePickerTests : BaseTestClass
+    {
+        private static TimePickerPage TimePickerPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            TimePickerPage = new NavigationMenu().GoToDateAndTime().GoToTimePicker();
+        }
+
+        [TestMethod]
+        public void SetSimpleTimePickerTime()
+        {
+            // Arrange
+            var expectedTime = new TimeSpan(7, 5, 0);
+
+            TimePickerPage.SetSimpleTimePickerTime(expectedTime);
+
+            // Act & Assert
+            TimePickerPage.VerifySimpleTimePickerTime(expectedTime);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/samples/XamlControlsGallery/XamlControlsGallery.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Legerity\Legerity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -1,0 +1,13 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FAB58D66-B3F1-408A-A96F-572170771367}
+	EndGlobalSection
+EndGlobal

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Legerity", "Legerity\Legerity.csproj", "{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{71D6D4B1-DD5C-4238-8E85-5BC755F40931}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsAlarmsAndClock", "..\samples\WindowsAlarmsAndClock\WindowsAlarmsAndClock.csproj", "{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,9 +19,16 @@ Global
 		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66} = {71D6D4B1-DD5C-4238-8E85-5BC755F40931}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FAB58D66-B3F1-408A-A96F-572170771367}

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -7,7 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Legerity", "Legerity\Legeri
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{71D6D4B1-DD5C-4238-8E85-5BC755F40931}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsAlarmsAndClock", "..\samples\WindowsAlarmsAndClock\WindowsAlarmsAndClock.csproj", "{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XamlControlsGallery", "..\samples\XamlControlsGallery\XamlControlsGallery.csproj", "{DEF3B388-F782-4E32-B72B-732F1C1BEB62}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsAlarmsAndClock", "..\samples\WindowsAlarmsAndClock\WindowsAlarmsAndClock.csproj", "{B6A4DAD1-7DEF-40B7-AEAE-667EA2931070}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,16 +21,21 @@ Global
 		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEF3B388-F782-4E32-B72B-732F1C1BEB62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEF3B388-F782-4E32-B72B-732F1C1BEB62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEF3B388-F782-4E32-B72B-732F1C1BEB62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEF3B388-F782-4E32-B72B-732F1C1BEB62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6A4DAD1-7DEF-40B7-AEAE-667EA2931070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6A4DAD1-7DEF-40B7-AEAE-667EA2931070}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6A4DAD1-7DEF-40B7-AEAE-667EA2931070}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6A4DAD1-7DEF-40B7-AEAE-667EA2931070}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{88AAEC2D-9E0A-43E3-8BF4-4856B442FD66} = {71D6D4B1-DD5C-4238-8E85-5BC755F40931}
+		{DEF3B388-F782-4E32-B72B-732F1C1BEB62} = {71D6D4B1-DD5C-4238-8E85-5BC755F40931}
+		{B6A4DAD1-7DEF-40B7-AEAE-667EA2931070} = {71D6D4B1-DD5C-4238-8E85-5BC755F40931}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FAB58D66-B3F1-408A-A96F-572170771367}

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -3,7 +3,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Legerity", "Legerity\Legerity.csproj", "{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Legerity", "Legerity\Legerity.csproj", "{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Legerity", "Legerity\Legerity.csproj", "{6E084F55-FB61-4B0A-AF1D-454D67FBFD8E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Legerity/AppManager.cs
+++ b/src/Legerity/AppManager.cs
@@ -1,0 +1,82 @@
+namespace Legerity
+{
+    using System;
+
+    using Legerity.Exceptions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a manager for the application under test.
+    /// </summary>
+    public static class AppManager
+    {
+        private static WindowsDriver<WindowsElement> windowsApp;
+
+        /// <summary>
+        /// Gets the instance of the started Windows application.
+        /// </summary>
+        /// <exception cref="NullReferenceException">
+        /// Thrown if the <see cref="WindowsApp"/> is null as a result of not calling <see cref="StartApp"/>.
+        /// </exception>
+        public static WindowsDriver<WindowsElement> WindowsApp
+        {
+            get
+            {
+                if (windowsApp == null)
+                {
+                    throw new DriverNotInitializedException(
+                        "'AppManager.WindowsApp' not set. Call 'AppManager.StartApp()' with WindowsAppManagerOptions before trying to access it.");
+                }
+
+                return windowsApp;
+            }
+        }
+
+        /// <summary>
+        /// Starts the application ready for testing.
+        /// </summary>
+        /// <param name="opts">
+        /// The options to configure the driver with.
+        /// </param>
+        /// <exception cref="DriverLoadFailedException">
+        /// Thrown if the application is null or the session ID is null once initialized.
+        /// </exception>
+        public static void StartApp(AppManagerOptions opts)
+        {
+            if (windowsApp != null)
+            {
+                return;
+            }
+
+            StopApp();
+
+            if (opts is WindowsAppManagerOptions winOpts)
+            {
+                windowsApp = new WindowsDriver<WindowsElement>(new Uri(winOpts.AppiumDriverUrl), winOpts.AppiumOptions);
+                if (windowsApp?.SessionId == null)
+                {
+                    throw new DriverLoadFailedException(opts);
+                }
+
+                // Set implicit timeout to 1.5 seconds to make element search to retry every 500 ms for at most three times
+                windowsApp.Manage().Timeouts().ImplicitWait = winOpts.ImplicitWait;
+            }
+        }
+
+        /// <summary>
+        /// Stops the application.
+        /// </summary>
+        public static void StopApp()
+        {
+            if (windowsApp != null)
+            {
+                windowsApp.Quit();
+                windowsApp = null;
+            }
+        }
+    }
+}

--- a/src/Legerity/AppManager.cs
+++ b/src/Legerity/AppManager.cs
@@ -3,6 +3,7 @@ namespace Legerity
     using System;
 
     using Legerity.Exceptions;
+    using Legerity.Windows;
 
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;

--- a/src/Legerity/AppManagerOptions.cs
+++ b/src/Legerity/AppManagerOptions.cs
@@ -1,0 +1,37 @@
+namespace Legerity
+{
+    using System;
+
+    using OpenQA.Selenium.Appium;
+
+    /// <summary>
+    /// Defines a base model that represents configuration options for the <see cref="AppManager"/>.
+    /// </summary>
+    public abstract class AppManagerOptions
+    {
+        /// <summary>
+        /// Gets or sets the URL to the Appium driver.
+        /// </summary>
+        public string AppiumDriverUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options to configure the Appium driver.
+        /// </summary>
+        public AppiumOptions AppiumOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the implicit wait timeout, which is the amount of time the driver should wait when searching for an element if it is not immediately present.
+        /// <para>
+        /// By default, the wait time will be 1.5 seconds.
+        /// </para>
+        /// </summary>
+        public TimeSpan ImplicitWait { get; set; } = TimeSpan.FromSeconds(1.5);
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"AppiumDriverUrl [{this.AppiumDriverUrl}]";
+        }
+    }
+}

--- a/src/Legerity/ElementWrapper`1.cs
+++ b/src/Legerity/ElementWrapper`1.cs
@@ -1,0 +1,36 @@
+namespace Legerity
+{
+    using System;
+
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a base wrapper for elements to expose platform element logic.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="AppiumWebElement"/>.
+    /// </typeparam>
+    public abstract class ElementWrapper<TElement>
+        where TElement : AppiumWebElement
+    {
+        private readonly WeakReference elementReference;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElementWrapper{TElement}"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="TElement"/> reference.
+        /// </param>
+        protected ElementWrapper(TElement element)
+        {
+            this.elementReference = new WeakReference(element);
+        }
+
+        /// <summary>Gets the original <see cref="TElement"/> reference object.</summary>
+        public TElement Element =>
+            this.elementReference != null && this.elementReference.IsAlive
+                ? this.elementReference.Target as TElement
+                : null;
+    }
+}

--- a/src/Legerity/Exceptions/DriverLoadFailedException.cs
+++ b/src/Legerity/Exceptions/DriverLoadFailedException.cs
@@ -1,0 +1,27 @@
+namespace Legerity.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// Defines an exception thrown if the Appium driver fails to load the requested application.
+    /// </summary>
+    public class DriverLoadFailedException : LegerityException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DriverLoadFailedException"/> class.
+        /// </summary>
+        /// <param name="opts">
+        /// The app manager options used to initialize the driver.
+        /// </param>
+        internal DriverLoadFailedException(AppManagerOptions opts)
+            : base($"The application driver could not be initialized with the specified app manager options. {opts}")
+        {
+            this.AppManagerOptions = opts;
+        }
+
+        /// <summary>
+        /// Gets the app manager options used to initialize the driver.
+        /// </summary>
+        internal AppManagerOptions AppManagerOptions { get; }
+    }
+}

--- a/src/Legerity/Exceptions/DriverNotInitializedException.cs
+++ b/src/Legerity/Exceptions/DriverNotInitializedException.cs
@@ -1,0 +1,17 @@
+namespace Legerity.Exceptions
+{
+    /// <summary>
+    /// Defines an exception thrown when an attempt is made to access a driver which has not been initialized.
+    /// </summary>
+    public class DriverNotInitializedException : LegerityException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DriverNotInitializedException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        internal DriverNotInitializedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Legerity/Exceptions/LegerityException.cs
+++ b/src/Legerity/Exceptions/LegerityException.cs
@@ -1,0 +1,36 @@
+namespace Legerity
+{
+    using System;
+
+    /// <summary>
+    /// Defines a framework specific base exception.
+    /// </summary>
+    public class LegerityException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LegerityException"/> class.
+        /// </summary>
+        internal LegerityException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LegerityException"/> class with a specified error message.</summary>
+        /// <param name="message">The message that describes the error.</param>
+        internal LegerityException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LegerityException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        internal LegerityException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Legerity/Exceptions/PageNotShownException.cs
+++ b/src/Legerity/Exceptions/PageNotShownException.cs
@@ -1,0 +1,25 @@
+namespace Legerity.Exceptions
+{
+    /// <summary>
+    /// Defines an exception for when a page is not shown.
+    /// </summary>
+    public class PageNotShownException : LegerityException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageNotShownException"/> class.
+        /// </summary>
+        /// <param name="pageName">
+        /// The name of the page that was not shown.
+        /// </param>
+        internal PageNotShownException(string pageName)
+            : base($"Unable to verify on page '{pageName}'")
+        {
+            this.PageName = pageName;
+        }
+
+        /// <summary>
+        /// Gets the name of the page that was not shown.
+        /// </summary>
+        public string PageName { get; }
+    }
+}

--- a/src/Legerity/Extensions/StringExtensions.cs
+++ b/src/Legerity/Extensions/StringExtensions.cs
@@ -1,0 +1,38 @@
+namespace Legerity.Extensions
+{
+    using System;
+    using System.Globalization;
+
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="string"/>.
+    /// </summary>
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Determines whether the specified value contains the comparison value by the specified culture and comparison option. 
+        /// </summary>
+        /// <param name="value">
+        /// The value to check contains the <see cref="contains"/> value.
+        /// </param>
+        /// <param name="contains">
+        /// The value that should be contained within the <see cref="value"/>.
+        /// </param>
+        /// <param name="culture">
+        /// The culture for comparison.
+        /// </param>
+        /// <param name="compareOption">
+        /// The comparison option.
+        /// </param>
+        /// <returns>
+        /// True if the <paramref name="value"/> contains the <paramref name="contains"/> value; otherwise, false.
+        /// </returns>
+        public static bool Contains(
+            this string value,
+            string contains,
+            CultureInfo culture,
+            CompareOptions compareOption)
+        {
+            return culture.CompareInfo.IndexOf(value, contains, compareOption) >= 0;
+        }
+    }
+}

--- a/src/Legerity/Legerity.csproj
+++ b/src/Legerity/Legerity.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="4.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Legerity/Pages/BasePage.cs
+++ b/src/Legerity/Pages/BasePage.cs
@@ -1,0 +1,56 @@
+namespace Legerity.Pages
+{
+    using System;
+
+    using Legerity.Exceptions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a base page for creating tests following the page object pattern.
+    /// </summary>
+    public abstract class BasePage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BasePage"/> class.
+        /// </summary>
+        protected BasePage()
+        {
+            this.VerifyPageShown(TimeSpan.FromSeconds(2));
+        }
+
+        /// <summary>
+        /// Gets the instance of the started Windows application.
+        /// </summary>
+        protected WindowsDriver<WindowsElement> WindowsApp => AppManager.WindowsApp;
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected abstract By Trait { get; }
+
+        /// <summary>
+        /// Determines whether the current page is shown with the specified timeout.
+        /// </summary>
+        /// <param name="timeout">
+        /// The amount of time the driver should wait when searching for the <see cref="Trait"/> if it is not immediately present.
+        /// </param>
+        public void VerifyPageShown(TimeSpan? timeout)
+        {
+            if (timeout == null)
+            {
+                if (this.WindowsApp.FindElement(this.Trait) == null)
+                {
+                    throw new PageNotShownException(this.GetType().Name);
+                }
+            }
+            else
+            {
+                var wait = new WebDriverWait(this.WindowsApp, timeout.Value);
+                wait.Until(driver => driver.FindElement(this.Trait) != null);
+            }
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/GridView.cs
+++ b/src/Legerity/Windows/Elements/Core/GridView.cs
@@ -1,0 +1,65 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.Linq;
+
+    using Legerity.Extensions;
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP GridView control.
+    /// </summary>
+    public class GridView : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GridView"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference..
+        /// </param>
+        public GridView(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="GridView"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="GridView"/>.
+        /// </returns>
+        public static implicit operator GridView(WindowsElement element)
+        {
+            return new GridView(element);
+        }
+
+        /// <summary>
+        /// Clicks on an item in the list view with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to click.
+        /// </param>
+        public void ClickItem(string name)
+        {
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(By.ClassName("GridViewItem"));
+
+            AppiumWebElement item = listElements.FirstOrDefault(
+                element => element.GetAttribute("Name").Contains(
+                    name,
+                    CultureInfo.CurrentCulture,
+                    CompareOptions.IgnoreCase));
+
+            item.Click();
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/ListView.cs
+++ b/src/Legerity/Windows/Elements/Core/ListView.cs
@@ -1,0 +1,65 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.Linq;
+
+    using Legerity.Extensions;
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP ListView control.
+    /// </summary>
+    public class ListView : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListView"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference..
+        /// </param>
+        public ListView(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ListView"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ListView"/>.
+        /// </returns>
+        public static implicit operator ListView(WindowsElement element)
+        {
+            return new ListView(element);
+        }
+
+        /// <summary>
+        /// Clicks on an item in the list view with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to click.
+        /// </param>
+        public void ClickItem(string name)
+        {
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(By.ClassName("ListViewItem"));
+
+            AppiumWebElement item = listElements.FirstOrDefault(
+                element => element.GetAttribute("Name").Contains(
+                    name,
+                    CultureInfo.CurrentCulture,
+                    CompareOptions.IgnoreCase));
+
+            item.Click();
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/TimePicker.cs
+++ b/src/Legerity/Windows/Elements/Core/TimePicker.cs
@@ -1,0 +1,72 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP TimePicker control.
+    /// </summary>
+    public class TimePicker
+    {
+        private readonly WeakReference elementReference;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimePicker"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference..
+        /// </param>
+        public TimePicker(WindowsElement element)
+        {
+            this.elementReference = new WeakReference(element);
+        }
+
+        /// <summary>Gets the original <see cref="WindowsElement"/> reference object.</summary>
+        public WindowsElement Element =>
+            this.elementReference != null && this.elementReference.IsAlive
+                ? this.elementReference.Target as WindowsElement
+                : null;
+
+        /// <summary>
+        /// Gets the query for the hour looping selector.
+        /// </summary>
+        public By Hour => ByExtensions.AutomationId("HourLoopingSelector");
+
+        /// <summary>
+        /// Gets the query for the minute looping selector.
+        /// </summary>
+        public By Minute => ByExtensions.AutomationId("MinuteLoopingSelector");
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="TimePicker"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="TimePicker"/>.
+        /// </returns>
+        public static implicit operator TimePicker(WindowsElement element)
+        {
+            return new TimePicker(element);
+        }
+
+        /// <summary>
+        /// Sets the time to the specified time.
+        /// </summary>
+        /// <param name="time">
+        /// The time to set.
+        /// </param>
+        public void SetTime(TimeSpan time)
+        {
+            this.Element.FindElement(this.Hour).FindElementByName(time.ToString("%h")).Click();
+            this.Element.FindElement(this.Minute).FindElementByName(time.ToString("mm")).Click();
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/TimePicker.cs
+++ b/src/Legerity/Windows/Elements/Core/TimePicker.cs
@@ -12,10 +12,8 @@ namespace Legerity.Windows.Elements.Core
     /// <summary>
     /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP TimePicker control.
     /// </summary>
-    public class TimePicker
+    public class TimePicker : WindowsElementWrapper
     {
-        private readonly WeakReference elementReference;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TimePicker"/> class.
         /// </summary>
@@ -23,25 +21,34 @@ namespace Legerity.Windows.Elements.Core
         /// The <see cref="WindowsElement"/> reference..
         /// </param>
         public TimePicker(WindowsElement element)
+            : base(element)
         {
-            this.elementReference = new WeakReference(element);
         }
 
-        /// <summary>Gets the original <see cref="WindowsElement"/> reference object.</summary>
-        public WindowsElement Element =>
-            this.elementReference != null && this.elementReference.IsAlive
-                ? this.elementReference.Target as WindowsElement
-                : null;
+        /// <summary>
+        /// Gets the query for the popup displayed for the time picker when invoking the control.
+        /// </summary>
+        public By Flyout => ByExtensions.AutomationId("TimePickerFlyoutPresenter");
 
         /// <summary>
         /// Gets the query for the hour looping selector.
         /// </summary>
-        public By Hour => ByExtensions.AutomationId("HourLoopingSelector");
+        public By HourSelector => ByExtensions.AutomationId("HourLoopingSelector");
 
         /// <summary>
         /// Gets the query for the minute looping selector.
         /// </summary>
-        public By Minute => ByExtensions.AutomationId("MinuteLoopingSelector");
+        public By MinuteSelector => ByExtensions.AutomationId("MinuteLoopingSelector");
+
+        /// <summary>
+        /// Gets the query for the accept button.
+        /// </summary>
+        public By AcceptButton => ByExtensions.AutomationId("AcceptButton");
+
+        /// <summary>
+        /// Gets the query for the dismiss button.
+        /// </summary>
+        public By DismissButton => ByExtensions.AutomationId("DismissButton");
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="TimePicker"/> without direct casting.
@@ -65,8 +72,14 @@ namespace Legerity.Windows.Elements.Core
         /// </param>
         public void SetTime(TimeSpan time)
         {
-            this.Element.FindElement(this.Hour).FindElementByName(time.ToString("%h")).Click();
-            this.Element.FindElement(this.Minute).FindElementByName(time.ToString("mm")).Click();
+            // Taps the time picker to show the popup.
+            this.Element.Click();
+
+            // Finds the popup and changes the time.
+            WindowsElement popup = this.Driver.FindElement(this.Flyout);
+            popup.FindElement(this.HourSelector).FindElementByName(time.ToString("%h")).Click();
+            popup.FindElement(this.MinuteSelector).FindElementByName(time.ToString("mm")).Click();
+            popup.FindElement(this.AcceptButton).Click();
         }
     }
 }

--- a/src/Legerity/Windows/Elements/WindowsElementWrapper.cs
+++ b/src/Legerity/Windows/Elements/WindowsElementWrapper.cs
@@ -1,0 +1,26 @@
+namespace Legerity.Windows.Elements
+{
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines an element wrapper for a <see cref="WindowsElement"/>.
+    /// </summary>
+    public abstract class WindowsElementWrapper : ElementWrapper<WindowsElement>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WindowsElementWrapper"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        protected WindowsElementWrapper(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the instance of the Appium driver for the Windows application.
+        /// </summary>
+        public WindowsDriver<WindowsElement> Driver => AppManager.WindowsApp;
+    }
+}

--- a/src/Legerity/Windows/Extensions/ByExtensions.cs
+++ b/src/Legerity/Windows/Extensions/ByExtensions.cs
@@ -1,0 +1,36 @@
+namespace Legerity.Windows.Extensions
+{
+    using System;
+
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines a collection of extensions for the <see cref="By"/> class.
+    /// </summary>
+    public static class ByExtensions
+    {
+        /// <summary>
+        /// Provides a query for retrieving an element by a Windows AutomationId.
+        /// </summary>
+        /// <param name="automationId">
+        /// The automation ID of the element to retrieve.
+        /// </param>
+        /// <returns>
+        /// The <see cref="By"/> query for the Windows element.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the <paramref name="automationId"/> is null.
+        /// </exception>
+        public static By AutomationId(string automationId)
+        {
+            if (automationId == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(automationId),
+                    "Cannot find elements with a null automation id attribute.");
+            }
+
+            return By.XPath($".//*[@AutomationId='{automationId}']");
+        }
+    }
+}

--- a/src/Legerity/Windows/WindowsAppManagerOptions.cs
+++ b/src/Legerity/Windows/WindowsAppManagerOptions.cs
@@ -51,14 +51,13 @@ namespace Legerity.Windows
         {
             var options = new AppiumOptions();
             options.AddAdditionalCapability("app", this.AppId);
-            if (additionalOptions == null)
-            {
-                return;
-            }
 
-            foreach ((string capabilityName, object capabilityValue) in additionalOptions)
+            if (additionalOptions != null)
             {
-                options.AddAdditionalCapability(capabilityName, capabilityValue);
+                foreach ((string capabilityName, object capabilityValue) in additionalOptions)
+                {
+                    options.AddAdditionalCapability(capabilityName, capabilityValue);
+                }
             }
 
             this.AppiumOptions = options;

--- a/src/Legerity/Windows/WindowsAppManagerOptions.cs
+++ b/src/Legerity/Windows/WindowsAppManagerOptions.cs
@@ -1,4 +1,4 @@
-namespace Legerity
+namespace Legerity.Windows
 {
     using OpenQA.Selenium.Appium;
 

--- a/src/Legerity/WindowsAppManagerOptions.cs
+++ b/src/Legerity/WindowsAppManagerOptions.cs
@@ -1,0 +1,74 @@
+namespace Legerity
+{
+    using OpenQA.Selenium.Appium;
+
+    /// <summary>
+    /// Defines a specific <see cref="AppManagerOptions"/> for a Windows application.
+    /// </summary>
+    public class WindowsAppManagerOptions : AppManagerOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WindowsAppManagerOptions"/> class.
+        /// </summary>
+        /// <param name="appId">
+        /// The ID of the application under test.
+        /// </param>
+        public WindowsAppManagerOptions(string appId)
+            : this(appId, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WindowsAppManagerOptions"/> class.
+        /// </summary>
+        /// <param name="appId">
+        /// The ID of the application under test.
+        /// </param>
+        /// <param name="additionalOptions">
+        /// The additional options to apply to the <see cref="AppiumOptions"/>.
+        /// </param>
+        public WindowsAppManagerOptions(string appId, params (string, object)[] additionalOptions)
+        {
+            this.AppId = appId;
+            this.Configure(additionalOptions);
+        }
+
+        /// <summary>
+        /// Gets or sets the ID of the application under test.
+        /// </summary>
+        public string AppId { get; set; }
+
+        /// <summary>
+        /// Configures the <see cref="AppManagerOptions.AppiumOptions"/> with the specified additional options.
+        /// <para>
+        /// By default, the <see cref="AppId"/> will be added to the options as capability 'app'.
+        /// </para>
+        /// </summary>
+        /// <param name="additionalOptions">
+        /// The additional options to apply to the <see cref="AppiumOptions"/>.
+        /// </param>
+        public void Configure((string, object)[] additionalOptions)
+        {
+            var options = new AppiumOptions();
+            options.AddAdditionalCapability("app", this.AppId);
+            if (additionalOptions == null)
+            {
+                return;
+            }
+
+            foreach ((string capabilityName, object capabilityValue) in additionalOptions)
+            {
+                options.AddAdditionalCapability(capabilityName, capabilityValue);
+            }
+
+            this.AppiumOptions = options;
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"{base.ToString()}, AppId [{this.AppId}]";
+        }
+    }
+}


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

This PR is the starting point for creating automated UI tests with Appium for Windows applications following the page object pattern. 

Additionally, there are some starting point `WindowsElement` wrappers contained within this PR which were initially created to test functions of core controls in the Windows 10 SDKs. Note, these are not a complete set of wrappers and will be included in a separate piece of work.

Sample test projects have been added for the Windows Alarms & Clock application from my original [Windows UWP Appium page object pattern example](https://github.com/jamesmcroft/uwp-appium-pop-example), and another sample project added for the XAML Controls Gallery application.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

- [Windows (UWP) Appium Page Object Pattern Example](https://github.com/jamesmcroft/uwp-appium-pop-example)