### PR TITLE
Added various UWP basic input control element wrappers

### DIFF
--- a/samples/XamlControlsGallery/BaseTestClass.cs
+++ b/samples/XamlControlsGallery/BaseTestClass.cs
@@ -20,7 +20,7 @@ namespace XamlControlsGallery
         [TestCleanup]
         public virtual void Cleanup()
         {
-            // AppManager.StopApp();
+            AppManager.StopApp();
         }
     }
 }

--- a/samples/XamlControlsGallery/BaseTestClass.cs
+++ b/samples/XamlControlsGallery/BaseTestClass.cs
@@ -20,7 +20,7 @@ namespace XamlControlsGallery
         [TestCleanup]
         public virtual void Cleanup()
         {
-            AppManager.StopApp();
+            // AppManager.StopApp();
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/BasicInputPage.cs
+++ b/samples/XamlControlsGallery/Pages/BasicInputPage.cs
@@ -1,0 +1,41 @@
+namespace XamlControlsGallery.Pages
+{
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the Basic Input page of the XAML Controls Gallery application.
+    /// </summary>
+    public class BasicInputPage : BasePage
+    {
+        private readonly By controlList;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BasicInputPage"/> class.
+        /// </summary>
+        public BasicInputPage()
+        {
+            this.controlList = By.Name("Items In Group");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='Basic Input'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Navigates to the combo-box page.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="ComboBoxPage"/>.
+        /// </returns>
+        public ComboBoxPage GoToComboBox()
+        {
+            GridView gridView = this.WindowsApp.FindElement(this.controlList);
+            gridView.ClickItem("ComboBox");
+            return new ComboBoxPage();
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/BasicInputPage.cs
+++ b/samples/XamlControlsGallery/Pages/BasicInputPage.cs
@@ -49,6 +49,16 @@ namespace XamlControlsGallery.Pages
             return new SliderPage();
         }
 
+        /// <summary>
+        /// Navigates to the toggle switch page.
+        /// </summary>
+        /// <returns>The <see cref="ToggleSwitchPage"/>.</returns>
+        public ToggleSwitchPage GoToToggleSwitch()
+        {
+            this.NavigateTo("ToggleSwitch");
+            return new ToggleSwitchPage();
+        }
+
         private void NavigateTo(string page)
         {
             GridView gridView = this.WindowsApp.FindElement(this.controlList);

--- a/samples/XamlControlsGallery/Pages/BasicInputPage.cs
+++ b/samples/XamlControlsGallery/Pages/BasicInputPage.cs
@@ -33,9 +33,26 @@ namespace XamlControlsGallery.Pages
         /// </returns>
         public ComboBoxPage GoToComboBox()
         {
-            GridView gridView = this.WindowsApp.FindElement(this.controlList);
-            gridView.ClickItem("ComboBox");
+            this.NavigateTo("ComboBox");
             return new ComboBoxPage();
+        }
+
+        /// <summary>
+        /// Navigates to the slider page.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="ComboBoxPage"/>.
+        /// </returns>
+        public SliderPage GoToSlider()
+        {
+            this.NavigateTo("Slider");
+            return new SliderPage();
+        }
+
+        private void NavigateTo(string page)
+        {
+            GridView gridView = this.WindowsApp.FindElement(this.controlList);
+            gridView.ClickItem(page);
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/ComboBoxPage.cs
+++ b/samples/XamlControlsGallery/Pages/ComboBoxPage.cs
@@ -1,0 +1,58 @@
+namespace XamlControlsGallery.Pages
+{
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the ComboBox page of the XAML Controls Gallery application.
+    /// </summary>
+    public class ComboBoxPage : BasePage
+    {
+        private readonly By colorComboBox;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComboBoxPage"/> class.
+        /// </summary>
+        public ComboBoxPage()
+        {
+            this.colorComboBox = By.Name("Colors");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='ComboBox'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Sets the colors combo-box selected item to the specified item..
+        /// </summary>
+        /// <param name="expectedItem">
+        /// The expected item.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ComboBoxPage"/>.
+        /// </returns>
+        public ComboBoxPage SetColorsComboBoxItem(string expectedItem)
+        {
+            ComboBox comboBox = this.WindowsApp.FindElement(this.colorComboBox);
+            comboBox.SelectItem(expectedItem);
+            return this;
+        }
+
+        /// <summary>
+        /// Verifies that the colors combo-box has been updated.
+        /// </summary>
+        /// <param name="expectedItem">
+        /// The selected item of the combo-box to verify updated.
+        /// </param>
+        public void VerifyColorsComboBoxItem(string expectedItem)
+        {
+            ComboBox comboBox = this.WindowsApp.FindElement(this.colorComboBox);
+            Assert.AreEqual(expectedItem, comboBox.GetSelectItem());
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/DateAndTimePage.cs
+++ b/samples/XamlControlsGallery/Pages/DateAndTimePage.cs
@@ -37,5 +37,18 @@ namespace XamlControlsGallery.Pages
             gridView.ClickItem("TimePicker");
             return new TimePickerPage();
         }
+
+        /// <summary>
+        /// Navigates to the date picker page.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="DatePickerPage"/>.
+        /// </returns>
+        public DatePickerPage GoToDatePicker()
+        {
+            GridView gridView = this.WindowsApp.FindElement(this.controlList);
+            gridView.ClickItem("DatePicker");
+            return new DatePickerPage();
+        }
     }
 }

--- a/samples/XamlControlsGallery/Pages/DatePickerPage.cs
+++ b/samples/XamlControlsGallery/Pages/DatePickerPage.cs
@@ -1,0 +1,64 @@
+namespace XamlControlsGallery.Pages
+{
+    using System;
+
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines the DatePicker page of the XAML Controls Gallery application.
+    /// </summary>
+    public class DatePickerPage : BasePage
+    {
+        private readonly By simpleDatePicker;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DatePickerPage"/> class.
+        /// </summary>
+        public DatePickerPage()
+        {
+            this.simpleDatePicker = By.XPath(".//*[@ClassName='DatePicker'][@Name='Pick a date']");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='DatePicker'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Sets the simple date picker's date with the specified date.
+        /// </summary>
+        /// <param name="date">
+        /// The date to set.
+        /// </param>
+        /// <returns>
+        /// The <see cref="DatePickerPage"/>.
+        /// </returns>
+        public DatePickerPage SetSimpleDatePickerDate(DateTime date)
+        {
+            DatePicker datePicker = this.WindowsApp.FindElement(this.simpleDatePicker);
+            datePicker.SetDate(date);
+            return this;
+        }
+
+        /// <summary>
+        /// Verifies that the simple date picker date has been updated.
+        /// </summary>
+        /// <param name="date">
+        /// The date of the date picker to verify updated.
+        /// </param>
+        public void VerifySimpleTimePickerTime(DateTime date)
+        {
+            string dateString = date.ToString("dd MMMM yyyy");
+
+            WindowsElement updatedTimePicker = this.WindowsApp.FindElement(By.Name($"Pick a date‎ {dateString} date picker"));
+            Assert.IsNotNull(updatedTimePicker);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/NavigationMenu.cs
+++ b/samples/XamlControlsGallery/Pages/NavigationMenu.cs
@@ -27,7 +27,7 @@ namespace XamlControlsGallery.Pages
         protected override By Trait => ByExtensions.AutomationId("NavigationViewControl");
 
         /// <summary>
-        /// Navigates to the basic input page.
+        /// Navigates to the date and time page.
         /// </summary>
         /// <returns>
         /// The <see cref="DateAndTimePage"/>.
@@ -37,6 +37,19 @@ namespace XamlControlsGallery.Pages
             ListView listView = this.WindowsApp.FindElement(this.menuList);
             listView.ClickItem("Date and Time");
             return new DateAndTimePage();
+        }
+
+        /// <summary>
+        /// Navigates to the basic input page.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="DateAndTimePage"/>.
+        /// </returns>
+        public BasicInputPage GoToBasicInput()
+        {
+            ListView listView = this.WindowsApp.FindElement(this.menuList);
+            listView.ClickItem("Basic Input");
+            return new BasicInputPage();
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/SliderPage.cs
+++ b/samples/XamlControlsGallery/Pages/SliderPage.cs
@@ -1,0 +1,62 @@
+namespace XamlControlsGallery.Pages
+{
+    using System;
+
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines the SliderPage page of the XAML Controls Gallery application.
+    /// </summary>
+    public class SliderPage : BasePage
+    {
+        private readonly By simpleSlider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SliderPage"/> class.
+        /// </summary>
+        public SliderPage()
+        {
+            this.simpleSlider = By.Name("simple slider");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='Slider'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Sets the simple slider value.
+        /// </summary>
+        /// <param name="value">
+        /// The value to set.
+        /// </param>
+        /// <returns>
+        /// The <see cref="SliderPage"/>.
+        /// </returns>
+        public SliderPage SetSimpleSliderValue(double value)
+        {
+            Slider slider = this.WindowsApp.FindElement(this.simpleSlider);
+            slider.SetValue(value);
+            return this;
+        }
+
+        /// <summary>
+        /// Verifies that the simple slider value has been updated.
+        /// </summary>
+        /// <param name="value">
+        /// The value of the slider to verify updated.
+        /// </param>
+        public void VerifySimpleSliderValue(double value)
+        {
+            Slider slider = this.WindowsApp.FindElement(this.simpleSlider);
+            Assert.AreEqual(value, slider.Value);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/SliderPage.cs
+++ b/samples/XamlControlsGallery/Pages/SliderPage.cs
@@ -12,7 +12,7 @@ namespace XamlControlsGallery.Pages
     using OpenQA.Selenium.Appium.Windows;
 
     /// <summary>
-    /// Defines the SliderPage page of the XAML Controls Gallery application.
+    /// Defines the Slider page of the XAML Controls Gallery application.
     /// </summary>
     public class SliderPage : BasePage
     {

--- a/samples/XamlControlsGallery/Pages/ToggleSwitchPage.cs
+++ b/samples/XamlControlsGallery/Pages/ToggleSwitchPage.cs
@@ -1,0 +1,71 @@
+namespace XamlControlsGallery.Pages
+{
+    using System;
+
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines the ToggleSwitch page of the XAML Controls Gallery application.
+    /// </summary>
+    public class ToggleSwitchPage : BasePage
+    {
+        private readonly By simpleToggleSwitch;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ToggleSwitchPage"/> class.
+        /// </summary>
+        public ToggleSwitchPage()
+        {
+            this.simpleToggleSwitch = By.Name("simple ToggleSwitch");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='ToggleSwitch'][@AutomationId='TitleTextBlock']");
+
+        /// <summary>
+        /// Toggles the simple switch.
+        /// </summary>
+        /// <param name="on">
+        /// A value indicating whether to toggle on.
+        /// </param>
+        /// <returns>
+        /// The <see cref="SliderPage"/>.
+        /// </returns>
+        public ToggleSwitchPage ToggleSimpleSwitch(bool on)
+        {
+            ToggleSwitch toggle = this.WindowsApp.FindElement(this.simpleToggleSwitch);
+
+            if (on)
+            {
+                toggle.ToggleOn();
+            }
+            else
+            {
+                toggle.ToggleOff();
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Verifies that the simple toggle switch state has been updated.
+        /// </summary>
+        /// <param name="on">
+        /// A value indicating whether the toggle should be on.
+        /// </param>
+        public void VerifySimpleToggleSwitch(bool on)
+        {
+            ToggleSwitch toggle = this.WindowsApp.FindElement(this.simpleToggleSwitch);
+            Assert.AreEqual(on, toggle.IsOn);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Tests/ComboBoxTests.cs
+++ b/samples/XamlControlsGallery/Tests/ComboBoxTests.cs
@@ -1,0 +1,34 @@
+namespace XamlControlsGallery.Tests
+{
+    using System;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using XamlControlsGallery.Pages;
+
+    [TestClass]
+    public class ComboBoxTests : BaseTestClass
+    {
+        private static ComboBoxPage ComboBoxPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            ComboBoxPage = new NavigationMenu().GoToBasicInput().GoToComboBox();
+        }
+
+        [TestMethod]
+        public void SetColorsComboBoxItem()
+        {
+            // Arrange
+            var expectedItem = "Green";
+
+            // Act
+            ComboBoxPage.SetColorsComboBoxItem(expectedItem);
+
+            // Assert
+            ComboBoxPage.VerifyColorsComboBoxItem(expectedItem);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Tests/DatePickerTests.cs
+++ b/samples/XamlControlsGallery/Tests/DatePickerTests.cs
@@ -24,9 +24,10 @@ namespace XamlControlsGallery.Tests
             // Arrange
             var expectedDate = new DateTime(2020, 4, 14);
 
+            // Act
             DatePickerPage.SetSimpleDatePickerDate(expectedDate);
 
-            // Act & Assert
+            // Assert
             DatePickerPage.VerifySimpleTimePickerTime(expectedDate);
         }
     }

--- a/samples/XamlControlsGallery/Tests/DatePickerTests.cs
+++ b/samples/XamlControlsGallery/Tests/DatePickerTests.cs
@@ -1,0 +1,33 @@
+namespace XamlControlsGallery.Tests
+{
+    using System;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using XamlControlsGallery.Pages;
+
+    [TestClass]
+    public class DatePickerTests : BaseTestClass
+    {
+        private static DatePickerPage DatePickerPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            DatePickerPage = new NavigationMenu().GoToDateAndTime().GoToDatePicker();
+        }
+
+        [TestMethod]
+        public void SetSimpleDatePickerDate()
+        {
+            // Arrange
+            var expectedDate = new DateTime(2020, 4, 14);
+
+            DatePickerPage.SetSimpleDatePickerDate(expectedDate);
+
+            // Act & Assert
+            DatePickerPage.VerifySimpleTimePickerTime(expectedDate);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Tests/SliderTests.cs
+++ b/samples/XamlControlsGallery/Tests/SliderTests.cs
@@ -1,0 +1,32 @@
+namespace XamlControlsGallery.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using XamlControlsGallery.Pages;
+
+    [TestClass]
+    public class SliderTests : BaseTestClass
+    {
+        private static SliderPage SliderPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            SliderPage = new NavigationMenu().GoToBasicInput().GoToSlider();
+        }
+
+        [TestMethod]
+        public void SetSliderValue()
+        {
+            // Arrange
+            const int expectedValue = 62;
+
+            // Act
+            SliderPage.SetSimpleSliderValue(expectedValue);
+
+            // Assert
+            SliderPage.VerifySimpleSliderValue(expectedValue);
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Tests/TimePickerTests.cs
+++ b/samples/XamlControlsGallery/Tests/TimePickerTests.cs
@@ -24,9 +24,10 @@ namespace XamlControlsGallery.Tests
             // Arrange
             var expectedTime = new TimeSpan(7, 5, 0);
 
+            // Act
             TimePickerPage.SetSimpleTimePickerTime(expectedTime);
 
-            // Act & Assert
+            // Assert
             TimePickerPage.VerifySimpleTimePickerTime(expectedTime);
         }
     }

--- a/samples/XamlControlsGallery/Tests/ToggleSwitchTests.cs
+++ b/samples/XamlControlsGallery/Tests/ToggleSwitchTests.cs
@@ -1,0 +1,45 @@
+namespace XamlControlsGallery.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using XamlControlsGallery.Pages;
+
+    [TestClass]
+    public class ToggleSwitchTests : BaseTestClass
+    {
+        private static ToggleSwitchPage ToggleSwitchPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            ToggleSwitchPage = new NavigationMenu().GoToBasicInput().GoToToggleSwitch();
+        }
+
+        [TestMethod]
+        public void SetSimpleToggleOn()
+        {
+            // Arrange
+            const bool expectedState = true;
+
+            // Act
+            ToggleSwitchPage.ToggleSimpleSwitch(expectedState);
+
+            // Assert
+            ToggleSwitchPage.VerifySimpleToggleSwitch(expectedState);
+        }
+
+        [TestMethod]
+        public void SetSimpleToggleOff()
+        {
+            // Arrange
+            const bool expectedState = false;
+
+            // Act
+            ToggleSwitchPage.ToggleSimpleSwitch(expectedState);
+
+            // Assert
+            ToggleSwitchPage.VerifySimpleToggleSwitch(expectedState);
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/ComboBox.cs
+++ b/src/Legerity/Windows/Elements/Core/ComboBox.cs
@@ -1,0 +1,73 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP ComboBox control.
+    /// </summary>
+    public class ComboBox : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComboBox"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public ComboBox(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ComboBox"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ComboBox"/>.
+        /// </returns>
+        public static implicit operator ComboBox(WindowsElement element)
+        {
+            return new ComboBox(element);
+        }
+
+        /// <summary>
+        /// Selects an item in the combo-box with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to select.
+        /// </param>
+        public void SelectItem(string name)
+        {
+            this.Element.Click();
+
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(By.ClassName("ComboBoxItem"));
+
+            AppiumWebElement item = listElements.FirstOrDefault(
+                element => element.GetAttribute("Name").Equals(name, StringComparison.CurrentCultureIgnoreCase));
+
+            item.Click();
+        }
+
+        /// <summary>
+        /// Retrieves the currently select item.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="string"/> associated with the selected item.
+        /// </returns>
+        public string GetSelectItem()
+        {
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(By.ClassName("ComboBoxItem"));
+            return listElements.Count == 1 ? listElements.FirstOrDefault().GetAttribute("Name") : null;
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/DatePicker.cs
+++ b/src/Legerity/Windows/Elements/Core/DatePicker.cs
@@ -1,0 +1,87 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP DatePicker control.
+    /// </summary>
+    public class DatePicker : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DatePicker"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public DatePicker(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the query for the popup displayed for the date picker when invoking the control.
+        /// </summary>
+        public By Flyout => ByExtensions.AutomationId("DatePickerFlyoutPresenter");
+
+        /// <summary>
+        /// Gets the query for the day looping selector.
+        /// </summary>
+        public By DaySelector => ByExtensions.AutomationId("DayLoopingSelector");
+
+        /// <summary>
+        /// Gets the query for the month looping selector.
+        /// </summary>
+        public By MonthSelector => ByExtensions.AutomationId("MonthLoopingSelector");
+
+        /// <summary>
+        /// Gets the query for the year looping selector.
+        /// </summary>
+        public By YearSelector => ByExtensions.AutomationId("YearLoopingSelector");
+
+        /// <summary>
+        /// Gets the query for the accept button.
+        /// </summary>
+        public By AcceptButton => ByExtensions.AutomationId("AcceptButton");
+
+        /// <summary>
+        /// Gets the query for the dismiss button.
+        /// </summary>
+        public By DismissButton => ByExtensions.AutomationId("DismissButton");
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="DatePicker"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="DatePicker"/>.
+        /// </returns>
+        public static implicit operator DatePicker(WindowsElement element)
+        {
+            return new DatePicker(element);
+        }
+
+        /// <summary>
+        /// Sets the date to the specified date.
+        /// </summary>
+        /// <param name="date">The date to set.</param>
+        public void SetDate(DateTime date)
+        {
+            // Taps the time picker to show the popup.
+            this.Element.Click();
+
+            // Finds the popup and changes the time.
+            WindowsElement popup = this.Driver.FindElement(this.Flyout);
+            popup.FindElement(this.DaySelector).FindElementByName(date.ToString("%d")).Click();
+            popup.FindElement(this.MonthSelector).FindElementByName(date.ToString("MMMM")).Click();
+            popup.FindElement(this.YearSelector).FindElementByName(date.ToString("yyyy")).Click();
+            popup.FindElement(this.AcceptButton).Click();
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/GridView.cs
+++ b/src/Legerity/Windows/Elements/Core/GridView.cs
@@ -54,10 +54,7 @@ namespace Legerity.Windows.Elements.Core
             ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(By.ClassName("GridViewItem"));
 
             AppiumWebElement item = listElements.FirstOrDefault(
-                element => element.GetAttribute("Name").Contains(
-                    name,
-                    CultureInfo.CurrentCulture,
-                    CompareOptions.IgnoreCase));
+                element => element.GetAttribute("Name").Equals(name, StringComparison.CurrentCultureIgnoreCase));
 
             item.Click();
         }

--- a/src/Legerity/Windows/Elements/Core/ListView.cs
+++ b/src/Legerity/Windows/Elements/Core/ListView.cs
@@ -54,10 +54,7 @@ namespace Legerity.Windows.Elements.Core
             ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(By.ClassName("ListViewItem"));
 
             AppiumWebElement item = listElements.FirstOrDefault(
-                element => element.GetAttribute("Name").Contains(
-                    name,
-                    CultureInfo.CurrentCulture,
-                    CompareOptions.IgnoreCase));
+                element => element.GetAttribute("Name").Equals(name, StringComparison.CurrentCultureIgnoreCase));
 
             item.Click();
         }

--- a/src/Legerity/Windows/Elements/Core/Slider.cs
+++ b/src/Legerity/Windows/Elements/Core/Slider.cs
@@ -65,6 +65,15 @@ namespace Legerity.Windows.Elements.Core
             return new Slider(element);
         }
 
+        /// <summary>
+        /// Sets the value of the slider.
+        /// </summary>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if the value is out of the minimum and maximum range of the slider.
+        /// </exception>
         public void SetValue(double value)
         {
             double min = this.Minimum;

--- a/src/Legerity/Windows/Elements/Core/Slider.cs
+++ b/src/Legerity/Windows/Elements/Core/Slider.cs
@@ -1,0 +1,93 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP Slider control.
+    /// </summary>
+    public class Slider : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Slider"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public Slider(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the minimum value of the slider.
+        /// </summary>
+        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+
+        /// <summary>
+        /// Gets the maximum value of the slider.
+        /// </summary>
+        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+
+        /// <summary>
+        /// Gets the small change (step) value of the slider.
+        /// </summary>
+        public double SmallChange => double.Parse(this.Element.GetAttribute("RangeValue.SmallChange"));
+
+        /// <summary>
+        /// Gets the value of the slider.
+        /// </summary>
+        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+
+        /// <summary>
+        /// Gets a value indicating whether the control is in a readonly state.
+        /// </summary>
+        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Slider"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Slider"/>.
+        /// </returns>
+        public static implicit operator Slider(WindowsElement element)
+        {
+            return new Slider(element);
+        }
+
+        public void SetValue(double value)
+        {
+            double min = this.Minimum;
+            double max = this.Maximum;
+
+            if (value < this.Minimum)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be greater than or equal to the minimum value {min}");
+            }
+
+            if (value > this.Maximum)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be less than or equal to the maximum value {max}");
+            }
+
+            this.Element.Click();
+
+            double currentValue = this.Value;
+            while (Math.Abs(currentValue - value) > double.Epsilon)
+            {
+                this.Element.SendKeys(currentValue < value ? Keys.ArrowRight : Keys.ArrowLeft);
+                currentValue = this.Value;
+            }
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/TimePicker.cs
+++ b/src/Legerity/Windows/Elements/Core/TimePicker.cs
@@ -18,7 +18,7 @@ namespace Legerity.Windows.Elements.Core
         /// Initializes a new instance of the <see cref="TimePicker"/> class.
         /// </summary>
         /// <param name="element">
-        /// The <see cref="WindowsElement"/> reference..
+        /// The <see cref="WindowsElement"/> reference.
         /// </param>
         public TimePicker(WindowsElement element)
             : base(element)

--- a/src/Legerity/Windows/Elements/Core/ToggleSwitch.cs
+++ b/src/Legerity/Windows/Elements/Core/ToggleSwitch.cs
@@ -1,0 +1,76 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the core UWP ToggleSwitch control.
+    /// </summary>
+    public class ToggleSwitch : WindowsElementWrapper
+    {
+        private const string ToggleOnValue = "1";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ToggleSwitch"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public ToggleSwitch(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the toggle switch is in the on position.
+        /// </summary>
+        public bool IsOn => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ToggleSwitch"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ToggleSwitch"/>.
+        /// </returns>
+        public static implicit operator ToggleSwitch(WindowsElement element)
+        {
+            return new ToggleSwitch(element);
+        }
+
+        /// <summary>
+        /// Toggles the switch on.
+        /// </summary>
+        public void ToggleOn()
+        {
+            if (this.IsOn)
+            {
+                return;
+            }
+
+            this.Element.Click();
+        }
+
+        /// <summary>
+        /// Toggles the switch off.
+        /// </summary>
+        public void ToggleOff()
+        {
+            if (!this.IsOn)
+            {
+                return;
+            }
+
+            this.Element.Click();
+        }
+    }
+}


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

Changes have been made to introduce the following UWP basic input control element wrappers (in-line with the XAML Controls Gallery):

- ToggleSwitch
- DatePicker
- Slider
- ComboBox

With these elements, the XAML Controls Gallery sample test project has been updated to include several new page objects and tests to further show the use to the page object pattern and the usage of the new wrapper elements.

Fixes have also been made to the ListView and GridView controls so that the elements selected when calling `ClickItem` are the correct items.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

No additional references.