### PR TITLE
Added iOS & Android app manager support

### DIFF
--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -14,6 +14,10 @@ Currently the `AppManager` configuration supports the following app drivers.
 
 - [WindowsDriver](https://github.com/microsoft/WinAppDriver)
   - [WindowsAppManagerOptions](../src/Legerity/Windows/WindowsAppManagerOptions.cs)
+- AndroidDriver
+  - [AndroidAppManagerOptions](../src/Legerity/Android/AndroidAppManagerOptions.cs)
+- IOSDriver
+  - [IOSAppManagerOptions](../src/Legerity/IOS/IOSAppManagerOptions.cs)
 
 The options object also provides the use of additional capabilities using the `AppiumOptions` object to apply to the driver when the app is started.
 
@@ -49,3 +53,11 @@ namespace WindowsAlarmsAndClock
     }
 }
 ```
+
+To access the driver for the currently running application, it's as simple as reaching out to one of the following [`AppManager`](../src/Legerity/AppManager.cs) properties:
+
+- `WindowsApp`
+- `AndroidApp`
+- `IOSApp`
+
+Each of these properties exposes the platform specific Appium driver which can be used to access UI elements.

--- a/src/Legerity/Android/AndroidAppManagerOptions.cs
+++ b/src/Legerity/Android/AndroidAppManagerOptions.cs
@@ -1,0 +1,120 @@
+namespace Legerity.Android
+{
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Enums;
+
+    /// <summary>
+    /// Defines a specific <see cref="AppManagerOptions"/> for an Android application.
+    /// </summary>
+    public class AndroidAppManagerOptions : AppManagerOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AndroidAppManagerOptions"/> class.
+        /// </summary>
+        /// <param name="appId">
+        /// The ID of the application under test, e.g. com.instagram.android.
+        /// </param>
+        /// <param name="appActivity">
+        /// The activity of the application to start, e.g. com.instagram.android.activity.MainTabActivity.
+        /// </param>
+        /// <param name="androidVersion">
+        /// The version of Android to run the application on.
+        /// </param>
+        /// <param name="deviceName">
+        /// The name of the Android device to run the application on.
+        /// </param>
+        public AndroidAppManagerOptions(string appId, string appActivity, string androidVersion, string deviceName)
+            : this(appId, appActivity, androidVersion, deviceName, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AndroidAppManagerOptions"/> class.
+        /// </summary>
+        /// <param name="appId">
+        /// The ID of the application under test, e.g. com.instagram.android.
+        /// </param>
+        /// <param name="appActivity">
+        /// The activity of the application to start, e.g. com.instagram.android.activity.MainTabActivity.
+        /// </param>
+        /// <param name="androidVersion">
+        /// The version of Android to run the application on.
+        /// </param>
+        /// <param name="deviceName">
+        /// The name of the Android device to run the application on.
+        /// </param>
+        /// <param name="additionalOptions">
+        /// The additional options to apply to the <see cref="AppiumOptions"/>.
+        /// </param>
+        public AndroidAppManagerOptions(
+            string appId,
+            string appActivity,
+            string androidVersion,
+            string deviceName,
+            params (string, object)[] additionalOptions)
+        {
+            this.AppId = appId;
+            this.AppActivity = appActivity;
+            this.AndroidVersion = androidVersion;
+            this.DeviceName = deviceName;
+            this.Configure(additionalOptions);
+        }
+
+        /// <summary>
+        /// Gets the ID of the application under test.
+        /// </summary>
+        public string AppId { get; }
+
+        /// <summary>
+        /// Gets the activity of the application to start, e.g. com.instagram.android.activity.MainTabActivity.
+        /// </summary>
+        public string AppActivity { get; }
+
+        /// <summary>
+        /// Gets the version of Android to run the application on.
+        /// </summary>
+        public string AndroidVersion { get; }
+
+        /// <summary>
+        /// Gets the name of the Android device to run the application on.
+        /// </summary>
+        public string DeviceName { get; }
+
+        /// <summary>
+        /// Configures the <see cref="AppManagerOptions.AppiumOptions"/> with the specified additional options.
+        /// <para>
+        /// By default, the <see cref="AppId"/> will be added to the options as capability 'app'.
+        /// </para>
+        /// </summary>
+        /// <param name="additionalOptions">
+        /// The additional options to apply to the <see cref="AppiumOptions"/>.
+        /// </param>
+        public void Configure((string, object)[] additionalOptions)
+        {
+            var options = new AppiumOptions();
+
+            options.AddAdditionalCapability(MobileCapabilityType.PlatformName, "Android");
+            options.AddAdditionalCapability(MobileCapabilityType.PlatformVersion, this.AndroidVersion);
+            options.AddAdditionalCapability(MobileCapabilityType.DeviceName, this.DeviceName);
+            options.AddAdditionalCapability("appPackage", this.AppId);
+            options.AddAdditionalCapability("appActivity", this.AppActivity);
+
+            if (additionalOptions != null)
+            {
+                foreach ((string capabilityName, object capabilityValue) in additionalOptions)
+                {
+                    options.AddAdditionalCapability(capabilityName, capabilityValue);
+                }
+            }
+
+            this.AppiumOptions = options;
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"{base.ToString()}, AppId [{this.AppId}]";
+        }
+    }
+}

--- a/src/Legerity/IOS/IOSAppManagerOptions.cs
+++ b/src/Legerity/IOS/IOSAppManagerOptions.cs
@@ -1,72 +1,59 @@
-namespace Legerity.Android
+namespace Legerity.IOS
 {
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Enums;
 
     /// <summary>
-    /// Defines a specific <see cref="AppManagerOptions"/> for an Android application.
+    /// Defines a specific <see cref="AppManagerOptions"/> for an iOS application.
     /// </summary>
-    public class AndroidAppManagerOptions : AppManagerOptions
+    public class IOSAppManagerOptions : AppManagerOptions
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AndroidAppManagerOptions"/> class.
+        /// Initializes a new instance of the <see cref="IOSAppManagerOptions"/> class.
         /// </summary>
         /// <param name="appId">
-        /// The ID of the application under test, e.g. com.instagram.android.
-        /// </param>
-        /// <param name="appActivity">
-        /// The activity of the application to start, e.g. com.instagram.android.activity.MainTabActivity.
+        /// The ID of the application under test, e.g. com.instagram.ios.
         /// </param>
         /// <param name="osVersion">
-        /// The version of Android to run the application on.
+        /// The version of iOS to run the application on.
         /// </param>
         /// <param name="deviceName">
-        /// The name of the Android device to run the application on.
+        /// The name of the iOS device to run the application on.
         /// </param>
         /// <param name="deviceId">
         /// The ID of the Android device to run the application on.
         /// </param>
-        public AndroidAppManagerOptions(
-            string appId,
-            string appActivity,
-            string osVersion,
-            string deviceName,
-            string deviceId)
-            : this(appId, appActivity, osVersion, deviceName, deviceId, null)
+        public IOSAppManagerOptions(string appId, string osVersion, string deviceName, string deviceId)
+            : this(appId, osVersion, deviceName, deviceId, null)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AndroidAppManagerOptions"/> class.
+        /// Initializes a new instance of the <see cref="IOSAppManagerOptions"/> class.
         /// </summary>
         /// <param name="appId">
-        /// The ID of the application under test, e.g. com.instagram.android.
-        /// </param>
-        /// <param name="appActivity">
-        /// The activity of the application to start, e.g. com.instagram.android.activity.MainTabActivity.
+        /// The ID of the application under test, e.g. com.instagram.ios.
         /// </param>
         /// <param name="osVersion">
-        /// The version of Android to run the application on.
+        /// The version of iOS to run the application on.
         /// </param>
         /// <param name="deviceName">
-        /// The name of the Android device to run the application on.
+        /// The name of the iOS device to run the application on.
         /// </param>
         /// <param name="deviceId">
-        /// The ID of the Android device to run the application on.
+        /// The ID of the iOS device to run the application on.
         /// </param>
         /// <param name="additionalOptions">
         /// The additional options to apply to the <see cref="AppiumOptions"/>.
         /// </param>
-        public AndroidAppManagerOptions(
+        public IOSAppManagerOptions(
             string appId,
-            string appActivity,
             string osVersion,
             string deviceName,
             string deviceId,
             params (string, object)[] additionalOptions)
         {
             this.AppId = appId;
-            this.AppActivity = appActivity;
             this.OSVersion = osVersion;
             this.DeviceName = deviceName;
             this.DeviceId = deviceId;
@@ -79,27 +66,22 @@ namespace Legerity.Android
         public string AppId { get; }
 
         /// <summary>
-        /// Gets the activity of the application to start, e.g. com.instagram.android.activity.MainTabActivity.
-        /// </summary>
-        public string AppActivity { get; }
-
-        /// <summary>
-        /// Gets the version of Android to run the application on.
+        /// Gets the version of iOS to run the application on.
         /// </summary>
         public string OSVersion { get; }
 
         /// <summary>
-        /// Gets the name of the Android device to run the application on.
+        /// Gets the name of the iOS device to run the application on.
         /// </summary>
         public string DeviceName { get; }
 
         /// <summary>
-        /// Gets the ID of the Android device to run the application on.
+        /// Gets the ID of the iOS device to run the application on.
         /// </summary>
         public string DeviceId { get; }
 
         /// <summary>
-        /// Configures the <see cref="AppManagerOptions.AppiumOptions"/> with the specified additional options.
+        /// Configures the <see cref="AppiumOptions"/> with the specified additional options.
         /// <para>
         /// By default, the <see cref="AppId"/> will be added to the options as capability 'app'.
         /// </para>
@@ -111,12 +93,11 @@ namespace Legerity.Android
         {
             var options = new AppiumOptions();
 
-            options.AddAdditionalCapability(MobileCapabilityType.PlatformName, "Android");
+            options.AddAdditionalCapability(MobileCapabilityType.PlatformName, "iOS");
             options.AddAdditionalCapability(MobileCapabilityType.PlatformVersion, this.OSVersion);
             options.AddAdditionalCapability(MobileCapabilityType.DeviceName, this.DeviceName);
             options.AddAdditionalCapability(MobileCapabilityType.Udid, this.DeviceId);
-            options.AddAdditionalCapability("appPackage", this.AppId);
-            options.AddAdditionalCapability("appActivity", this.AppActivity);
+            options.AddAdditionalCapability(MobileCapabilityType.App, this.AppId);
 
             if (additionalOptions != null)
             {

--- a/src/Legerity/Legerity.csproj
+++ b/src/Legerity/Legerity.csproj
@@ -28,12 +28,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\assets\ProjectLogo.png" Pack="true" PackagePath=""/>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+    <None Include="..\..\assets\ProjectLogo.png" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Appium.WebDriver" Version="4.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

Changes have been made to introduce iOS and Android drivers to the app manager. Each platform also has an appropriate manager options configuration model which can be used to configure the driver for the device or emulator the applications will run on.

This is the starting point to developing out platform specific element wrappers for iOS and Android components.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->