### PR TITLE
Added support for WCT RadialGauge

### DIFF
--- a/samples/WindowsCommunityToolkitSampleApp/BaseTestClass.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/BaseTestClass.cs
@@ -1,0 +1,25 @@
+namespace WindowsCommunityToolkitSampleApp
+{
+    using Legerity;
+    using Legerity.Windows;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    public abstract class BaseTestClass
+    {
+        [TestInitialize]
+        public virtual void Initialize()
+        {
+            AppManager.StartApp(
+                new WindowsAppManagerOptions("Microsoft.UWPCommunityToolkitSampleApp_8wekyb3d8bbwe!App")
+                {
+                    DriverUri = "http://127.0.0.1:4723"
+                });
+        }
+
+        [TestCleanup]
+        public virtual void Cleanup()
+        {
+            AppManager.StopApp();
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
@@ -1,0 +1,51 @@
+namespace WindowsCommunityToolkitSampleApp.Pages
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Elements.WinUI;
+    using Legerity.Windows.Extensions;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+
+    public class AppPage : BasePage
+    {
+        private readonly By sampleSearchBoxQuery = ByExtensions.AutomationId("SearchBox");
+
+        /// <summary>
+        /// Gets the UI component associated with the sample picker.
+        /// </summary>
+        public GridView SamplePicker => this.WindowsApp.FindElement(ByExtensions.AutomationId("SamplePickerGridView"));
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => ByExtensions.AutomationId("NavView");
+
+        /// <summary>
+        /// Selects a sample from the available options with the given name.
+        /// </summary>
+        /// <typeparam name="TPage">The type of page to return.</typeparam>
+        /// <param name="name">The name of the sample to click.</param>
+        /// <returns>The <see cref="TPage"/> instance.</returns>
+        public TPage SelectSample<TPage>(string name) where TPage : BasePage
+        {
+            this.SearchForSample(name);
+
+            AppiumWebElement item = this.SamplePicker.Items.FirstOrDefault(i =>
+                i.FindElement(By.XPath($".//*[@ClassName='TextBlock'][@Name='{name}']")) != null);
+            item.Click();
+
+            return Activator.CreateInstance<TPage>();
+        }
+
+        private void SearchForSample(string sampleName)
+        {
+            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
+            AutoSuggestBox controlsSearchBox = navigationView.Element.FindElement(this.sampleSearchBoxQuery);
+            controlsSearchBox.SetText(sampleName);
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/RadialGaugePage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/RadialGaugePage.cs
@@ -1,0 +1,38 @@
+namespace WindowsCommunityToolkitSampleApp.Pages
+{
+    using Legerity.Windows.Elements.WCT;
+    using Legerity.Windows.Extensions;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the RadialGauge page of the Windows Community Toolkit sample application.
+    /// </summary>
+    public class RadialGaugePage : AppPage
+    {
+        private readonly By radialGauge;
+
+        public RadialGaugePage()
+        {
+            this.radialGauge = ByExtensions.AutomationId("RadialGauge");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@ClassName='TextBlock'][@Name='RadialGauge']");
+
+        public RadialGaugePage SetRadialGaugeValue(double value)
+        {
+            RadialGauge gauge = this.WindowsApp.FindElement(this.radialGauge);
+            gauge.SetValue(value);
+            return this;
+        }
+
+        public void VerifyRadialGaugeValue(double value)
+        {
+            RadialGauge gauge = this.WindowsApp.FindElement(this.radialGauge);
+            Assert.AreEqual(value, gauge.Value);
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Tests/RadialGaugeTests.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Tests/RadialGaugeTests.cs
@@ -1,0 +1,31 @@
+namespace WindowsCommunityToolkitSampleApp.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Pages;
+
+    [TestClass]
+    public class RadialGaugeTests : BaseTestClass
+    {
+        private static RadialGaugePage RadialGaugePage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            RadialGaugePage = new AppPage().SelectSample<RadialGaugePage>("RadialGauge");
+        }
+
+        [TestMethod]
+        public void SetRadialGaugeValue()
+        {
+            // Arrange
+            const int expectedValue = 180;
+
+            // Act
+            RadialGaugePage.SetRadialGaugeValue(expectedValue);
+
+            // Assert
+            RadialGaugePage.VerifyRadialGaugeValue(expectedValue);
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/WindowsCommunityToolkitSampleApp.csproj
+++ b/samples/WindowsCommunityToolkitSampleApp/WindowsCommunityToolkitSampleApp.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Legerity.WCT\Legerity.WCT.csproj" />
+    <ProjectReference Include="..\..\src\Legerity.WinUI\Legerity.WinUI.csproj" />
+    <ProjectReference Include="..\..\src\Legerity\Legerity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Legerity.WCT/Legerity.WCT.csproj
+++ b/src/Legerity.WCT/Legerity.WCT.csproj
@@ -1,0 +1,44 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Version>1.0.0.0</Version>
+    <Authors>MADE Apps</Authors>
+    <Company>MADE Apps</Company>
+    <Product>Legerity for Windows Community Toolkit - Framework for UI tests with Appium with .NET</Product>
+    <Description>An extension to Legerity to support Windows Community Toolkit elements for speeding up the development of automated UI tests with Appium with .NET.</Description>
+    <Copyright>Copyright (C) MADE Apps. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/MADE-Apps/legerity</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageIcon>ProjectLogo.png</PackageIcon>
+    <PackageTags>Appium WinAppDriver UWP WCT</PackageTags>
+    <NeutralLanguage>en</NeutralLanguage>
+    <PackageId>Legerity.WCT</PackageId>
+    <RootNamespace>Legerity.Windows.Elements.WCT</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Legerity.WCT.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\assets\ProjectLogo.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Appium.WebDriver" Version="4.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Legerity\Legerity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Legerity.WCT/RadialGauge.cs
+++ b/src/Legerity.WCT/RadialGauge.cs
@@ -1,0 +1,110 @@
+namespace Legerity.Windows.Elements.WCT
+{
+    using System;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the Windows Community Toolkit RadialGauge control.
+    /// </summary>
+    public class RadialGauge : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadialGauge"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public RadialGauge(WindowsElement element) : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the minimum value of the gauge.
+        /// </summary>
+        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+
+        /// <summary>
+        /// Gets the maximum value of the gauge.
+        /// </summary>
+        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+
+        /// <summary>
+        /// Gets the small change (step) value of the gauge.
+        /// </summary>
+        public double SmallChange => double.Parse(this.Element.GetAttribute("RangeValue.SmallChange"));
+
+        /// <summary>
+        /// Gets the value of the gauge.
+        /// </summary>
+        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+
+        /// <summary>
+        /// Gets a value indicating whether the control is in a readonly state.
+        /// </summary>
+        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadialGauge"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="RadialGauge"/>.
+        /// </returns>
+        public static implicit operator RadialGauge(WindowsElement element)
+        {
+            return new RadialGauge(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="RadialGauge"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="RadialGauge"/>.
+        /// </returns>
+        public static implicit operator RadialGauge(AppiumWebElement element)
+        {
+            return new RadialGauge(element as WindowsElement);
+        }
+
+        /// <summary>
+        /// Sets the value of the gauge.
+        /// </summary>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if the value is out of the minimum and maximum range of the gauge.
+        /// </exception>
+        public void SetValue(double value)
+        {
+            double min = this.Minimum;
+            double max = this.Maximum;
+
+            if (value < this.Minimum)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be greater than or equal to the minimum value {min}");
+            }
+
+            if (value > this.Maximum)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be less than or equal to the maximum value {max}");
+            }
+
+            this.Element.Click();
+
+            double currentValue = this.Value;
+            while (Math.Abs(currentValue - value) > double.Epsilon)
+            {
+                this.Element.SendKeys(currentValue < value ? Keys.ArrowRight : Keys.ArrowLeft);
+                currentValue = this.Value;
+            }
+        }
+    }
+}

--- a/src/Legerity.WinUI/NavigationViewItem.cs
+++ b/src/Legerity.WinUI/NavigationViewItem.cs
@@ -24,6 +24,17 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Initializes a new instance of the <see cref="NavigationViewItem"/> class.
         /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public NavigationViewItem(WindowsElement element)
+            : this(null, null, element)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NavigationViewItem"/> class.
+        /// </summary>
         /// <param name="parentNavigationView">
         /// The parent <see cref="NavigationView"/>.
         /// </param>

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebTests", "..\samples\WebT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Legerity.WCT", "Legerity.WCT\Legerity.WCT.csproj", "{DAE078FF-6E67-440E-B501-C2524209CF88}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsCommunityToolkitSampleApp", "..\samples\WindowsCommunityToolkitSampleApp\WindowsCommunityToolkitSampleApp.csproj", "{837B7598-683F-4987-9765-B7C6CB0784CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{DAE078FF-6E67-440E-B501-C2524209CF88}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DAE078FF-6E67-440E-B501-C2524209CF88}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DAE078FF-6E67-440E-B501-C2524209CF88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{837B7598-683F-4987-9765-B7C6CB0784CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{837B7598-683F-4987-9765-B7C6CB0784CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{837B7598-683F-4987-9765-B7C6CB0784CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{837B7598-683F-4987-9765-B7C6CB0784CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -61,6 +67,7 @@ Global
 		{CB7ABF30-DCCF-46FA-BA02-BCAEEE04D08F} = {71D6D4B1-DD5C-4238-8E85-5BC755F40931}
 		{158C404E-1082-4803-A5AD-D26FC6432A6D} = {71D6D4B1-DD5C-4238-8E85-5BC755F40931}
 		{0BCFB2AC-9B1B-41DF-919C-521E60AA0186} = {CB7ABF30-DCCF-46FA-BA02-BCAEEE04D08F}
+		{837B7598-683F-4987-9765-B7C6CB0784CE} = {158C404E-1082-4803-A5AD-D26FC6432A6D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FAB58D66-B3F1-408A-A96F-572170771367}

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Windows", "Windows", "{158C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebTests", "..\samples\WebTests\WebTests.csproj", "{0BCFB2AC-9B1B-41DF-919C-521E60AA0186}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Legerity.WCT", "Legerity.WCT\Legerity.WCT.csproj", "{DAE078FF-6E67-440E-B501-C2524209CF88}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{0BCFB2AC-9B1B-41DF-919C-521E60AA0186}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BCFB2AC-9B1B-41DF-919C-521E60AA0186}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BCFB2AC-9B1B-41DF-919C-521E60AA0186}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAE078FF-6E67-440E-B501-C2524209CF88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAE078FF-6E67-440E-B501-C2524209CF88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAE078FF-6E67-440E-B501-C2524209CF88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAE078FF-6E67-440E-B501-C2524209CF88}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

Changes have been made to add a new Windows Community Toolkit specific framework library for writing UI tests against the controls on offer. 

This first addition is for the `RadialGauge` control providing support for interaction and validation of values including the current value, the min/max values, and the step increment.

Also included in this change is the addition of a Legerity sample for the Windows Community Toolkit Sample app to showcase the usage of the Legerity elements in a test project.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

Resolves #26 
