### PR TITLE
Added support for WCT InAppNotification

### DIFF
--- a/docs/Windows/WindowsControlWrappers.md
+++ b/docs/Windows/WindowsControlWrappers.md
@@ -50,4 +50,5 @@ These UWP control wrappers are designed to be used with controls from the [WinUI
 
 These UWP control wrappers are designed to be used with controls from the [Windows Community Toolkit](https://github.com/windows-toolkit/WindowsCommunityToolkit) suite.
 
+- [InAppNotification](../../src/Legerity.WCT/InAppNotification.cs)
 - [RadialGauge](../../src/Legerity.WCT/RadialGauge.cs)

--- a/samples/WindowsCommunityToolkitSampleApp/Elements/VsCodeInAppNotification.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Elements/VsCodeInAppNotification.cs
@@ -1,0 +1,49 @@
+namespace WindowsCommunityToolkitSampleApp.Elements
+{
+    using System.Linq;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Elements.WCT;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    public class VsCodeInAppNotification : InAppNotification
+    {
+        public VsCodeInAppNotification(WindowsElement element) : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the dismiss button.
+        /// </summary>
+        public override Button DismissButton => this.Element.FindElements(By.ClassName("Button")).FirstOrDefault(x => x.GetAttribute("Name") == "Close");
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="VsCodeInAppNotification"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="VsCodeInAppNotification"/>.
+        /// </returns>
+        public static implicit operator VsCodeInAppNotification(WindowsElement element)
+        {
+            return new VsCodeInAppNotification(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="VsCodeInAppNotification"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="VsCodeInAppNotification"/>.
+        /// </returns>
+        public static implicit operator VsCodeInAppNotification(AppiumWebElement element)
+        {
+            return new VsCodeInAppNotification(element as WindowsElement);
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/InAppNotificationPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/InAppNotificationPage.cs
@@ -1,0 +1,117 @@
+namespace WindowsCommunityToolkitSampleApp.Pages
+{
+    using System.Linq;
+    using Elements;
+    using Legerity.Exceptions;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Elements.WCT;
+    using Legerity.Windows.Extensions;
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the InAppNotification page of the Windows Community Toolkit sample application.
+    /// </summary>
+    public class InAppNotificationPage : AppPage
+    {
+        private readonly By exampleInAppNotificationQuery = ByExtensions.AutomationId("ExampleInAppNotification");
+
+        private readonly By exampleCodeInAppNotificationQuery =
+            ByExtensions.AutomationId("ExampleVSCodeInAppNotification");
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@ClassName='TextBlock'][@Name='InAppNotification']");
+
+        /// <summary>
+        /// Gets the example in-app notification element.
+        /// </summary>
+        public InAppNotification ExampleInAppNotification =>
+            this.WindowsApp.FindElement(this.exampleInAppNotificationQuery);
+
+        /// <summary>
+        /// Gets the example VS Code in-app notification element.
+        /// </summary>
+        public VsCodeInAppNotification ExampleVSCodeInAppNotification =>
+            this.WindowsApp.FindElement(this.exampleCodeInAppNotificationQuery);
+
+        public Button NotificationWithRandomTextButton => this.WindowsApp.FindElements(By.ClassName("Button"))
+            .FirstOrDefault(x => x.GetAttribute("Name") == "Show notification with random text");
+
+        public Button NotificationWithButtonsButton => this.WindowsApp.FindElements(By.ClassName("Button"))
+            .FirstOrDefault(x => x.GetAttribute("Name") == "Show notification with buttons (without DataTemplate)");
+
+        public Button NotificationWithVSCodeTemplateButton => this.WindowsApp.FindElements(By.ClassName("Button"))
+            .FirstOrDefault(x => x.GetAttribute("Name") == "Show notification with Visual Studio Code template (info notification)");
+
+        public InAppNotificationPage ShowNotificationWithRandomText()
+        {
+            this.NotificationWithRandomTextButton.Click();
+            return this;
+        }
+
+        public InAppNotificationPage ShowNotificationWithButtons()
+        {
+            this.NotificationWithButtonsButton.Click();
+            return this;
+        }
+
+        public InAppNotificationPage ShowNotificationWithVSCodeTemplate()
+        {
+            this.NotificationWithVSCodeTemplateButton.Click();
+            return this;
+        }
+
+        public InAppNotificationPage VerifyExampleInAppNotificationShown()
+        {
+            if (!this.ExampleInAppNotification.IsVisible)
+            {
+                throw new ElementNotShownException(this.exampleInAppNotificationQuery.ToString());
+            }
+
+            return this;
+        }
+
+        public InAppNotificationPage DismissExampleInAppNotification()
+        {
+            this.ExampleInAppNotification.Dismiss();
+            return this;
+        }
+
+        public InAppNotificationPage VerifyExampleInAppNotificationHidden()
+        {
+            if (this.ExampleInAppNotification.IsVisible)
+            {
+                throw new ElementShownException(this.exampleInAppNotificationQuery.ToString());
+            }
+
+            return this;
+        }
+
+        public InAppNotificationPage VerifyExampleVSCodeInAppNotificationShown()
+        {
+            if (!this.ExampleVSCodeInAppNotification.IsVisible)
+            {
+                throw new ElementNotShownException(this.exampleCodeInAppNotificationQuery.ToString());
+            }
+
+            return this;
+        }
+
+        public InAppNotificationPage DismissExampleVSCodeInAppNotification()
+        {
+            this.ExampleVSCodeInAppNotification.Dismiss();
+            return this;
+        }
+
+        public InAppNotificationPage VerifyExampleVSCodeInAppNotificationHidden()
+        {
+            if (this.ExampleVSCodeInAppNotification.IsVisible)
+            {
+                throw new ElementShownException(this.exampleCodeInAppNotificationQuery.ToString());
+            }
+
+            return this;
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Tests/InAppNotificationTests.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Tests/InAppNotificationTests.cs
@@ -1,0 +1,51 @@
+namespace WindowsCommunityToolkitSampleApp.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Pages;
+
+    [TestClass]
+    public class InAppNotificationTests : BaseTestClass
+    {
+        private static InAppNotificationPage InAppNotificationPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            InAppNotificationPage = new AppPage().SelectSample<InAppNotificationPage>("InAppNotification");
+        }
+
+        [TestMethod]
+        public void ShowAndDismissNotificationWithRandomText()
+        {
+            // Act & Assert
+            InAppNotificationPage
+                .ShowNotificationWithRandomText()
+                .VerifyExampleInAppNotificationShown()
+                .DismissExampleInAppNotification()
+                .VerifyExampleInAppNotificationHidden();
+        }
+
+        [TestMethod]
+        public void ShowAndDismissNotificationWithButtons()
+        {
+            // Act & Assert
+            InAppNotificationPage
+                .ShowNotificationWithButtons()
+                .VerifyExampleInAppNotificationShown()
+                .DismissExampleInAppNotification()
+                .VerifyExampleInAppNotificationHidden();
+        }
+
+        [TestMethod]
+        public void ShowAndDismissNotificationWithVSCodeTemplate()
+        {
+            // Act & Assert
+            InAppNotificationPage
+                .ShowNotificationWithVSCodeTemplate()
+                .VerifyExampleVSCodeInAppNotificationShown()
+                .DismissExampleVSCodeInAppNotification()
+                .VerifyExampleVSCodeInAppNotificationHidden();
+        }
+    }
+}

--- a/src/Legerity.WCT/InAppNotification.cs
+++ b/src/Legerity.WCT/InAppNotification.cs
@@ -1,0 +1,76 @@
+namespace Legerity.Windows.Elements.WCT
+{
+    using System.Linq;
+    using Core;
+    using Extensions;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the Windows Community Toolkit InAppNotification control.
+    /// </summary>
+    public class InAppNotification : WindowsElementWrapper
+    {
+        private readonly By dismissButtonQuery = ByExtensions.AutomationId("PART_DismissButton");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InAppNotification"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public InAppNotification(WindowsElement element) : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the dismiss button.
+        /// </summary>
+        public virtual Button DismissButton => this.Element.FindElement(this.dismissButtonQuery);
+
+        /// <summary>
+        /// Gets the message displayed.
+        /// <para>
+        /// Note, this only works if the Content is based on a <see cref="string"/> or if the ContentTemplate includes a TextBlock element with the message.
+        /// </para>
+        /// </summary>
+        public string Message => this.Element.FindElementsByClassName("TextBlock").FirstOrDefault()?.Text;
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InAppNotification"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="InAppNotification"/>.
+        /// </returns>
+        public static implicit operator InAppNotification(WindowsElement element)
+        {
+            return new InAppNotification(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="InAppNotification"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="InAppNotification"/>.
+        /// </returns>
+        public static implicit operator InAppNotification(AppiumWebElement element)
+        {
+            return new InAppNotification(element as WindowsElement);
+        }
+
+        /// <summary>
+        /// Dismissed the in-app notification.
+        /// </summary>
+        public virtual void Dismiss()
+        {
+            this.DismissButton.Click();
+        }
+    }
+}

--- a/src/Legerity/Exceptions/ElementNotShownException.cs
+++ b/src/Legerity/Exceptions/ElementNotShownException.cs
@@ -11,8 +11,8 @@ namespace Legerity.Exceptions
         /// <param name="elementName">
         /// The name of the element that was not shown.
         /// </param>
-        internal ElementNotShownException(string elementName)
-            : base($"Unable to verify '{elementName}' exists")
+        public ElementNotShownException(string elementName)
+            : base($"'{elementName}' is not shown when it should")
         {
             this.ElementName = elementName;
         }

--- a/src/Legerity/Exceptions/ElementShownException.cs
+++ b/src/Legerity/Exceptions/ElementShownException.cs
@@ -1,0 +1,25 @@
+namespace Legerity.Exceptions
+{
+    /// <summary>
+    /// Defines an exception for when an element is shown when it shouldn't be.
+    /// </summary>
+    public class ElementShownException : LegerityException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElementShownException"/> class.
+        /// </summary>
+        /// <param name="elementName">
+        /// The name of the element that was shown.
+        /// </param>
+        public ElementShownException(string elementName)
+            : base($"'{elementName}' is shown when it shouldn't")
+        {
+            this.ElementName = elementName;
+        }
+
+        /// <summary>
+        /// Gets the name of the element that was shown.
+        /// </summary>
+        public string ElementName { get; }
+    }
+}

--- a/src/Legerity/Pages/BasePage.cs
+++ b/src/Legerity/Pages/BasePage.cs
@@ -1,12 +1,9 @@
 namespace Legerity.Pages
 {
     using System;
-
-    using Legerity.Android;
     using Legerity.Exceptions;
 
     using OpenQA.Selenium;
-    using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Android;
     using OpenQA.Selenium.Appium.iOS;
     using OpenQA.Selenium.Appium.Windows;
@@ -79,15 +76,80 @@ namespace Legerity.Pages
             {
                 if (this.WebApp != null)
                 {
-                    this.AttemptWaitForDriverElement(this.WebApp, timeout.Value);
+                    AttemptWaitForDriverElement(this.Trait, timeout.Value, this.WebApp);
                 }
             }
         }
 
-        private void AttemptWaitForDriverElement(IWebDriver appDriver, TimeSpan timeout)
+        /// <summary>
+        /// Determines whether the given element is shown.
+        /// </summary>
+        /// <param name="by">
+        /// The query for the element to find.
+        /// </param>
+        public void VerifyElementShown(By by)
+        {
+            this.VerifyElementShown(by, null);
+        }
+
+        /// <summary>
+        /// Determines whether the given element is shown with the specified timeout.
+        /// </summary>
+        /// <param name="by">
+        /// The query for the element to find.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time the driver should wait when searching for the <paramref name="by"/> element if it is not immediately present.
+        /// </param>
+        public void VerifyElementShown(By by, TimeSpan? timeout)
+        {
+            if (this.WebApp == null)
+            {
+                throw new DriverNotInitializedException(
+                    $"An app driver has not been initialized. Call 'AppManager.StartApp()' with an instance of an {nameof(AppManagerOptions)} to setup for testing.");
+            }
+
+            if (timeout == null)
+            {
+                if (this.WebApp != null && this.WebApp.FindElement(by) == null)
+                {
+                    throw new ElementNotShownException(by.ToString());
+                }
+            }
+            else
+            {
+                if (this.WebApp != null)
+                {
+                    AttemptWaitForDriverElement(by, timeout.Value, this.WebApp);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the given element is not shown.
+        /// </summary>
+        /// <param name="by">
+        /// The query for the element to locate.
+        /// </param>
+        public void VerifyElementNotShown(By by)
+        {
+            if (this.WebApp == null)
+            {
+                throw new DriverNotInitializedException(
+                    $"An app driver has not been initialized. Call 'AppManager.StartApp()' with an instance of an {nameof(AppManagerOptions)} to setup for testing.");
+            }
+
+            if (this.WebApp != null && this.WebApp.FindElement(by) == null)
+            {
+                throw new ElementNotShownException(by.ToString());
+            }
+
+        }
+
+        private static void AttemptWaitForDriverElement(By by, TimeSpan timeout, IWebDriver appDriver)
         {
             var wait = new WebDriverWait(appDriver, timeout);
-            wait.Until(driver => driver.FindElement(this.Trait) != null);
+            wait.Until(driver => driver.FindElement(by) != null);
         }
     }
 }


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

This next addition for the WCT suite of control elements is for the `InAppNotification` control providing support for dismissing and overriding customizations for custom template scenarios.

Tests have been added against the WCT sample application for this element including the custom VS code template in-app notification.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

Resolves #25 
