### PR TITLE
Added support for WCT Expander

### DIFF
--- a/samples/WindowsCommunityToolkitSampleApp/BaseTestClass.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/BaseTestClass.cs
@@ -6,11 +6,17 @@ namespace WindowsCommunityToolkitSampleApp
 
     public abstract class BaseTestClass
     {
+        // The sample application ID if the WCT sample app is built through Visual Studio.
+        private const string DebugSampleApp = "52b9212c-97a9-4639-9426-3e1ea9c1569e_vpw621za47p9m!App";
+
+        // The sample application ID if the WCT sample app is installed from the Windows Store.
+        private const string StoreSampleApp = "Microsoft.UWPCommunityToolkitSampleApp_8wekyb3d8bbwe!App";
+
         [TestInitialize]
         public virtual void Initialize()
         {
             AppManager.StartApp(
-                new WindowsAppManagerOptions("Microsoft.UWPCommunityToolkitSampleApp_8wekyb3d8bbwe!App")
+                new WindowsAppManagerOptions(DebugSampleApp)
                 {
                     DriverUri = "http://127.0.0.1:4723"
                 });

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/ExpanderPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/ExpanderPage.cs
@@ -1,0 +1,105 @@
+namespace WindowsCommunityToolkitSampleApp.Pages
+{
+    using Legerity.Windows.Elements.WCT;
+    using Legerity.Windows.Extensions;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the Expander page of the Windows Community Toolkit sample application.
+    /// </summary>
+    public class ExpanderPage : AppPage
+    {
+        private readonly By verticalExpanderQuery;
+        private readonly By horizontalExpanderQuery;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpanderPage"/> class.
+        /// </summary>
+        public ExpanderPage()
+        {
+            this.verticalExpanderQuery = ByExtensions.AutomationId("Expander1");
+            this.horizontalExpanderQuery = ByExtensions.AutomationId("Expander2");
+        }
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@ClassName='TextBlock'][@Name='Expander']");
+
+        /// <summary>
+        /// Toggles the expander content.
+        /// </summary>
+        /// <param name="expanded">
+        /// A value indicating whether to toggle expanded.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ExpanderPage"/>.
+        /// </returns>
+        public ExpanderPage ToggleVerticalExpander(bool expanded)
+        {
+            Expander expander = this.WindowsApp.FindElement(this.verticalExpanderQuery);
+
+            if (expanded)
+            {
+                expander.Expand();
+            }
+            else
+            {
+                expander.Collapse();
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Toggles the expander content.
+        /// </summary>
+        /// <param name="expanded">
+        /// A value indicating whether to toggle expanded.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ExpanderPage"/>.
+        /// </returns>
+        public ExpanderPage ToggleHorizontalExpander(bool expanded)
+        {
+            Expander expander = this.WindowsApp.FindElement(this.horizontalExpanderQuery);
+
+            if (expanded)
+            {
+                expander.Expand();
+            }
+            else
+            {
+                expander.Collapse();
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Verifies that the expanded state has been updated.
+        /// </summary>
+        /// <param name="expanded">
+        /// A value indicating whether the expander should be expanded.
+        /// </param>
+        public void VerifyVerticalExpanderState(bool expanded)
+        {
+            Expander expander = this.WindowsApp.FindElement(this.verticalExpanderQuery);
+            Assert.AreEqual(expanded, expander.IsExpanded);
+        }
+
+        /// <summary>
+        /// Verifies that the expanded state has been updated.
+        /// </summary>
+        /// <param name="expanded">
+        /// A value indicating whether the expander should be expanded.
+        /// </param>
+        public void VerifyHorizontalExpanderState(bool expanded)
+        {
+            Expander expander = this.WindowsApp.FindElement(this.horizontalExpanderQuery);
+            Assert.AreEqual(expanded, expander.IsExpanded);
+        }
+
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Tests/ExpanderTests.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Tests/ExpanderTests.cs
@@ -1,0 +1,71 @@
+namespace WindowsCommunityToolkitSampleApp.Tests
+{
+    using WindowsCommunityToolkitSampleApp;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Pages;
+
+    [TestClass]
+    public class ExpanderTests : BaseTestClass
+    {
+        private static ExpanderPage ExpanderPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            ExpanderPage = new AppPage().SelectSample<ExpanderPage>("Expander");
+        }
+
+        [TestMethod]
+        public void SetVerticalExpanderExpanded()
+        {
+            // Arrange
+            const bool expectedState = true;
+
+            // Act
+            ExpanderPage.ToggleVerticalExpander(expectedState);
+
+            // Assert
+            ExpanderPage.VerifyVerticalExpanderState(expectedState);
+        }
+
+        [TestMethod]
+        public void SetVerticalExpanderCollapsed()
+        {
+            // Arrange
+            const bool expectedState = false;
+
+            // Act
+            ExpanderPage.ToggleVerticalExpander(expectedState);
+
+            // Assert
+            ExpanderPage.VerifyVerticalExpanderState(expectedState);
+        }
+
+        [TestMethod]
+        public void SetHorizontalExpanderExpanded()
+        {
+            // Arrange
+            const bool expectedState = true;
+
+            // Act
+            ExpanderPage.ToggleHorizontalExpander(expectedState);
+
+            // Assert
+            ExpanderPage.VerifyHorizontalExpanderState(expectedState);
+        }
+
+        [TestMethod]
+        public void SetHorizontalExpanderCollapsed()
+        {
+            // Arrange
+            const bool expectedState = false;
+
+            // Act
+            ExpanderPage.ToggleHorizontalExpander(expectedState);
+
+            // Assert
+            ExpanderPage.VerifyHorizontalExpanderState(expectedState);
+        }
+    }
+}

--- a/src/Legerity.WCT/Expander.cs
+++ b/src/Legerity.WCT/Expander.cs
@@ -1,0 +1,89 @@
+namespace Legerity.Windows.Elements.WCT
+{
+    using Core;
+    using Extensions;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the Windows Community Toolkit Expander control.
+    /// </summary>
+    public class Expander : WindowsElementWrapper
+    {
+        private const string ToggleOnValue = "1";
+
+        private readonly By toggleButtonQuery = ByExtensions.AutomationId("PART_ExpanderToggleButton");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Expander"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public Expander(WindowsElement element) : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the expander has the content expanded (visible).
+        /// </summary>
+        public bool IsExpanded => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
+
+        private ToggleButton ToggleButton => this.Element.FindElement(this.toggleButtonQuery);
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Expander"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Expander"/>.
+        /// </returns>
+        public static implicit operator Expander(WindowsElement element)
+        {
+            return new Expander(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="Expander"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Expander"/>.
+        /// </returns>
+        public static implicit operator Expander(AppiumWebElement element)
+        {
+            return new Expander(element as WindowsElement);
+        }
+
+        /// <summary>
+        /// Expands the content of the expander.
+        /// </summary>
+        public void Expand()
+        {
+            if (this.IsExpanded)
+            {
+                return;
+            }
+
+            this.ToggleButton.Click();
+        }
+
+        /// <summary>
+        /// Collapses the content of the expander.
+        /// </summary>
+        public void Collapse()
+        {
+            if (!this.IsExpanded)
+            {
+                return;
+            }
+
+            this.ToggleButton.Click();
+        }
+    }
+}


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

This next addition for the WCT suite of control elements is for the `Expander` control providing support for expanding and collapsing content.

Tests have been added against the WCT sample application for this element.

This change has been made based on [fix #3504 in the Windows Community Toolkit repo](https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3504) which is still in an open state. This PR should not be merged until that is completed.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

Resolves #21 