### PR TITLE
Added support for WinUI MenuBar element

### DIFF
--- a/docs/Windows/WindowsControlWrappers.md
+++ b/docs/Windows/WindowsControlWrappers.md
@@ -28,6 +28,8 @@ These UWP control wrappers are designed to be used with applications built with 
 - [HyperlinkButton](../../src/Legerity/Windows/Elements/Core/HyperlinkButton.cs)
 - [InkToolbar](../../src/Legerity/Windows/Elements/Core/InkToolbar.cs)
 - [ListView](../../src/Legerity/Windows/Elements/Core/ListView.cs)
+- [MenuFlyoutItem](../../src/Legerity/Windows/Elements/Core/MenuFlyoutItem.cs)
+- [MenuFlyoutSubItem](../../src/Legerity/Windows/Elements/Core/MenuFlyoutSubItem.cs)
 - [PasswordBox](../../src/Legerity/Windows/Elements/Core/PasswordBox.cs)
 - [Pivot](../../src/Legerity/Windows/Elements/Core/Pivot.cs)
 - [ProgressBar](../../src/Legerity/Windows/Elements/Core/ProgressBar.cs)
@@ -43,7 +45,11 @@ These UWP control wrappers are designed to be used with applications built with 
 
 These UWP control wrappers are designed to be used with controls from the [WinUI](https://github.com/microsoft/microsoft-ui-xaml) suite.
 
+- [MenuBar](../../src/Legerity.WinUI/MenuBar.cs)
+- [MenuBarItem](../../src/Legerity.WinUI/MenuBarItem.cs)
 - [NavigationView](../../src/Legerity.WinUI/NavigationView.cs)
+- [NavigationViewItem](../../src/Legerity.WinUI/NavigationViewItem.cs)
+- [NumberBox](../../src/Legerity.WinUI/NumberBox.cs)
 - [TabView](../../src/Legerity.WinUI/TabView.cs)
 
 ## Windows Community Toolkit Controls

--- a/samples/XamlControlsGallery/BaseTestClass.cs
+++ b/samples/XamlControlsGallery/BaseTestClass.cs
@@ -7,11 +7,17 @@ namespace XamlControlsGallery
 
     public abstract class BaseTestClass
     {
+        // The sample application ID if the XamlControlsGallery sample app is built through Visual Studio.
+        private const string DebugSampleApp = "Microsoft.XAMLControlsGallery.Debug_8wekyb3d8bbwe!App";
+
+        // The sample application ID if the XamlControlsGallery sample app is installed from the Windows Store.
+        private const string StoreSampleApp = "Microsoft.XAMLControlsGallery_8wekyb3d8bbwe!App";
+
         [TestInitialize]
         public virtual void Initialize()
         {
             AppManager.StartApp(
-                new WindowsAppManagerOptions("Microsoft.XAMLControlsGallery_8wekyb3d8bbwe!App")
+                new WindowsAppManagerOptions(DebugSampleApp)
                 {
                     DriverUri = "http://127.0.0.1:4723"
                 });

--- a/samples/XamlControlsGallery/Pages/MenusAndToolbars/MenuBarPage.cs
+++ b/samples/XamlControlsGallery/Pages/MenusAndToolbars/MenuBarPage.cs
@@ -1,0 +1,57 @@
+namespace XamlControlsGallery.Pages.MenusAndToolbars
+{
+    using System.Linq;
+    using Legerity;
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Elements.WinUI;
+    using Legerity.Windows.Extensions;
+
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines the MenuBar page of the XAML Controls Gallery application.
+    /// </summary>
+    public class MenuBarPage : BasePage
+    {
+        public MenuBar SimpleMenuBar => this.WindowsApp.FindElement(ByExtensions.AutomationId("Example1"));
+
+        public MenuBar MenuBarWithSubMenus => this.WindowsApp.FindElement(ByExtensions.AutomationId("Example3"));
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@Name='MenuBar'][@AutomationId='TitleTextBlock']");
+
+        public MenuBarPage SelectSimpleMenuBarOption(string name, string child = null)
+        {
+            MenuBarItem option = this.SimpleMenuBar.ClickOption(name);
+            if (!string.IsNullOrWhiteSpace(child))
+            {
+                option.ClickChildOption(child);
+            }
+            return this;
+        }
+
+        public MenuBarPage SelectMenuBarWithSubMenusOption(string name, string child = null, string subChild = null)
+        {
+            MenuBarItem option = this.MenuBarWithSubMenus.ClickOption(name);
+            if (string.IsNullOrWhiteSpace(child))
+            {
+                return this;
+            }
+
+            if (string.IsNullOrWhiteSpace(subChild))
+            {
+                option.ClickChildOption(child);
+            }
+            else
+            {
+                MenuFlyoutSubItem childSubItem = option.ClickChildSubOption(child);
+                childSubItem.ClickChildOption(subChild);
+            }
+
+            return this;
+        }
+    }
+}

--- a/samples/XamlControlsGallery/Pages/NavigationMenu.cs
+++ b/samples/XamlControlsGallery/Pages/NavigationMenu.cs
@@ -139,6 +139,12 @@ namespace XamlControlsGallery.Pages
             return new InkToolbarPage();
         }
 
+        public MenuBarPage GoToMenuBarPage()
+        {
+            this.SearchForControl("MenuBar");
+            return new MenuBarPage();
+        }
+
         /// <summary>
         /// Navigates to the number box control page.
         /// </summary>

--- a/samples/XamlControlsGallery/Tests/MenusAndToolbars/MenuBarTests.cs
+++ b/samples/XamlControlsGallery/Tests/MenusAndToolbars/MenuBarTests.cs
@@ -1,0 +1,48 @@
+namespace XamlControlsGallery.Tests.BasicInput
+{
+    using System.Linq;
+    using Legerity;
+    using Legerity.Windows.Elements.WinUI;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium;
+    using XamlControlsGallery.Pages;
+    using XamlControlsGallery.Pages.BasicInput;
+    using XamlControlsGallery.Pages.MenusAndToolbars;
+
+    [TestClass]
+    public class MenuBarTests : BaseTestClass
+    {
+        private static MenuBarPage MenuBarPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            MenuBarPage = new NavigationMenu().GoToMenuBarPage();
+        }
+
+        [TestMethod]
+        public void ClickSimpleFileNewButton()
+        {
+            MenuBarPage.SelectSimpleMenuBarOption("File", "New");
+        }
+
+        [TestMethod]
+        public void ClickSimpleEditCopyButton()
+        {
+            MenuBarPage.SelectSimpleMenuBarOption("Edit", "Copy");
+        }
+
+        [TestMethod]
+        public void ClickSimpleHelpAboutButton()
+        {
+            MenuBarPage.SelectSimpleMenuBarOption("Help", "About");
+        }
+
+        [TestMethod]
+        public void ClickSubMenusFileNewPlainTextDocumentButton()
+        {
+            MenuBarPage.SelectMenuBarWithSubMenusOption("File", "New", "Plain Text Document");
+        }
+    }
+}

--- a/src/Legerity.WinUI/MenuBar.cs
+++ b/src/Legerity.WinUI/MenuBar.cs
@@ -1,0 +1,83 @@
+namespace Legerity.Windows.Elements.WinUI
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Core;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the WinUI UWP MenuBar control.
+    /// </summary>
+    public class MenuBar : WindowsElementWrapper
+    {
+        private readonly By menuBarItemsQuery = By.ClassName("Microsoft.UI.Xaml.Controls.MenuBarItem");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuBar"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public MenuBar(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the UI components associated with the menu items.
+        /// </summary>
+        public IEnumerable<MenuBarItem> MenuItems =>
+            this.Element.FindElements(this.menuBarItemsQuery)
+                .Select(element => new MenuBarItem(this, element as WindowsElement));
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="MenuBar"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="MenuBar"/>.
+        /// </returns>
+        public static implicit operator MenuBar(WindowsElement element)
+        {
+            return new MenuBar(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="MenuBar"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="MenuBar"/>.
+        /// </returns>
+        public static implicit operator MenuBar(AppiumWebElement element)
+        {
+            return new MenuBar(element as WindowsElement);
+        }
+
+
+        /// <summary>
+        /// Clicks on a child menu option with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="MenuBarItem"/>.
+        /// </returns>
+        public MenuBarItem ClickOption(string name)
+        {
+            MenuBarItem item = this.MenuItems.FirstOrDefault(
+                element => element.Element.GetAttribute("Name")
+                    .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+    }
+}

--- a/src/Legerity.WinUI/MenuBarItem.cs
+++ b/src/Legerity.WinUI/MenuBarItem.cs
@@ -1,0 +1,122 @@
+namespace Legerity.Windows.Elements.WinUI
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Core;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the WinUI MenuBarItem control.
+    /// </summary>
+    public class MenuBarItem : WindowsElementWrapper
+    {
+        private readonly By menuFlyoutItemQuery = By.ClassName("MenuFlyoutItem");
+
+        private readonly By menuFlyoutSubItemQuery = By.ClassName("MenuFlyoutSubItem");
+
+        private readonly WeakReference parentMenuBarReference;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuBarItem"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public MenuBarItem(WindowsElement element)
+            : this(null, element)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuBarItem"/> class.
+        /// </summary>
+        /// <param name="parentMenuBar">
+        /// The parent <see cref="MenuBar"/>.
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public MenuBarItem(
+            MenuBar parentMenuBar,
+            WindowsElement element)
+            : base(element)
+        {
+            if (parentMenuBar != null)
+            {
+                this.parentMenuBarReference = new WeakReference(parentMenuBar);
+            }
+        }
+
+        /// <summary>Gets the original parent <see cref="MenuBar"/> reference object.</summary>
+        public MenuBar ParentMenuBar =>
+            this.parentMenuBarReference != null && this.parentMenuBarReference.IsAlive
+                ? this.parentMenuBarReference.Target as MenuBar
+                : null;
+
+        /// <summary>
+        /// Gets the UI components associated with the child menu items.
+        /// </summary>
+        public IEnumerable<MenuFlyoutItem> ChildMenuItems => this.GetChildMenuItems();
+
+        /// <summary>
+        /// Gets the UI components associated with the child menu sub-items.
+        /// </summary>
+        public IEnumerable<MenuFlyoutSubItem> ChildMenuSubItems => this.GetChildMenuSubItems();
+
+        /// <summary>
+        /// Clicks the item.
+        /// </summary>
+        public void Click()
+        {
+            this.Element.Click();
+        }
+
+        /// <summary>
+        /// Clicks on a child menu option with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="MenuFlyoutItem"/>.
+        /// </returns>
+        public MenuFlyoutItem ClickChildOption(string name)
+        {
+            MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
+                element => element.Element.GetAttribute("Name")
+                    .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
+        /// Clicks on a child menu sub option with the specified item name.
+        /// </summary>
+        /// <param name="name">The name of the sub-item to click.</param>
+        /// <returns>The clicked <see cref="MenuFlyoutSubItem"/>.</returns>
+        public MenuFlyoutSubItem ClickChildSubOption(string name)
+        {
+            MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
+                element => element.Element.GetAttribute("Name")
+                    .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        private IEnumerable<MenuFlyoutItem> GetChildMenuItems()
+        {
+            return this.Driver.FindElement(By.ClassName("MenuFlyout"))
+                .FindElements(this.menuFlyoutItemQuery).Select(
+                    element => new MenuFlyoutItem(element as WindowsElement));
+        }
+
+        private IEnumerable<MenuFlyoutSubItem> GetChildMenuSubItems()
+        {
+            return this.Driver.FindElement(By.ClassName("MenuFlyout"))
+                .FindElements(this.menuFlyoutSubItemQuery).Select(
+                    element => new MenuFlyoutSubItem(element as WindowsElement));
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/MenuFlyoutItem.cs
+++ b/src/Legerity/Windows/Elements/Core/MenuFlyoutItem.cs
@@ -1,0 +1,29 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the UWP MenuFlyoutItem control.
+    /// </summary>
+    public class MenuFlyoutItem : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuFlyoutItem"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public MenuFlyoutItem(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Clicks the item.
+        /// </summary>
+        public void Click()
+        {
+            this.Element.Click();
+        }
+    }
+}

--- a/src/Legerity/Windows/Elements/Core/MenuFlyoutSubItem.cs
+++ b/src/Legerity/Windows/Elements/Core/MenuFlyoutSubItem.cs
@@ -1,0 +1,94 @@
+namespace Legerity.Windows.Elements.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the UWP MenuFlyoutSubItem control.
+    /// </summary>
+    public class MenuFlyoutSubItem : WindowsElementWrapper
+    {
+        private readonly By menuFlyoutItemQuery = By.ClassName("MenuFlyoutItem");
+
+        private readonly By menuFlyoutSubItemQuery = By.ClassName("MenuFlyoutSubItem");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MenuFlyoutSubItem"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public MenuFlyoutSubItem(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the UI components associated with the child menu items.
+        /// </summary>
+        public IEnumerable<MenuFlyoutItem> ChildMenuItems => this.GetChildMenuItems();
+
+        /// <summary>
+        /// Gets the UI components associated with the child menu sub-items.
+        /// </summary>
+        public IEnumerable<MenuFlyoutSubItem> ChildMenuSubItems => this.GetChildMenuSubItems();
+
+        /// <summary>
+        /// Clicks the item.
+        /// </summary>
+        public void Click()
+        {
+            this.Element.Click();
+        }
+
+        /// <summary>
+        /// Clicks on a child menu option with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="MenuFlyoutItem"/>.
+        /// </returns>
+        public MenuFlyoutItem ClickChildOption(string name)
+        {
+            MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
+                element => element.Element.GetAttribute("Name")
+                    .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
+        /// Clicks on a child menu sub option with the specified item name.
+        /// </summary>
+        /// <param name="name">The name of the sub-item to click.</param>
+        /// <returns>The clicked <see cref="MenuFlyoutSubItem"/>.</returns>
+        public MenuFlyoutSubItem ClickChildSubOption(string name)
+        {
+            MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
+                element => element.Element.GetAttribute("Name")
+                    .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        private IEnumerable<MenuFlyoutItem> GetChildMenuItems()
+        {
+            return this.Driver.FindElement(By.ClassName("MenuFlyout"))
+                .FindElements(this.menuFlyoutItemQuery).Select(
+                    element => new MenuFlyoutItem(element as WindowsElement));
+        }
+
+        private IEnumerable<MenuFlyoutSubItem> GetChildMenuSubItems()
+        {
+            return this.Driver.FindElement(By.ClassName("MenuFlyout"))
+                .FindElements(this.menuFlyoutSubItemQuery).Select(
+                    element => new MenuFlyoutSubItem(element as WindowsElement));
+        }
+    }
+}


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

Changes have been made to implement a Windows element wrapper for the WinUI `MenuBar` control. This provides the capability to select a top-level menu item, child flyout items, child flyout sub-items, and their child items also.

Tests have been added against the Xaml Controls Gallery sample application for this element based on changes made in [PR 571](https://github.com/microsoft/Xaml-Controls-Gallery/pull/571).

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

Resolves #6 
