### PR TITLE
Added web Input file element

### DIFF
--- a/docs/Web/WebControlWrappers.md
+++ b/docs/Web/WebControlWrappers.md
@@ -10,6 +10,7 @@ These Web control wrappers are designed to be used with applications built with 
 
 - [Button](../../src/Legerity/Web/Elements/Core/Button.cs)
 - [CheckBox](../../src/Legerity/Web/Elements/Core/CheckBox.cs)
+- [FileInput](../../src/Legerity/Web/Elements/Core/FileInput.cs)
 - [List](../../src/Legerity/Web/Elements/Core/List.cs)
 - [NumberInput](../../src/Legerity/Web/Elements/Core/NumberInput.cs)
 - [RadioButton](../../src/Legerity/Web/Elements/Core/RadioButton.cs)

--- a/samples/W3SchoolsWebTests/Tests/FileInputTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/FileInputTests.cs
@@ -1,0 +1,43 @@
+namespace W3SchoolsWebTests.Tests
+{
+    using System;
+    using System.IO;
+    using Legerity;
+    using Legerity.Web.Elements.Core;
+    using NUnit.Framework;
+    using OpenQA.Selenium.Remote;
+    using Shouldly;
+    using W3SchoolsWebTests;
+
+    [TestFixture]
+    public class FileInputTests : BaseTestClass
+    {
+        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_file";
+
+        [Test]
+        public void ShouldSetAbsoluteFilePath()
+        {
+            string filePath = Path.Combine(Environment.CurrentDirectory, @"Tools\Edge\MicrosoftWebDriver.exe");
+
+            FileInput fileInput = AppManager.WebApp.FindElementById("myfile") as RemoteWebElement;
+            fileInput.SetAbsoluteFilePath(filePath);
+
+            // Cannot check absolute file path as browser security feature prevents seeing full URI.
+            fileInput.FilePath.ShouldContain("MicrosoftWebDriver.exe");
+        }
+
+        [Test]
+        public void ShouldClearFile()
+        {
+            string filePath = Path.Combine(Environment.CurrentDirectory, @"Tools\Edge\MicrosoftWebDriver.exe");
+
+            FileInput fileInput = AppManager.WebApp.FindElementById("myfile") as RemoteWebElement;
+            fileInput.SetAbsoluteFilePath(filePath);
+
+            fileInput.ClearFile();
+
+            // Cannot check absolute file path as browser security feature prevents seeing full URI.
+            fileInput.FilePath.ShouldBe(string.Empty);
+        }
+    }
+}

--- a/src/Legerity/Web/Elements/Core/FileInput.cs
+++ b/src/Legerity/Web/Elements/Core/FileInput.cs
@@ -1,0 +1,71 @@
+namespace Legerity.Web.Elements.Core
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+    using Web.Elements;
+
+    /// <summary>
+    /// Defines a <see cref="IWebElement"/> wrapper for the core web Input file control.
+    /// </summary>
+    public class FileInput : WebElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileInput"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public FileInput(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileInput"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
+        public FileInput(RemoteWebElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the file path for the selected file.
+        /// </summary>
+        public string FilePath => this.Element.GetAttribute("value");
+
+        /// <summary>
+        /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="FileInput"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="FileInput"/>.
+        /// </returns>
+        public static implicit operator FileInput(RemoteWebElement element)
+        {
+            return new FileInput(element);
+        }
+
+        /// <summary>
+        /// Sets the selected file by an absolute file path.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        public void SetAbsoluteFilePath(string filePath)
+        {
+            this.ClearFile();
+            this.Element.SendKeys(filePath);
+        }
+
+        /// <summary>
+        /// Clears the selected file.
+        /// </summary>
+        public void ClearFile()
+        {
+            this.Element.Clear();
+        }
+    }
+}


### PR DESCRIPTION
## Fixes #59
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to add a new core Web `FileInput` element which allows a file path to be set and cleared, as well as exposing the file path value. 

Tests have been added using W3Schools examples.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->