### PR TITLE
Added web Image element

### DIFF
--- a/docs/Web/WebControlWrappers.md
+++ b/docs/Web/WebControlWrappers.md
@@ -10,6 +10,7 @@ These Web control wrappers are designed to be used with applications built with 
 
 - [Button](../../src/Legerity/Web/Elements/Core/Button.cs)
 - [CheckBox](../../src/Legerity/Web/Elements/Core/CheckBox.cs)
+- [Image](../../src/Legerity/Web/Elements/Core/Image.cs)
 - [List](../../src/Legerity/Web/Elements/Core/List.cs)
 - [NumberInput](../../src/Legerity/Web/Elements/Core/NumberInput.cs)
 - [RadioButton](../../src/Legerity/Web/Elements/Core/RadioButton.cs)

--- a/samples/W3SchoolsWebTests/Tests/ImageTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/ImageTests.cs
@@ -1,0 +1,37 @@
+namespace W3SchoolsWebTests.Tests
+{
+    using Legerity;
+    using Legerity.Web.Elements.Core;
+    using NUnit.Framework;
+    using OpenQA.Selenium.Remote;
+    using Shouldly;
+    using W3SchoolsWebTests;
+
+    [TestFixture]
+    public class ImageTests : BaseTestClass
+    {
+        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_image_test";
+
+        [Test]
+        public void ShouldGetImageSource()
+        {
+            Image image = AppManager.WebApp.FindElementByTagName("img") as RemoteWebElement;
+            image.Source.ShouldContain("img_girl.jpg");
+        }
+
+        [Test]
+        public void ShouldGetAltText()
+        {
+            Image image = AppManager.WebApp.FindElementByTagName("img") as RemoteWebElement;
+            image.AltText.ShouldBe("Girl in a jacket");
+        }
+
+        [Test]
+        public void ShouldGetSize()
+        {
+            Image image = AppManager.WebApp.FindElementByTagName("img") as RemoteWebElement;
+            image.Width.ShouldBe(500);
+            image.Height.ShouldBe(600);
+        }
+    }
+}

--- a/src/Legerity/Web/Elements/Core/Image.cs
+++ b/src/Legerity/Web/Elements/Core/Image.cs
@@ -1,0 +1,68 @@
+namespace Legerity.Web.Elements.Core
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+    using Web.Elements;
+
+    /// <summary>
+    /// Defines a <see cref="IWebElement"/> wrapper for the core web Image control.
+    /// </summary>
+    public class Image : WebElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Image"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public Image(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Image"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
+        public Image(RemoteWebElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the source URI of the image.
+        /// </summary>
+        public string Source => this.Element.GetAttribute("src");
+
+        /// <summary>
+        /// Gets the alt text of the image.
+        /// </summary>
+        public string AltText => this.Element.GetAttribute("alt");
+
+        /// <summary>
+        /// Gets the width of the image.
+        /// </summary>
+        public double Width => double.Parse(this.Element.GetAttribute("width"));
+
+        /// <summary>
+        /// Gets the height of the image.
+        /// </summary>
+        public double Height => double.Parse(this.Element.GetAttribute("height"));
+
+        /// <summary>
+        /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Image"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Image"/>.
+        /// </returns>
+        public static implicit operator Image(RemoteWebElement element)
+        {
+            return new Image(element);
+        }
+    }
+}


### PR DESCRIPTION
## Fixes #60 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to add a core web Image element that provides the capabilities of getting the image source, alt text, and the size of the image.

Tests have been added based on the W3Schools example.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->