### PR TITLE
Added web Select and Option elements

### DIFF
--- a/docs/Web/WebControlWrappers.md
+++ b/docs/Web/WebControlWrappers.md
@@ -12,6 +12,8 @@ These Web control wrappers are designed to be used with applications built with 
 - [CheckBox](../../src/Legerity/Web/Elements/Core/CheckBox.cs)
 - [List](../../src/Legerity/Web/Elements/Core/List.cs)
 - [NumberInput](../../src/Legerity/Web/Elements/Core/NumberInput.cs)
+- [Option](../../src/Legerity/Web/Elements/Core/Option.cs)
 - [RadioButton](../../src/Legerity/Web/Elements/Core/RadioButton.cs)
 - [RangeInput](../../src/Legerity/Web/Elements/Core/RangeInput.cs)
+- [Select](../../src/Legerity/Web/Elements/Core/Select.cs)
 - [TextInput](../../src/Legerity/Web/Elements/Core/TextInput.cs)

--- a/samples/W3SchoolsWebTests/Tests/SelectTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/SelectTests.cs
@@ -1,0 +1,62 @@
+namespace W3SchoolsWebTests.Tests
+{
+    using System.Linq;
+    using Legerity;
+    using Legerity.Web.Elements.Core;
+    using NUnit.Framework;
+    using OpenQA.Selenium.Remote;
+    using Shouldly;
+    using W3SchoolsWebTests;
+
+    [TestFixture]
+    public class SelectTests : BaseTestClass
+    {
+        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select";
+
+        [Test]
+        public void ShouldGetItems()
+        {
+            Select carsSelect = AppManager.WebApp.FindElementById("cars") as RemoteWebElement;
+            carsSelect.Options.Count().ShouldBe(4);
+
+            var itemValues = carsSelect.Options.Select(e => e.Value).ToList();
+            itemValues.ShouldContain("volvo");
+            itemValues.ShouldContain("saab");
+            itemValues.ShouldContain("opel");
+            itemValues.ShouldContain("audi");
+        }
+
+        [Test]
+        public void ShouldGetIsMultiple()
+        {
+            Select carsSelect = AppManager.WebApp.FindElementById("cars") as RemoteWebElement;
+            carsSelect.IsMultiple.ShouldBe(false);
+        }
+
+        [TestCase("volvo")]
+        [TestCase("saab")]
+        [TestCase("opel")]
+        [TestCase("audi")]
+        public void ShouldSelectOptionByValue(string value)
+        {
+            Select carsSelect = AppManager.WebApp.FindElementById("cars") as RemoteWebElement;
+            carsSelect.SelectOptionByValue(value);
+
+            Option selectedOption = carsSelect.SelectedOption;
+            selectedOption.Value.ShouldBe(value);
+        }
+
+        [TestCase("Volvo")]
+        [TestCase("Saab")]
+        [TestCase("Opel")]
+        [TestCase("Audi")]
+        public void ShouldSelectOptionByDisplayValue(string value)
+        {
+            Select carsSelect = AppManager.WebApp.FindElementById("cars") as RemoteWebElement;
+            carsSelect.SelectOptionByDisplayValue(value);
+
+            Option selectedOption = carsSelect.SelectedOption;
+            selectedOption.DisplayValue.ShouldBe(value);
+        }
+    }
+}

--- a/src/Legerity/Web/Elements/Core/Option.cs
+++ b/src/Legerity/Web/Elements/Core/Option.cs
@@ -1,0 +1,71 @@
+namespace Legerity.Web.Elements.Core
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+    using Web.Elements;
+
+    /// <summary>
+    /// Defines a <see cref="IWebElement"/> wrapper for the core web Option control.
+    /// </summary>
+    public class Option : WebElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Option"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public Option(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Option"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
+        public Option(RemoteWebElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the value of the option.
+        /// </summary>
+        public string Value => this.Element.GetAttribute("value");
+
+        /// <summary>
+        /// Gets the display value of the option.
+        /// </summary>
+        public string DisplayValue => this.Element.Text;
+
+        /// <summary>
+        /// Gets a value indicating whether the option is selected.
+        /// </summary>
+        public bool IsSelected => this.Element.Selected;
+
+        /// <summary>
+        /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Option"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Option"/>.
+        /// </returns>
+        public static implicit operator Option(RemoteWebElement element)
+        {
+            return new Option(element);
+        }
+
+        /// <summary>
+        /// Selects the option.
+        /// </summary>
+        public void Select()
+        {
+            this.Element.Click();
+        }
+    }
+}

--- a/src/Legerity/Web/Elements/Core/Select.cs
+++ b/src/Legerity/Web/Elements/Core/Select.cs
@@ -1,0 +1,112 @@
+namespace Legerity.Web.Elements.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+    using Web.Elements;
+
+    /// <summary>
+    /// Defines a <see cref="IWebElement"/> wrapper for the core web Select control.
+    /// </summary>
+    public class Select : WebElementWrapper
+    {
+        private readonly By selectItemQuery = By.TagName("option");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Select"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public Select(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Select"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
+        public Select(RemoteWebElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether multiple items can be selected.
+        /// </summary>
+        public bool IsMultiple => this.GetIsMultiple();
+
+        /// <summary>
+        /// Gets the collection of items associated with the select.
+        /// </summary>
+        public IEnumerable<Option> Options => this.Element.FindElements(this.selectItemQuery).Select(e => new Option(e));
+
+        /// <summary>
+        /// Gets the selected item when in a single selection state.
+        /// </summary>
+        public Option SelectedOption => this.Options.FirstOrDefault(e => e.IsSelected);
+
+        /// <summary>
+        /// Gets the selected items when in a multiple selection state.
+        /// </summary>
+        public IEnumerable<Option> SelectedOptions => this.Options.Where(e => e.IsSelected);
+
+        /// <summary>
+        /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Select"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Select"/>.
+        /// </returns>
+        public static implicit operator Select(RemoteWebElement element)
+        {
+            return new Select(element);
+        }
+
+        /// <summary>
+        /// Selects an item in the select element with the specified display value.
+        /// </summary>
+        /// <param name="displayValue">
+        /// The display value of the item to select.
+        /// </param>
+        public void SelectOptionByDisplayValue(string displayValue)
+        {
+            Option item =
+                this.Options.FirstOrDefault(e =>
+                    e.DisplayValue.Equals(displayValue, StringComparison.CurrentCultureIgnoreCase));
+            item.Select();
+        }
+
+        /// <summary>
+        /// Selects an item in the select element with the specified value.
+        /// </summary>
+        /// <param name="value">
+        /// The value of the item to select.
+        /// </param>
+        public void SelectOptionByValue(string value)
+        {
+            Option item =
+                this.Options.FirstOrDefault(e =>
+                    e.Value.Equals(value, StringComparison.CurrentCultureIgnoreCase));
+            item.Select();
+        }
+
+        private bool GetIsMultiple()
+        {
+            string multipleAttr = this.Element.GetAttribute("multiple");
+            if (multipleAttr == null)
+            {
+                return false;
+            }
+
+            return bool.TryParse(multipleAttr, out bool isMultiple) && isMultiple;
+        }
+    }
+}


### PR DESCRIPTION
## Fixes #61 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to include a web `Select` and `Option` element. The select element has the capability of getting the options available, whether the element is in multiple selection mode, the currently selected item or items, and the ability to select an option by value or display value.

Tests have been added based on the W3Schools example.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->
