### PR TITLE
Added web element wrapper for TextArea

### DIFF
--- a/docs/Web/WebControlWrappers.md
+++ b/docs/Web/WebControlWrappers.md
@@ -18,4 +18,5 @@ These Web control wrappers are designed to be used with applications built with 
 - [RadioButton](../../src/Legerity/Web/Elements/Core/RadioButton.cs)
 - [RangeInput](../../src/Legerity/Web/Elements/Core/RangeInput.cs)
 - [Select](../../src/Legerity/Web/Elements/Core/Select.cs)
+- [TextArea](../../src/Legerity/Web/Elements/Core/TextArea.cs)
 - [TextInput](../../src/Legerity/Web/Elements/Core/TextInput.cs)

--- a/samples/W3SchoolsWebTests/Tests/TextAreaTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/TextAreaTests.cs
@@ -1,0 +1,55 @@
+namespace W3SchoolsWebTests.Tests
+{
+    using Legerity;
+    using Legerity.Web.Elements.Core;
+    using NUnit.Framework;
+    using OpenQA.Selenium.Remote;
+    using Shouldly;
+    using W3SchoolsWebTests;
+
+    [TestFixture]
+    public class TextAreaTests : BaseTestClass
+    {
+        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_textarea";
+
+        [Test]
+        public void ShouldSetText()
+        {
+            TextArea review = AppManager.WebApp.FindElementById("w3review") as RemoteWebElement;
+            review.SetText("James");
+            review.Text.ShouldBe("James");
+        }
+
+        [Test]
+        public void ShouldAppendText()
+        {
+            TextArea review = AppManager.WebApp.FindElementById("w3review") as RemoteWebElement;
+            review.SetText("James");
+            review.AppendText(" Croft");
+            review.Text.ShouldBe("James Croft");
+        }
+
+        [Test]
+        public void ShouldClearText()
+        {
+            TextArea review = AppManager.WebApp.FindElementById("w3review") as RemoteWebElement;
+            review.SetText("James");
+            review.ClearText();
+            review.Text.ShouldBe(string.Empty);
+        }
+
+        [Test]
+        public void ShouldGetRows()
+        {
+            TextArea review = AppManager.WebApp.FindElementById("w3review") as RemoteWebElement;
+            review.Rows.ShouldBe(4);
+        }
+
+        [Test]
+        public void ShouldGetCols()
+        {
+            TextArea review = AppManager.WebApp.FindElementById("w3review") as RemoteWebElement;
+            review.Cols.ShouldBe(50);
+        }
+    }
+}

--- a/src/Legerity/Web/Elements/Core/TextArea.cs
+++ b/src/Legerity/Web/Elements/Core/TextArea.cs
@@ -1,0 +1,57 @@
+namespace Legerity.Web.Elements.Core
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a <see cref="IWebElement"/> wrapper for the core web TextArea control.
+    /// </summary>
+    public class TextArea : TextInput
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextArea"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public TextArea(IWebElement element) : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextArea"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
+        public TextArea(RemoteWebElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the number of visible text lines.
+        /// </summary>
+        public int Rows => int.Parse(this.Element.GetAttribute("rows"));
+
+        /// <summary>
+        /// Gets the visible width.
+        /// </summary>
+        public int Cols => int.Parse(this.Element.GetAttribute("cols"));
+
+        /// <summary>
+        /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="TextArea"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="TextArea"/>.
+        /// </returns>
+        public static implicit operator TextArea(RemoteWebElement element)
+        {
+            return new TextArea(element);
+        }
+
+    }
+}

--- a/src/Legerity/Web/Elements/Core/TextInput.cs
+++ b/src/Legerity/Web/Elements/Core/TextInput.cs
@@ -15,6 +15,16 @@ namespace Legerity.Web.Elements.Core
         /// <param name="element">
         /// The <see cref="IWebElement"/> reference.
         /// </param>
+        public TextInput(IWebElement element) : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextInput"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
         public TextInput(RemoteWebElement element)
             : base(element)
         {


### PR DESCRIPTION
## Fixes #62 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to introduce a web element wrapper for the `TextArea` element. This element extends the existing `TextInput` element providing additional properties for the number of rows and cols. 

Tests have been added using the W3Schools examples.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->