### PR TITLE
Added WCT Carousel element

### DIFF
--- a/docs/Windows/WindowsControlWrappers.md
+++ b/docs/Windows/WindowsControlWrappers.md
@@ -60,6 +60,7 @@ These Windows control wrappers are designed to be used with controls from the [W
 
 - [BladeView](../../src/Legerity.WCT/BladeView.cs)
 - [BladeViewItem](../../src/Legerity.WCT/BladeViewItem.cs)
+- [Carousel](../../src/Legerity.WCT/Carousel.cs)
 - [Expander](../../src/Legerity.WCT/Expander.cs)
 - [InAppNotification](../../src/Legerity.WCT/InAppNotification.cs)
 - [RadialGauge](../../src/Legerity.WCT/RadialGauge.cs)

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
@@ -2,6 +2,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using Legerity.Pages;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WinUI;
@@ -45,6 +46,8 @@ namespace WindowsCommunityToolkitSampleApp.Pages
             NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
             AutoSuggestBox controlsSearchBox = navigationView.Element.FindElement(this.sampleSearchBoxQuery);
             controlsSearchBox.SetText(sampleName);
+
+            Thread.Sleep(100);
         }
     }
 }

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/CarouselPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/CarouselPage.cs
@@ -1,0 +1,51 @@
+namespace WindowsCommunityToolkitSampleApp.Pages
+{
+    using Legerity.Windows.Elements.WCT;
+    using Legerity.Windows.Extensions;
+    using OpenQA.Selenium;
+    using Shouldly;
+
+    /// <summary>
+    /// Defines the Carousel page of the Windows Community Toolkit sample application.
+    /// </summary>
+    public class CarouselPage : AppPage
+    {
+        private readonly By carouselQuery = ByExtensions.AutomationId("CarouselControl");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CarouselPage"/> class.
+        /// </summary>
+        public CarouselPage()
+        {
+        }
+
+        public Carousel Carousel => this.WindowsApp.FindElement(this.carouselQuery);
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@ClassName='TextBlock'][@Name='Carousel']");
+
+        public CarouselPage SelectCarouselItem(string name)
+        {
+            this.Carousel.SelectItem(name);
+            return this;
+        }
+
+        public CarouselPage SelectCarouselItem(int index)
+        {
+            this.Carousel.SelectItem(index);
+            return this;
+        }
+
+        public void VerifySelectedCarouselItem(string expectedItem)
+        {
+            this.Carousel.SelectedItem.Text.ShouldBe(expectedItem);
+        }
+
+        public void VerifySelectedCarouselItem(int expectedIndex)
+        {
+            this.Carousel.SelectedIndex.ShouldBe(expectedIndex);
+        }
+    }
+}

--- a/samples/WindowsCommunityToolkitSampleApp/Tests/CarouselTests.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Tests/CarouselTests.cs
@@ -1,0 +1,46 @@
+namespace WindowsCommunityToolkitSampleApp.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Pages;
+
+    [TestClass]
+    public class CarouselTests : BaseTestClass
+    {
+        private static CarouselPage CarouselPage { get; set; }
+
+        [TestInitialize]
+        public override void Initialize()
+        {
+            base.Initialize();
+            CarouselPage = new AppPage().SelectSample<CarouselPage>("Carousel");
+        }
+
+        [TestMethod]
+        public void SetCarouselItemByName()
+        {
+            // Arrange
+            string expectedItem = "November hike waterfall";
+
+            // Act
+            CarouselPage.SelectCarouselItem(expectedItem);
+
+            // Assert
+            CarouselPage.VerifySelectedCarouselItem(expectedItem);
+        }
+
+        [TestMethod]
+        public void SetCarouselItemByIndex()
+        {
+            // Arrange
+            int expectedIndex = 1;
+
+            // Act
+            CarouselPage.SelectCarouselItem(expectedIndex);
+
+            // Assert
+            CarouselPage.VerifySelectedCarouselItem(expectedIndex);
+        }
+
+    }
+
+}

--- a/src/Legerity.WCT/Carousel.cs
+++ b/src/Legerity.WCT/Carousel.cs
@@ -1,0 +1,120 @@
+namespace Legerity.Windows.Elements.WCT
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using Core;
+    using Extensions;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the Windows Community Toolkit Carousel control.
+    /// </summary>
+    public class Carousel : WindowsElementWrapper
+    {
+        private readonly By carouselItemQuery = By.ClassName("CarouselItem");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Carousel"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public Carousel(WindowsElement element) : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Gets the collection of items associated with the carousel.
+        /// </summary>
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.carouselItemQuery);
+
+        /// <summary>
+        /// Gets the element associated with the currently selected item.
+        /// </summary>
+        public AppiumWebElement SelectedItem =>
+            this.Items.FirstOrDefault(
+                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
+                    "True",
+                    StringComparison.CurrentCultureIgnoreCase));
+
+        /// <summary>
+        /// Gets the index of the element associated with the currently selected item. 
+        /// </summary>
+        public int SelectedIndex => this.Items.IndexOf(this.SelectedItem);
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ListView"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ListView"/>.
+        /// </returns>
+        public static implicit operator Carousel(WindowsElement element)
+        {
+            return new Carousel(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="ListView"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ListView"/>.
+        /// </returns>
+        public static implicit operator Carousel(AppiumWebElement element)
+        {
+            return new Carousel(element as WindowsElement);
+        }
+
+        /// <summary>
+        /// Clicks on an item in the carousel with the specified item name.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the item to click.
+        /// </param>
+        public void SelectItem(string name)
+        {
+            this.VerifyElementsShown(this.carouselItemQuery, TimeSpan.FromSeconds(2));
+
+            int index = this.Items.IndexOf(this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name)));
+            int selectedIndex = this.SelectedIndex;
+            while (Math.Abs(index - selectedIndex) > double.Epsilon)
+            {
+                this.Element.SendKeys(selectedIndex < index ? Keys.ArrowRight : Keys.ArrowLeft);
+                selectedIndex = this.SelectedIndex;
+            }
+        }
+
+        /// <summary>
+        /// Clicks on an item in the carousel with the specified item name.
+        /// </summary>
+        /// <param name="index">
+        /// The index of the item to click.
+        /// </param>
+        /// <exception cref="T:System.IndexOutOfRangeException">Cannot select an element that is outside the range of items available.</exception>
+        public void SelectItem(int index)
+        {
+            if (index > this.Items.Count - 1)
+            {
+                throw new IndexOutOfRangeException(
+                    "Cannot select an element that is outside the range of items available.");
+            }
+
+            this.VerifyElementsShown(this.carouselItemQuery, TimeSpan.FromSeconds(2));
+
+            int selectedIndex = this.SelectedIndex;
+            while (Math.Abs(index - selectedIndex) > double.Epsilon)
+            {
+                this.Element.SendKeys(selectedIndex < index ? Keys.ArrowRight : Keys.ArrowLeft);
+                selectedIndex = this.SelectedIndex;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Fixes #20 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to include an element wrapper for the [Windows Community Toolkit Carousel](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI.Controls.Layout/Carousel/Carousel.cs) control. 

The element allows for an item to be selected, as well as exposing the list of items, selected item, and selected index. 

Tested using the latest debug variant of the Windows Community Toolkit sample application.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->