### PR TITLE
Added IWebElement constructor for web elements

### DIFF
--- a/src/Legerity/Web/Elements/Core/Button.cs
+++ b/src/Legerity/Web/Elements/Core/Button.cs
@@ -13,6 +13,17 @@ namespace Legerity.Web.Elements.Core
         /// Initializes a new instance of the <see cref="Button"/> class.
         /// </summary>
         /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public Button(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Button"/> class.
+        /// </summary>
+        /// <param name="element">
         /// The <see cref="RemoteWebElement"/> reference.
         /// </param>
         public Button(RemoteWebElement element)

--- a/src/Legerity/Web/Elements/Core/CheckBox.cs
+++ b/src/Legerity/Web/Elements/Core/CheckBox.cs
@@ -13,6 +13,17 @@ namespace Legerity.Web.Elements.Core
         /// Initializes a new instance of the <see cref="CheckBox"/> class.
         /// </summary>
         /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public CheckBox(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CheckBox"/> class.
+        /// </summary>
+        /// <param name="element">
         /// The <see cref="RemoteWebElement"/> reference.
         /// </param>
         public CheckBox(RemoteWebElement element)

--- a/src/Legerity/Web/Elements/Core/List.cs
+++ b/src/Legerity/Web/Elements/Core/List.cs
@@ -16,6 +16,17 @@ namespace Legerity.Web.Elements.Core
         /// Initializes a new instance of the <see cref="List"/> class.
         /// </summary>
         /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public List(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="List"/> class.
+        /// </summary>
+        /// <param name="element">
         /// The <see cref="RemoteWebElement"/> reference.
         /// </param>
         public List(RemoteWebElement element)

--- a/src/Legerity/Web/Elements/Core/NumberInput.cs
+++ b/src/Legerity/Web/Elements/Core/NumberInput.cs
@@ -13,6 +13,17 @@ namespace Legerity.Web.Elements.Core
         /// Initializes a new instance of the <see cref="NumberInput"/> class.
         /// </summary>
         /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public NumberInput(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NumberInput"/> class.
+        /// </summary>
+        /// <param name="element">
         /// The <see cref="RemoteWebElement"/> reference.
         /// </param>
         public NumberInput(RemoteWebElement element)

--- a/src/Legerity/Web/Elements/Core/RadioButton.cs
+++ b/src/Legerity/Web/Elements/Core/RadioButton.cs
@@ -12,6 +12,17 @@ namespace Legerity.Web.Elements.Core
         /// Initializes a new instance of the <see cref="RadioButton"/> class.
         /// </summary>
         /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public RadioButton(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadioButton"/> class.
+        /// </summary>
+        /// <param name="element">
         /// The <see cref="RemoteWebElement"/> reference.
         /// </param>
         public RadioButton(RemoteWebElement element)

--- a/src/Legerity/Web/Elements/Core/RangeInput.cs
+++ b/src/Legerity/Web/Elements/Core/RangeInput.cs
@@ -13,6 +13,17 @@ namespace Legerity.Web.Elements.Core
         /// Initializes a new instance of the <see cref="RangeInput"/> class.
         /// </summary>
         /// <param name="element">
+        /// The <see cref="IWebElement"/> reference.
+        /// </param>
+        public RangeInput(IWebElement element)
+            : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RangeInput"/> class.
+        /// </summary>
+        /// <param name="element">
         /// The <see cref="RemoteWebElement"/> reference.
         /// </param>
         public RangeInput(RemoteWebElement element)

--- a/src/Legerity/Web/Elements/WebElementWrapper.cs
+++ b/src/Legerity/Web/Elements/WebElementWrapper.cs
@@ -22,6 +22,16 @@ namespace Legerity.Web.Elements
         /// <param name="element">
         /// The <see cref="IWebElement"/> reference.
         /// </param>
+        protected WebElementWrapper(IWebElement element) : this(element as RemoteWebElement)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebElementWrapper"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="RemoteWebElement"/> reference.
+        /// </param>
         protected WebElementWrapper(RemoteWebElement element)
         {
             this.elementReference = new WeakReference(element);


### PR DESCRIPTION
## Fixes #69 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to include a new constructor for all web elements to allow elements to initialized with the `IWebElement` returned by the web driver's find queries. 

## PR checklist

- [ ] Sample tests have been added/updated and pass
- [ ] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes