### PR TITLE
Added WaitUntil conditions

### DIFF
--- a/samples/W3SchoolsWebTests/Tests/FileInputTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/FileInputTests.cs
@@ -17,19 +17,19 @@ namespace W3SchoolsWebTests.Tests
         [Test]
         public void ShouldSetAbsoluteFilePath()
         {
-            string filePath = Path.Combine(Environment.CurrentDirectory, @"Tools\Edge\MicrosoftWebDriver.exe");
+            string filePath = Path.Combine(Environment.CurrentDirectory, @"msedgedriver.exe");
 
             FileInput fileInput = AppManager.WebApp.FindElementById("myfile") as RemoteWebElement;
             fileInput.SetAbsoluteFilePath(filePath);
 
             // Cannot check absolute file path as browser security feature prevents seeing full URI.
-            fileInput.FilePath.ShouldContain("MicrosoftWebDriver.exe");
+            fileInput.FilePath.ShouldContain("msedgedriver.exe");
         }
 
         [Test]
         public void ShouldClearFile()
         {
-            string filePath = Path.Combine(Environment.CurrentDirectory, @"Tools\Edge\MicrosoftWebDriver.exe");
+            string filePath = Path.Combine(Environment.CurrentDirectory, @"msedgedriver.exe");
 
             FileInput fileInput = AppManager.WebApp.FindElementById("myfile") as RemoteWebElement;
             fileInput.SetAbsoluteFilePath(filePath);

--- a/samples/W3SchoolsWebTests/Tests/RadioButtonTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/RadioButtonTests.cs
@@ -15,9 +15,9 @@ namespace W3SchoolsWebTests.Tests
     {
         public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio";
 
-        [TestCase("male")]
-        [TestCase("female")]
-        [TestCase("other")]
+        [TestCase("html")]
+        [TestCase("css")]
+        [TestCase("javascript")]
         [TestCase("age1")]
         [TestCase("age2")]
         [TestCase("age3")]
@@ -28,7 +28,7 @@ namespace W3SchoolsWebTests.Tests
             radioButton.IsSelected.ShouldBeTrue();
         }
 
-        [TestCase("gender", "male", "female")]
+        [TestCase("fav_language", "html", "javascript")]
         [TestCase("age", "age3", "age2")]
         public void ShouldOnlySelectOneInGroup(string groupName, string initialRadioId, string expectedRadioId)
         {

--- a/samples/WebTests/Pages/HomePage.cs
+++ b/samples/WebTests/Pages/HomePage.cs
@@ -11,11 +11,11 @@ namespace WebTests.Pages
     /// </summary>
     public class HomePage : BasePage
     {
-        private readonly By heroPostsQuery = By.ClassName("nectar-recent-posts-single_featured");
+        private readonly By heroPostsLocator = By.ClassName("nectar-recent-posts-single_featured");
 
-        private readonly By heroPostItemQuery = By.ClassName("nectar-recent-post-slide");
+        private readonly By heroPostLocator = By.ClassName("nectar-recent-post-slide");
 
-        private readonly By readArticleButtonQuery = By.ClassName("nectar-button");
+        private readonly By readPostButtonLocator = By.ClassName("nectar-button");
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -24,9 +24,9 @@ namespace WebTests.Pages
 
         public HomePage VerifyHeroPostsShown()
         {
-            IWebElement heroPostsContainer = this.WebApp.FindElement(this.heroPostsQuery);
+            IWebElement heroPostsContainer = this.WebApp.FindElement(this.heroPostsLocator);
 
-            ReadOnlyCollection<IWebElement> heroPosts = heroPostsContainer.FindElements(this.heroPostItemQuery);
+            ReadOnlyCollection<IWebElement> heroPosts = heroPostsContainer.FindElements(this.heroPostLocator);
 
             Assert.AreEqual(3, heroPosts.Count);
 
@@ -35,12 +35,12 @@ namespace WebTests.Pages
 
         public PostPage NavigateToHeroPost()
         {
-            IWebElement heroPostsContainer = this.WebApp.FindElement(this.heroPostsQuery);
+            IWebElement heroPostsContainer = this.WebApp.FindElement(this.heroPostsLocator);
 
-            ReadOnlyCollection<IWebElement> heroPosts = heroPostsContainer.FindElements(this.heroPostItemQuery);
+            ReadOnlyCollection<IWebElement> heroPosts = heroPostsContainer.FindElements(this.heroPostLocator);
 
             IWebElement heroPost = heroPosts.FirstOrDefault(p => p.Displayed);
-            IWebElement readButton = heroPost.FindElement(this.readArticleButtonQuery);
+            IWebElement readButton = heroPost.FindElement(this.readPostButtonLocator);
 
             readButton.Click();
 

--- a/samples/WindowsAlarmsAndClock/Elements/AlarmPopup.cs
+++ b/samples/WindowsAlarmsAndClock/Elements/AlarmPopup.cs
@@ -1,0 +1,91 @@
+namespace WindowsAlarmsAndClock.Elements
+{
+    using System;
+    using Legerity.Windows.Elements;
+    using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a <see cref="WindowsElement"/> wrapper for the AlarmPopup control.
+    /// </summary>
+    public class AlarmPopup : WindowsElementWrapper
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AlarmPopup"/> class.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/> reference.
+        /// </param>
+        public AlarmPopup(WindowsElement element)
+            : base(element)
+        {
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="AlarmPopup"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="WindowsElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="DurationPicker"/>.
+        /// </returns>
+        public static implicit operator AlarmPopup(WindowsElement element)
+        {
+            return new AlarmPopup(element);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="AppiumWebElement"/> to the <see cref="AlarmPopup"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="AlarmPopup"/>.
+        /// </returns>
+        public static implicit operator AlarmPopup(AppiumWebElement element)
+        {
+            return new AlarmPopup(element as WindowsElement);
+        }
+
+        /// <summary>
+        /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="AlarmPopup"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="AlarmPopup"/>.
+        /// </returns>
+        public static implicit operator AlarmPopup(RemoteWebElement element)
+        {
+            return new AlarmPopup(element as WindowsElement);
+        }
+
+        public CustomTimePicker DurationPicker => this.FindElement(ByExtensions.AutomationId("DurationPicker"));
+
+        public TextBox AlarmNameInput => this.FindElement(By.Name("Alarm name"));
+
+        public Button SaveButton => this.Element.FindElement(ByExtensions.AutomationId("PrimaryButton"));
+
+        public void SetTime(TimeSpan time)
+        {
+            this.DurationPicker.SetTime(time);
+        }
+
+        public void SetName(string name)
+        {
+            this.AlarmNameInput.SetText(name);
+        }
+
+        public void SaveAlarm()
+        {
+            this.SaveButton.Click();
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/Elements/CustomTimePicker.cs
+++ b/samples/WindowsAlarmsAndClock/Elements/CustomTimePicker.cs
@@ -4,20 +4,15 @@ namespace WindowsAlarmsAndClock.Elements
 
     using Legerity.Windows.Elements;
     using Legerity.Windows.Extensions;
-
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
 
     /// <summary>
     /// Defines a <see cref="WindowsElement"/> wrapper for the custom TimePicker control.
     /// </summary>
     public class CustomTimePicker : WindowsElementWrapper
     {
-        private readonly By hourSelectorQuery = ByExtensions.AutomationId("HourLoopingSelector");
-
-        private readonly By minuteSelectorQuery = ByExtensions.AutomationId("MinuteLoopingSelector");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomTimePicker"/> class.
         /// </summary>
@@ -58,6 +53,20 @@ namespace WindowsAlarmsAndClock.Elements
         }
 
         /// <summary>
+        /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="CustomTimePicker"/> without direct casting.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="AppiumWebElement"/>.
+        /// </param>
+        /// <returns>
+        /// The <see cref="CustomTimePicker"/>.
+        /// </returns>
+        public static implicit operator CustomTimePicker(RemoteWebElement element)
+        {
+            return new CustomTimePicker(element as WindowsElement);
+        }
+
+        /// <summary>
         /// Sets the time to the specified time.
         /// </summary>
         /// <param name="time">
@@ -65,8 +74,8 @@ namespace WindowsAlarmsAndClock.Elements
         /// </param>
         public void SetTime(TimeSpan time)
         {
-            this.Element.FindElement(this.hourSelectorQuery).FindElementByName(time.ToString("%h")).Click();
-            this.Element.FindElement(this.minuteSelectorQuery).FindElementByName(time.ToString("mm")).Click();
+            this.Element.FindElement(ByExtensions.AutomationId("HourPicker")).FindElementByName(time.ToString("%h")).Click();
+            this.Element.FindElement(ByExtensions.AutomationId("MinutePicker")).FindElementByName(time.ToString("mm")).Click();
         }
     }
 }

--- a/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
@@ -3,7 +3,8 @@ namespace WindowsAlarmsAndClock.Pages
     using System;
     using System.Collections.ObjectModel;
     using System.Linq;
-
+    using Elements;
+    using Legerity.Extensions;
     using Legerity.Pages;
     using Legerity.Windows.Extensions;
 
@@ -11,15 +12,14 @@ namespace WindowsAlarmsAndClock.Pages
 
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Remote;
 
     /// <summary>
     /// Defines the alarm page of the Windows Alarms &amp; Clock application.
     /// </summary>
-    public class AlarmPage : BasePage
+    public class AlarmPage : AppPage
     {
         private readonly By addAlarmButton;
-
-        private readonly By selectAlarmsButton;
 
         private readonly By alarmList;
 
@@ -29,9 +29,10 @@ namespace WindowsAlarmsAndClock.Pages
         public AlarmPage()
         {
             this.addAlarmButton = ByExtensions.AutomationId("AddAlarmButton");
-            this.selectAlarmsButton = ByExtensions.AutomationId("SelectAlarmsButton");
             this.alarmList = ByExtensions.AutomationId("AlarmListView");
         }
+
+        public AlarmPopup AlarmPopup => this.WindowsApp.FindElement(ByExtensions.AutomationId("EditFlyout"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -42,12 +43,12 @@ namespace WindowsAlarmsAndClock.Pages
         /// Navigates to adding an alarm.
         /// </summary>
         /// <returns>
-        /// The <see cref="EditAlarmPage"/>.
+        /// The <see cref="AlarmPage"/>.
         /// </returns>
-        public EditAlarmPage GoToAddAlarm()
+        public AlarmPage GoToAddAlarm()
         {
             this.WindowsApp.FindElement(this.addAlarmButton).Click();
-            return new EditAlarmPage();
+            return this;
         }
 
         /// <summary>
@@ -57,12 +58,30 @@ namespace WindowsAlarmsAndClock.Pages
         /// The name of the alarm to edit.
         /// </param>
         /// <returns>
-        /// The <see cref="EditAlarmPage"/>.
+        /// The <see cref="AlarmPage"/>.
         /// </returns>
-        public EditAlarmPage GoToEditAlarm(string alarmName)
+        public AlarmPage GoToEditAlarm(string alarmName)
         {
             this.GetListAlarmElement(alarmName).Click();
-            return new EditAlarmPage();
+            return this;
+        }
+
+        public AlarmPage SetAlarmTime(TimeSpan time)
+        {
+            this.AlarmPopup.SetTime(time);
+            return this;
+        }
+
+        public AlarmPage SetAlarmName(string name)
+        {
+            this.AlarmPopup.SetName(name);
+            return this;
+        }
+
+        public AlarmPage SaveAlarm()
+        {
+            this.AlarmPopup.SaveAlarm();
+            return this;
         }
 
         /// <summary>
@@ -101,7 +120,7 @@ namespace WindowsAlarmsAndClock.Pages
                 this.WindowsApp.FindElement(this.alarmList).FindElements(By.ClassName("ListViewItem"));
 
             return listElements.FirstOrDefault(
-                element => element.GetAttribute("Name").Contains(name, StringComparison.CurrentCulture));
+                element => element.GetName().Contains(name, StringComparison.CurrentCulture));
         }
     }
 }

--- a/samples/WindowsAlarmsAndClock/Pages/AppPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AppPage.cs
@@ -1,0 +1,30 @@
+namespace WindowsAlarmsAndClock.Pages
+{
+    using System;
+    using Legerity.Pages;
+    using Legerity.Windows.Elements.WinUI;
+    using Legerity.Windows.Extensions;
+    using OpenQA.Selenium;
+
+    public class AppPage : BasePage
+    {
+        public NavigationView NavigationView => this.WindowsApp.FindElement(this.Trait);
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => ByExtensions.AutomationId("NavView");
+
+        /// <summary>
+        /// Selects a sample from the available options with the given name.
+        /// </summary>
+        /// <typeparam name="TPage">The type of page to return.</typeparam>
+        /// <param name="name">The name of the sample to click.</param>
+        /// <returns>The <see cref="TPage"/> instance.</returns>
+        public TPage SelectPage<TPage>(string name) where TPage : BasePage
+        {
+            this.NavigationView.ClickMenuOption(name);
+            return Activator.CreateInstance<TPage>();
+        }
+    }
+}

--- a/samples/WindowsAlarmsAndClock/Tests/AlarmTests.cs
+++ b/samples/WindowsAlarmsAndClock/Tests/AlarmTests.cs
@@ -16,7 +16,7 @@ namespace WindowsAlarmsAndClock.Tests
             const string ExpectedAlarmName = "Test Add Alarm";
             var expectedAlarmTime = new TimeSpan(7, 5, 0);
 
-            var alarmPage = new AlarmPage();
+            AlarmPage alarmPage = new AppPage().SelectPage<AlarmPage>("Alarm");
 
             // Act
             alarmPage.GoToAddAlarm().SetAlarmTime(expectedAlarmTime).SetAlarmName(ExpectedAlarmName).SaveAlarm();
@@ -32,7 +32,7 @@ namespace WindowsAlarmsAndClock.Tests
             const string ExpectedAlarmName = "Test Edit Alarm";
             var expectedAlarmTime = new TimeSpan(12, 30, 0);
 
-            var alarmPage = new AlarmPage();
+            AlarmPage alarmPage = new AppPage().SelectPage<AlarmPage>("Alarm");
             alarmPage.GoToAddAlarm().SetAlarmTime(new TimeSpan(7, 5, 0)).SetAlarmName(ExpectedAlarmName).SaveAlarm();
 
             // Act

--- a/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
+++ b/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Legerity.Windows\Legerity.Windows.csproj" />
+    <ProjectReference Include="..\..\src\Legerity.WinUI\Legerity.WinUI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/WindowsCommunityToolkitSampleApp/BaseTestClass.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/BaseTestClass.cs
@@ -16,7 +16,7 @@ namespace WindowsCommunityToolkitSampleApp
         public virtual void Initialize()
         {
             AppManager.StartApp(
-                new WindowsAppManagerOptions(DebugSampleApp)
+                new WindowsAppManagerOptions(StoreSampleApp)
                 {
                     DriverUri = "http://127.0.0.1:4723",
                     LaunchWinAppDriver = true

--- a/samples/WindowsCommunityToolkitSampleApp/Elements/VsCodeInAppNotification.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Elements/VsCodeInAppNotification.cs
@@ -1,6 +1,7 @@
 namespace WindowsCommunityToolkitSampleApp.Elements
 {
     using System.Linq;
+    using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WCT;
     using OpenQA.Selenium;
@@ -16,7 +17,7 @@ namespace WindowsCommunityToolkitSampleApp.Elements
         /// <summary>
         /// Gets the dismiss button.
         /// </summary>
-        public override Button DismissButton => this.Element.FindElements(By.ClassName("Button")).FirstOrDefault(x => x.GetAttribute("Name") == "Close");
+        public override Button DismissButton => this.Element.FindElements(By.ClassName("Button")).FirstOrDefault(x => x.GetName() == "Close");
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="VsCodeInAppNotification"/> without direct casting.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
@@ -12,7 +12,9 @@ namespace WindowsCommunityToolkitSampleApp.Pages
 
     public class AppPage : BasePage
     {
-        private readonly By sampleSearchBoxQuery = ByExtensions.AutomationId("SearchBox");
+        public NavigationView NavigationView => this.WindowsApp.FindElement(this.Trait);
+
+        public AutoSuggestBox SampleSearchBox => this.NavigationView.FindElement(ByExtensions.AutomationId("SearchBox"));
 
         /// <summary>
         /// Gets the UI component associated with the sample picker.
@@ -43,10 +45,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
 
         private void SearchForSample(string sampleName)
         {
-            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
-            AutoSuggestBox controlsSearchBox = navigationView.Element.FindElement(this.sampleSearchBoxQuery);
-            controlsSearchBox.SetText(sampleName);
-
+            this.SampleSearchBox.SetText(sampleName);
             Thread.Sleep(100);
         }
     }

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/BladeViewPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/BladeViewPage.cs
@@ -10,8 +10,6 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     /// </summary>
     public class BladeViewPage : AppPage
     {
-        private readonly By bladeViewQuery = ByExtensions.AutomationId("BladeView");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BladeViewPage"/> class.
         /// </summary>
@@ -19,7 +17,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         {
         }
 
-        public BladeView BladeView => this.WindowsApp.FindElement(this.bladeViewQuery);
+        public BladeView BladeView => this.WindowsApp.FindElement(ByExtensions.AutomationId("BladeView"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/CarouselPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/CarouselPage.cs
@@ -10,8 +10,6 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     /// </summary>
     public class CarouselPage : AppPage
     {
-        private readonly By carouselQuery = ByExtensions.AutomationId("CarouselControl");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CarouselPage"/> class.
         /// </summary>
@@ -19,7 +17,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         {
         }
 
-        public Carousel Carousel => this.WindowsApp.FindElement(this.carouselQuery);
+        public Carousel Carousel => this.WindowsApp.FindElement(ByExtensions.AutomationId("CarouselControl"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/ExpanderPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/ExpanderPage.cs
@@ -10,17 +10,9 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     /// </summary>
     public class ExpanderPage : AppPage
     {
-        private readonly By verticalExpanderQuery;
-        private readonly By horizontalExpanderQuery;
+        public Expander VerticalExpander => this.WindowsApp.FindElement(ByExtensions.AutomationId("Expander1"));
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExpanderPage"/> class.
-        /// </summary>
-        public ExpanderPage()
-        {
-            this.verticalExpanderQuery = ByExtensions.AutomationId("Expander1");
-            this.horizontalExpanderQuery = ByExtensions.AutomationId("Expander2");
-        }
+        public Expander HorizontalExpander => this.WindowsApp.FindElement(ByExtensions.AutomationId("Expander2"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -38,15 +30,13 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         /// </returns>
         public ExpanderPage ToggleVerticalExpander(bool expanded)
         {
-            Expander expander = this.WindowsApp.FindElement(this.verticalExpanderQuery);
-
             if (expanded)
             {
-                expander.Expand();
+                this.VerticalExpander.Expand();
             }
             else
             {
-                expander.Collapse();
+                this.VerticalExpander.Collapse();
             }
 
             return this;
@@ -63,15 +53,13 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         /// </returns>
         public ExpanderPage ToggleHorizontalExpander(bool expanded)
         {
-            Expander expander = this.WindowsApp.FindElement(this.horizontalExpanderQuery);
-
             if (expanded)
             {
-                expander.Expand();
+                this.HorizontalExpander.Expand();
             }
             else
             {
-                expander.Collapse();
+                this.HorizontalExpander.Collapse();
             }
 
             return this;
@@ -85,8 +73,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         /// </param>
         public void VerifyVerticalExpanderState(bool expanded)
         {
-            Expander expander = this.WindowsApp.FindElement(this.verticalExpanderQuery);
-            Assert.AreEqual(expanded, expander.IsExpanded);
+            Assert.AreEqual(expanded, this.VerticalExpander.IsExpanded);
         }
 
         /// <summary>
@@ -97,8 +84,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         /// </param>
         public void VerifyHorizontalExpanderState(bool expanded)
         {
-            Expander expander = this.WindowsApp.FindElement(this.horizontalExpanderQuery);
-            Assert.AreEqual(expanded, expander.IsExpanded);
+            Assert.AreEqual(expanded, this.HorizontalExpander.IsExpanded);
         }
 
     }

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/InAppNotificationPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/InAppNotificationPage.cs
@@ -3,6 +3,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     using System.Linq;
     using Elements;
     using Legerity.Exceptions;
+    using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WCT;
     using Legerity.Windows.Extensions;
@@ -13,36 +14,36 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     /// </summary>
     public class InAppNotificationPage : AppPage
     {
-        private readonly By exampleInAppNotificationQuery = ByExtensions.AutomationId("ExampleInAppNotification");
+        private readonly By exampleInAppNotificationLocator = ByExtensions.AutomationId("ExampleInAppNotification");
 
-        private readonly By exampleCodeInAppNotificationQuery =
+        private readonly By exampleCodeInAppNotificationLocator =
             ByExtensions.AutomationId("ExampleVSCodeInAppNotification");
-
-        /// <summary>
-        /// Gets a given trait of the page to verify that the page is in view.
-        /// </summary>
-        protected override By Trait => By.XPath(".//*[@ClassName='TextBlock'][@Name='InAppNotification']");
 
         /// <summary>
         /// Gets the example in-app notification element.
         /// </summary>
         public InAppNotification ExampleInAppNotification =>
-            this.WindowsApp.FindElement(this.exampleInAppNotificationQuery);
+            this.WindowsApp.FindElement(this.exampleInAppNotificationLocator);
 
         /// <summary>
         /// Gets the example VS Code in-app notification element.
         /// </summary>
         public VsCodeInAppNotification ExampleVSCodeInAppNotification =>
-            this.WindowsApp.FindElement(this.exampleCodeInAppNotificationQuery);
+            this.WindowsApp.FindElement(this.exampleCodeInAppNotificationLocator);
 
-        public Button NotificationWithRandomTextButton => this.WindowsApp.FindElements(By.ClassName("Button"))
-            .FirstOrDefault(x => x.GetAttribute("Name") == "Show notification with random text");
+        public Button NotificationWithRandomTextButton => this.WindowsApp.FindElements(By.ClassName(nameof(Button)))
+            .FirstOrDefault(x => x.GetName() == "Show notification with random text");
 
-        public Button NotificationWithButtonsButton => this.WindowsApp.FindElements(By.ClassName("Button"))
-            .FirstOrDefault(x => x.GetAttribute("Name") == "Show notification with buttons (without DataTemplate)");
+        public Button NotificationWithButtonsButton => this.WindowsApp.FindElements(By.ClassName(nameof(Button)))
+            .FirstOrDefault(x => x.GetName() == "Show notification with buttons (without DataTemplate)");
 
-        public Button NotificationWithVSCodeTemplateButton => this.WindowsApp.FindElements(By.ClassName("Button"))
-            .FirstOrDefault(x => x.GetAttribute("Name") == "Show notification with Visual Studio Code template (info notification)");
+        public Button NotificationWithVSCodeTemplateButton => this.WindowsApp.FindElements(By.ClassName(nameof(Button)))
+            .FirstOrDefault(x => x.GetName() == "Show notification with Visual Studio Code template (info notification)");
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.XPath(".//*[@ClassName='TextBlock'][@Name='InAppNotification']");
 
         public InAppNotificationPage ShowNotificationWithRandomText()
         {
@@ -66,7 +67,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         {
             if (!this.ExampleInAppNotification.IsVisible)
             {
-                throw new ElementNotShownException(this.exampleInAppNotificationQuery.ToString());
+                throw new ElementNotShownException(this.exampleInAppNotificationLocator.ToString());
             }
 
             return this;
@@ -80,7 +81,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
 
         public InAppNotificationPage VerifyExampleInAppNotificationHidden()
         {
-            this.VerifyElementNotShown(this.exampleInAppNotificationQuery);
+            this.VerifyElementNotShown(this.exampleInAppNotificationLocator);
             return this;
         }
 
@@ -88,7 +89,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         {
             if (!this.ExampleVSCodeInAppNotification.IsVisible)
             {
-                throw new ElementNotShownException(this.exampleCodeInAppNotificationQuery.ToString());
+                throw new ElementNotShownException(this.exampleCodeInAppNotificationLocator.ToString());
             }
 
             return this;
@@ -102,7 +103,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
 
         public InAppNotificationPage VerifyExampleVSCodeInAppNotificationHidden()
         {
-            this.VerifyElementNotShown(this.exampleCodeInAppNotificationQuery);
+            this.VerifyElementNotShown(this.exampleCodeInAppNotificationLocator);
             return this;
         }
     }

--- a/samples/XamlControlsGallery/Pages/Collections/FlipViewPage.cs
+++ b/samples/XamlControlsGallery/Pages/Collections/FlipViewPage.cs
@@ -13,7 +13,9 @@ namespace XamlControlsGallery.Pages.Collections
     /// </summary>
     public class FlipViewPage : BasePage
     {
-        private readonly By flipViewQuery = By.ClassName("FlipView");
+        private readonly By flipViewLocator = By.ClassName(nameof(FlipView));
+
+        public FlipView XamlFlipView => this.WindowsApp.FindElements(this.flipViewLocator).LastOrDefault();
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -27,8 +29,7 @@ namespace XamlControlsGallery.Pages.Collections
         /// <returns>The <see cref="FlipViewPage"/>.</returns>
         public FlipViewPage SelectXamlFlipViewItem(string name)
         {
-            FlipView xamlFlipView = this.WindowsApp.FindElements(this.flipViewQuery).LastOrDefault();
-            xamlFlipView.SelectItem(name);
+            this.XamlFlipView.SelectItem(name);
             return this;
         }
 
@@ -40,8 +41,7 @@ namespace XamlControlsGallery.Pages.Collections
         /// </param>
         public void VerifyXamlFlipViewItem(string expectedItem)
         {
-            FlipView xamlFlipView = this.WindowsApp.FindElements(this.flipViewQuery).LastOrDefault();
-            Assert.AreEqual(expectedItem, xamlFlipView.SelectedItem.Text);
+            Assert.AreEqual(expectedItem, this.XamlFlipView.SelectedItem.Text);
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/DateAndTime/CalendarDatePickerPage.cs
+++ b/samples/XamlControlsGallery/Pages/DateAndTime/CalendarDatePickerPage.cs
@@ -1,7 +1,6 @@
 namespace XamlControlsGallery.Pages.DateAndTime
 {
     using System;
-
     using Legerity.Pages;
     using Legerity.Windows.Elements.Core;
 
@@ -14,7 +13,7 @@ namespace XamlControlsGallery.Pages.DateAndTime
     /// </summary>
     public class CalendarDatePickerPage : BasePage
     {
-        private readonly By calendarDatePickerQuery = By.ClassName("CalendarDatePicker");
+        public CalendarDatePicker CalendarDatePicker => this.WindowsApp.FindElement(By.ClassName(nameof(this.CalendarDatePicker)));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -32,8 +31,7 @@ namespace XamlControlsGallery.Pages.DateAndTime
         /// </returns>
         public CalendarDatePickerPage SetCalendarDatePickerDate(DateTime date)
         {
-            CalendarDatePicker calendarDatePicker = this.WindowsApp.FindElement(this.calendarDatePickerQuery);
-            calendarDatePicker.SetDate(date);
+            this.CalendarDatePicker.SetDate(date);
             return this;
         }
 
@@ -47,8 +45,7 @@ namespace XamlControlsGallery.Pages.DateAndTime
         {
             string expectedValue = date.ToString("dd/MM/yyyy");
 
-            CalendarView calendarView = this.WindowsApp.FindElement(this.calendarDatePickerQuery);
-            string actual = calendarView.Value;
+            string actual = this.CalendarDatePicker.Value;
 
             Assert.IsTrue(expectedValue.Equals(actual, StringComparison.CurrentCultureIgnoreCase));
         }

--- a/samples/XamlControlsGallery/Pages/DateAndTime/CalendarViewPage.cs
+++ b/samples/XamlControlsGallery/Pages/DateAndTime/CalendarViewPage.cs
@@ -14,7 +14,7 @@ namespace XamlControlsGallery.Pages.DateAndTime
     /// </summary>
     public class CalendarViewPage : BasePage
     {
-        private readonly By calendarViewQuery = By.ClassName("CalendarView");
+        public CalendarView CalendarView => this.WindowsApp.FindElement(By.ClassName(nameof(this.CalendarView)));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -32,8 +32,7 @@ namespace XamlControlsGallery.Pages.DateAndTime
         /// </returns>
         public CalendarViewPage SetCalendarViewDate(DateTime date)
         {
-            CalendarView calendarView = this.WindowsApp.FindElement(this.calendarViewQuery);
-            calendarView.SetDate(date);
+            this.CalendarView.SetDate(date);
             return this;
         }
 
@@ -49,8 +48,7 @@ namespace XamlControlsGallery.Pages.DateAndTime
             string month = date.ToString("MMMM");
             string year = date.ToString("yyyy");
 
-            CalendarView calendarView = this.WindowsApp.FindElement(this.calendarViewQuery);
-            string actual = calendarView.Value;
+            string actual = this.CalendarView.Value;
 
             Assert.IsTrue(
                 actual.Contains(day, StringComparison.CurrentCultureIgnoreCase)

--- a/samples/XamlControlsGallery/Pages/GroupBasePage.cs
+++ b/samples/XamlControlsGallery/Pages/GroupBasePage.cs
@@ -11,9 +11,9 @@ namespace XamlControlsGallery.Pages
     public abstract class GroupBasePage : BasePage
     {
         /// <summary>
-        /// Gets the query associated with the control list.
+        /// Gets the locator associated with the control list.
         /// </summary>
-        public By ControlList => By.Name("Items In Group");
+        public By ControlListLocator => By.Name("Items In Group");
 
         /// <summary>
         /// Navigates to a page within the control list.
@@ -23,7 +23,7 @@ namespace XamlControlsGallery.Pages
         /// </param>
         public void NavigateTo(string page)
         {
-            GridView gridView = this.WindowsApp.FindElement(this.ControlList);
+            GridView gridView = this.WindowsApp.FindElement(this.ControlListLocator);
             gridView.ClickItem(page);
         }
     }

--- a/samples/XamlControlsGallery/Pages/Media/InkToolbarPage.cs
+++ b/samples/XamlControlsGallery/Pages/Media/InkToolbarPage.cs
@@ -10,7 +10,7 @@ namespace XamlControlsGallery.Pages.Media
     /// </summary>
     public class InkToolbarPage : BasePage
     {
-        private readonly By inkToolbarQuery = ByExtensions.AutomationId("inkToolbar");
+        public InkToolbar InkToolbar => this.WindowsApp.FindElement(ByExtensions.AutomationId("inkToolbar"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -28,8 +28,7 @@ namespace XamlControlsGallery.Pages.Media
         /// </returns>
         public InkToolbarPage SelectBallpointPenColor(string color)
         {
-            InkToolbar inkToolbar = this.WindowsApp.FindElement(this.inkToolbarQuery);
-            inkToolbar.SetBallpointPenColor(color);
+            this.InkToolbar.SetBallpointPenColor(color);
             return this;
         }
 
@@ -44,8 +43,7 @@ namespace XamlControlsGallery.Pages.Media
         /// </returns>
         public InkToolbarPage SelectPencilColor(string color)
         {
-            InkToolbar inkToolbar = this.WindowsApp.FindElement(this.inkToolbarQuery);
-            inkToolbar.SetBallpointPenColor(color);
+            this.InkToolbar.SetBallpointPenColor(color);
             return this;
         }
 
@@ -60,8 +58,7 @@ namespace XamlControlsGallery.Pages.Media
         /// </returns>
         public InkToolbarPage SelectHighlighterColor(string color)
         {
-            InkToolbar inkToolbar = this.WindowsApp.FindElement(this.inkToolbarQuery);
-            inkToolbar.SetHighlighterColor(color);
+            this.InkToolbar.SetHighlighterColor(color);
             return this;
         }
     }

--- a/samples/XamlControlsGallery/Pages/MenusAndToolbars/AppBarToggleButtonPage.cs
+++ b/samples/XamlControlsGallery/Pages/MenusAndToolbars/AppBarToggleButtonPage.cs
@@ -12,7 +12,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
     /// </summary>
     public class AppBarToggleButtonPage : BasePage
     {
-        private readonly By symbolIconQuery = By.Name("SymbolIcon");
+        public AppBarToggleButton ToggleButton => this.WindowsApp.FindElement(By.Name("SymbolIcon"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -30,15 +30,13 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
         /// </returns>
         public AppBarToggleButtonPage ToggleSymbolIconButton(bool on)
         {
-            AppBarToggleButton toggle = this.WindowsApp.FindElement(this.symbolIconQuery);
-
             if (on)
             {
-                toggle.ToggleOn();
+                this.ToggleButton.ToggleOn();
             }
             else
             {
-                toggle.ToggleOff();
+                this.ToggleButton.ToggleOff();
             }
 
             return this;
@@ -52,8 +50,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
         /// </param>
         public void VerifySymbolIconButton(bool on)
         {
-            AppBarToggleButton toggle = this.WindowsApp.FindElement(this.symbolIconQuery);
-            Assert.AreEqual(on, toggle.IsOn);
+            Assert.AreEqual(on, this.ToggleButton.IsOn);
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/MenusAndToolbars/CommandBarPage.cs
+++ b/samples/XamlControlsGallery/Pages/MenusAndToolbars/CommandBarPage.cs
@@ -11,7 +11,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
     /// </summary>
     public class CommandBarPage : BasePage
     {
-        private readonly By primaryCommandBarQuery = ByExtensions.AutomationId("PrimaryCommandBar");
+        public CommandBar PrimaryCommandBar => this.WindowsApp.FindElement(ByExtensions.AutomationId("PrimaryCommandBar"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -26,8 +26,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
         /// </returns>
         public CommandBarPage ClickAddButton()
         {
-            CommandBar primaryCommandBar = this.WindowsApp.FindElement(this.primaryCommandBarQuery);
-            primaryCommandBar.ClickPrimaryButton("addButton");
+            this.PrimaryCommandBar.ClickPrimaryButton("addButton");
             return this;
         }
 
@@ -39,8 +38,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
         /// </returns>
         public CommandBarPage ClickEditButton()
         {
-            CommandBar primaryCommandBar = this.WindowsApp.FindElement(this.primaryCommandBarQuery);
-            primaryCommandBar.ClickPrimaryButton("editButton");
+            this.PrimaryCommandBar.ClickPrimaryButton("editButton");
             return this;
         }
 
@@ -50,8 +48,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
         /// <returns>The <see cref="CommandBarPage"/>.</returns>
         public CommandBarPage ClickSettingsButton()
         {
-            CommandBar primaryCommandBar = this.WindowsApp.FindElement(this.primaryCommandBarQuery);
-            primaryCommandBar.ClickSecondaryButton("settingsButton");
+            this.PrimaryCommandBar.ClickSecondaryButton("settingsButton");
             return this;
         }
     }

--- a/samples/XamlControlsGallery/Pages/Navigation/TabViewPage.cs
+++ b/samples/XamlControlsGallery/Pages/Navigation/TabViewPage.cs
@@ -13,7 +13,7 @@ namespace XamlControlsGallery.Pages.Navigation
     /// </summary>
     public class TabViewPage : BasePage
     {
-        private readonly By tabViewQuery = ByExtensions.AutomationId("TabView1");
+        public TabView TabView => this.WindowsApp.FindElement(ByExtensions.AutomationId("TabView1"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -27,8 +27,7 @@ namespace XamlControlsGallery.Pages.Navigation
         /// <returns>The <see cref="TabViewPage"/>.</returns>
         public TabViewPage SelectTab(string name)
         {
-            TabView tabView = this.WindowsApp.FindElement(this.tabViewQuery);
-            tabView.SelectTab(name);
+            this.TabView.SelectTab(name);
             return this;
         }
 
@@ -39,8 +38,7 @@ namespace XamlControlsGallery.Pages.Navigation
         /// <returns>The <see cref="TabViewPage"/>.</returns>
         public TabViewPage CloseTab(string name)
         {
-            TabView tabView = this.WindowsApp.FindElement(this.tabViewQuery);
-            tabView.CloseTab(name);
+            this.TabView.CloseTab(name);
             return this;
         }
 
@@ -52,8 +50,7 @@ namespace XamlControlsGallery.Pages.Navigation
         /// </returns>
         public TabViewPage CreateTab()
         {
-            TabView tabView = this.WindowsApp.FindElement(this.tabViewQuery);
-            tabView.CreateTab();
+            this.TabView.CreateTab();
             return this;
         }
 
@@ -65,8 +62,7 @@ namespace XamlControlsGallery.Pages.Navigation
         /// </param>
         public void VerifyTabSelected(string expectedItem)
         {
-            TabView tabView = this.WindowsApp.FindElement(this.tabViewQuery);
-            Assert.AreEqual(expectedItem, tabView.SelectedItem.Text);
+            Assert.AreEqual(expectedItem, this.TabView.SelectedItem.Text);
         }
 
         /// <summary>
@@ -77,8 +73,7 @@ namespace XamlControlsGallery.Pages.Navigation
         /// </param>
         public void VerifyTabCount(int count)
         {
-            TabView tabView = this.WindowsApp.FindElement(this.tabViewQuery);
-            Assert.AreEqual(count, tabView.Tabs.Count);
+            Assert.AreEqual(count, this.TabView.Tabs.Count);
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/NavigationMenu.cs
+++ b/samples/XamlControlsGallery/Pages/NavigationMenu.cs
@@ -9,27 +9,22 @@ namespace XamlControlsGallery.Pages
 
     using OpenQA.Selenium;
     using StatusAndInfo;
-    using XamlControlsGallery.Pages.BasicInput;
-    using XamlControlsGallery.Pages.Collections;
-    using XamlControlsGallery.Pages.DateAndTime;
-    using XamlControlsGallery.Pages.Media;
-    using XamlControlsGallery.Pages.MenusAndToolbars;
-    using XamlControlsGallery.Pages.Navigation;
-    using XamlControlsGallery.Pages.Text;
+    using BasicInput;
+    using Collections;
+    using DateAndTime;
+    using Media;
+    using MenusAndToolbars;
+    using Navigation;
+    using Text;
 
     /// <summary>
     /// Defines a helper for navigating the application's menu.
     /// </summary>
     public class NavigationMenu : BasePage
     {
-        private readonly By controlsSearchBoxQuery = ByExtensions.AutomationId("controlsSearchBox");
+        public NavigationView NavigationView => this.WindowsApp.FindElement(this.Trait);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigationMenu"/> class.
-        /// </summary>
-        public NavigationMenu()
-        {
-        }
+        public AutoSuggestBox ControlsSearchBox => this.NavigationView.FindElement(ByExtensions.AutomationId("controlsSearchBox"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -178,8 +173,7 @@ namespace XamlControlsGallery.Pages
         /// <returns>The <see cref="SettingsPage"/>.</returns>
         public SettingsPage GoToSettingsPage()
         {
-            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
-            navigationView.OpenSettings();
+            this.NavigationView.OpenSettings();
             return new SettingsPage();
         }
 
@@ -204,7 +198,7 @@ namespace XamlControlsGallery.Pages
             this.SearchForControl("TabView");
             return new TabViewPage();
         }
-        
+
         /// <summary>
         /// Navigates to the time picker control page.
         /// </summary>
@@ -240,15 +234,13 @@ namespace XamlControlsGallery.Pages
         /// </returns>
         public NavigationMenu ToggleNavigationPane(bool open)
         {
-            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
-
             if (open)
             {
-                navigationView.OpenNavigationPane();
+                this.NavigationView.OpenNavigationPane();
             }
             else
             {
-                navigationView.CloseNavigationPane();
+                this.NavigationView.CloseNavigationPane();
             }
 
             return this;
@@ -265,8 +257,7 @@ namespace XamlControlsGallery.Pages
         /// </returns>
         public NavigationMenu VerifyToggleNavigationPane(bool open)
         {
-            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
-            Assert.AreEqual(open, navigationView.IsPaneOpen);
+            Assert.AreEqual(open, this.NavigationView.IsPaneOpen);
             return this;
         }
 
@@ -284,16 +275,13 @@ namespace XamlControlsGallery.Pages
         /// </returns>
         public NavigationMenu SelectControlOption(string expectedGroupOption, string expectedOption)
         {
-            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
-            navigationView.ClickMenuOption(expectedGroupOption).ClickChildOption(expectedOption);
+            this.NavigationView.ClickMenuOption(expectedGroupOption).ClickChildOption(expectedOption);
             return this;
         }
 
         private void SearchForControl(string control)
         {
-            NavigationView navigationView = this.WindowsApp.FindElement(this.Trait);
-            AutoSuggestBox controlsSearchBox = navigationView.Element.FindElement(this.controlsSearchBoxQuery);
-            controlsSearchBox.SelectSuggestion(control);
+            this.ControlsSearchBox.SelectSuggestion(control);
         }
     }
 }

--- a/samples/XamlControlsGallery/Pages/SettingsPage.cs
+++ b/samples/XamlControlsGallery/Pages/SettingsPage.cs
@@ -10,7 +10,7 @@ namespace XamlControlsGallery.Pages
 
     public class SettingsPage : BasePage
     {
-        private readonly By soundToggleQuery = ByExtensions.AutomationId("soundToggle");
+        public ToggleSwitch SoundToggle => this.WindowsApp.FindElement(ByExtensions.AutomationId("soundToggle"));
 
         protected override By Trait => By.XPath(".//*[@Name='Settings'][@AutomationId='TitleTextBlock']");
 
@@ -23,15 +23,13 @@ namespace XamlControlsGallery.Pages
         /// </returns>
         public SettingsPage ToggleSoundOption(bool toggleOn)
         {
-            ToggleSwitch soundToggle = this.WindowsApp.FindElement(this.soundToggleQuery);
-
             if (toggleOn)
             {
-                soundToggle.ToggleOn();
+                this.SoundToggle.ToggleOn();
             }
             else
             {
-                soundToggle.ToggleOff();
+                this.SoundToggle.ToggleOff();
             }
 
             return this;
@@ -51,9 +49,7 @@ namespace XamlControlsGallery.Pages
         /// </exception>
         public SettingsPage VerifyToggleSoundOption(bool expectedToggleOn)
         {
-            ToggleSwitch soundToggle = this.WindowsApp.FindElement(this.soundToggleQuery);
-
-            if ((!expectedToggleOn || !soundToggle.IsOn) && (expectedToggleOn || soundToggle.IsOn))
+            if ((!expectedToggleOn || !this.SoundToggle.IsOn) && (expectedToggleOn || this.SoundToggle.IsOn))
             {
                 throw new AssertFailedException(
                     $"The toggle switch 'soundToggle' was not in the expected state. Expected toggle on: {expectedToggleOn}.");

--- a/samples/XamlControlsGallery/Pages/StatusAndInfo/InfoBarPage.cs
+++ b/samples/XamlControlsGallery/Pages/StatusAndInfo/InfoBarPage.cs
@@ -10,7 +10,7 @@ namespace XamlControlsGallery.Pages.StatusAndInfo
     /// </summary>
     public class InfoBarPage : BasePage
     {
-        private readonly By closableBarWithOptsQuery = ByExtensions.AutomationId("TestInfoBar1");
+        public InfoBar CloseableBarWithOpts => this.WindowsApp.FindElement(ByExtensions.AutomationId("TestInfoBar1"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
@@ -19,8 +19,7 @@ namespace XamlControlsGallery.Pages.StatusAndInfo
 
         public InfoBarPage CloseClosableBarWithOptions()
         {
-            InfoBar closeableBarWithOpts = this.WindowsApp.FindElement(this.closableBarWithOptsQuery);
-            closeableBarWithOpts.Close();
+            this.CloseableBarWithOpts.Close();
             return this;
         }
     }

--- a/samples/XamlControlsGallery/Pages/Text/NumberBoxPage.cs
+++ b/samples/XamlControlsGallery/Pages/Text/NumberBoxPage.cs
@@ -13,19 +13,10 @@ namespace XamlControlsGallery.Pages.Text
     /// </summary>
     public class NumberBoxPage : BasePage
     {
-        private readonly By spinnerNumberBoxQuery = ByExtensions.AutomationId("NumberBoxSpinButtonPlacementExample");
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NumberBoxPage"/> class.
-        /// </summary>
-        public NumberBoxPage()
-        {
-        }
-
         /// <summary>
         /// Gets the element associated with the spinner number box.
         /// </summary>
-        public NumberBox SpinnerNumberBox => this.WindowsApp.FindElement(this.spinnerNumberBoxQuery);
+        public NumberBox SpinnerNumberBox => this.WindowsApp.FindElement(ByExtensions.AutomationId("NumberBoxSpinButtonPlacementExample"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/src/Legerity.Android/Elements/AndroidElementWrapper.cs
+++ b/src/Legerity.Android/Elements/AndroidElementWrapper.cs
@@ -37,48 +37,48 @@ namespace Legerity.Android.Elements
         /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
-        /// <param name="query">The query to find a specific element.</param>
+        /// <param name="locator">The locator to find a specific element.</param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
-        protected void VerifyDriverElementShown(By query, TimeSpan? timeout)
+        protected void VerifyDriverElementShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Driver.FindElement(query) == null)
+                if (this.Driver.FindElement(locator) == null)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElement(query) != null);
+                wait.Until(driver => driver.FindElement(locator) != null);
             }
         }
 
         /// <summary>
         /// Determines whether the specified elements are shown with the specified timeout.
         /// </summary>
-        /// <param name="query">
-        /// The query to find a collection of elements.
+        /// <param name="locator">
+        /// The locator to find a collection of elements.
         /// </param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
-        protected void VerifyDriverElementsShown(By query, TimeSpan? timeout)
+        protected void VerifyDriverElementsShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Driver.FindElements(query).Count == 0)
+                if (this.Driver.FindElements(locator).Count == 0)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElements(query).Count != 0);
+                wait.Until(driver => driver.FindElements(locator).Count != 0);
             }
         }
     }

--- a/src/Legerity.Core/ByExtras.cs
+++ b/src/Legerity.Core/ByExtras.cs
@@ -3,7 +3,7 @@ namespace Legerity
     using OpenQA.Selenium;
 
     /// <summary>
-    /// Defines a collection of extra query constraints for <see cref="By"/>.
+    /// Defines a collection of extra locator constraints for <see cref="By"/>.
     /// </summary>
     public static class ByExtras
     {

--- a/src/Legerity.Core/Extensions/AttributeExtensions.cs
+++ b/src/Legerity.Core/Extensions/AttributeExtensions.cs
@@ -1,0 +1,35 @@
+namespace Legerity.Extensions
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a collection of extensions for retrieving element attributes.
+    /// </summary>
+    public static class AttributeExtensions
+    {
+        /// <summary>
+        /// Retrieves the Name attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve a Name from.</param>
+        /// <returns>The Name of the element.</returns>
+        public static string GetName(this IWebElement element)
+        {
+            return element.GetAttribute("Name");
+        }
+
+        /// <summary>
+        /// Retrieves the Name attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a Name from.</param>
+        /// <returns>The Name of the element.</returns>
+        public static string GetName<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetName(element.Element);
+        }
+    }
+}

--- a/src/Legerity.Core/Extensions/DriverExtensions.cs
+++ b/src/Legerity.Core/Extensions/DriverExtensions.cs
@@ -1,9 +1,11 @@
 namespace Legerity.Extensions
 {
+    using System;
     using System.Collections.ObjectModel;
     using System.Linq;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
+    using OpenQA.Selenium.Support.UI;
 
     /// <summary>
     /// Defines a collection of extensions for a driver.
@@ -84,6 +86,17 @@ namespace Legerity.Extensions
         public static ReadOnlyCollection<IWebElement> GetAllElements(this RemoteWebDriver driver)
         {
             return driver.FindElements(By.XPath("//*"));
+        }
+
+        /// <summary>
+        /// Waits until a specified driver condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="appDriver">The driver to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        public static void WaitUntil(this IWebDriver appDriver, Func<IWebDriver, bool> condition, TimeSpan? timeout = default)
+        {
+            new WebDriverWait(appDriver, timeout ?? TimeSpan.Zero).Until(condition);
         }
     }
 }

--- a/src/Legerity.Core/Extensions/DriverExtensions.cs
+++ b/src/Legerity.Core/Extensions/DriverExtensions.cs
@@ -11,25 +11,25 @@ namespace Legerity.Extensions
     public static class DriverExtensions
     {
         /// <summary>
-        /// Finds the first element in the page that matches the <see cref="By" /> query.
+        /// Finds the first element in the page that matches the <see cref="By" /> locator.
         /// </summary>
         /// <param name="driver">The remote web driver.</param>
-        /// <param name="by">The query to find the element.</param>
+        /// <param name="locator">The locator to find the element.</param>
         /// <returns>A <see cref="RemoteWebElement"/>.</returns>
-        public static RemoteWebElement FindWebElement(this RemoteWebDriver driver, By by)
+        public static RemoteWebElement FindWebElement(this RemoteWebDriver driver, By locator)
         {
-            return driver.FindElement(by) as RemoteWebElement;
+            return driver.FindElement(locator) as RemoteWebElement;
         }
 
         /// <summary>
-        /// Finds all the elements in the page that matches the <see cref="By" /> query.
+        /// Finds all the elements in the page that matches the <see cref="By" /> locator.
         /// </summary>
         /// <param name="driver">The remote web driver.</param>
-        /// <param name="by">The query to find the elements.</param>
+        /// <param name="locator">The locator to find the elements.</param>
         /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this RemoteWebDriver driver, By by)
+        public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this RemoteWebDriver driver, By locator)
         {
-            return driver.FindElements(by).Cast<RemoteWebElement>().ToList().AsReadOnly();
+            return driver.FindElements(locator).Cast<RemoteWebElement>().ToList().AsReadOnly();
         }
 
         /// <summary>

--- a/src/Legerity.Core/Extensions/ElementExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementExtensions.cs
@@ -1,10 +1,12 @@
 namespace Legerity.Extensions
 {
+    using System;
     using System.Collections.ObjectModel;
     using System.Drawing;
     using System.Linq;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
+    using OpenQA.Selenium.Support.UI;
 
     /// <summary>
     /// Defines a collection of extensions for elements.
@@ -97,6 +99,29 @@ namespace Legerity.Extensions
         public static ReadOnlyCollection<IWebElement> GetAllElements(this IWebElement element)
         {
             return element.FindElements(By.XPath("//*"));
+        }
+
+        /// <summary>
+        /// Waits until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+        public static void WaitUntil<TElement>(this TElement element, Func<TElement, bool> condition, TimeSpan? timeout = default)
+            where TElement : IWebElement
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(element);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
         }
     }
 }

--- a/src/Legerity.Core/Extensions/ElementExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementExtensions.cs
@@ -24,25 +24,25 @@ namespace Legerity.Extensions
         }
 
         /// <summary>
-        /// Finds the first element in the given element that matches the <see cref="By" /> query.
+        /// Finds the first element in the given element that matches the <see cref="By" /> locator.
         /// </summary>
         /// <param name="element">The remote web element.</param>
-        /// <param name="by">The query to find the element.</param>
+        /// <param name="locator">The locator to find the element.</param>
         /// <returns>A <see cref="RemoteWebElement"/>.</returns>
-        public static RemoteWebElement FindWebElement(this IWebElement element, By by)
+        public static RemoteWebElement FindWebElement(this IWebElement element, By locator)
         {
-            return element.FindElement(by) as RemoteWebElement;
+            return element.FindElement(locator) as RemoteWebElement;
         }
 
         /// <summary>
-        /// Finds all the elements in the given element that matches the <see cref="By" /> query.
+        /// Finds all the elements in the given element that matches the <see cref="By" /> locator.
         /// </summary>
         /// <param name="element">The remote web element.</param>
-        /// <param name="by">The query to find the elements.</param>
+        /// <param name="locator">The locator to find the elements.</param>
         /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this IWebElement element, By by)
+        public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this IWebElement element, By locator)
         {
-            return element.FindElements(by).Cast<RemoteWebElement>().ToList().AsReadOnly();
+            return element.FindElements(locator).Cast<RemoteWebElement>().ToList().AsReadOnly();
         }
 
         /// <summary>

--- a/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
@@ -1,0 +1,156 @@
+namespace Legerity.Extensions
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Drawing;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="IElementWrapper{TElement}"/> objects.
+    /// </summary>
+    public static class ElementWrapperExtensions
+    {
+        /// <summary>
+        /// Determines the bounding rectangle for the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The element to determine the rect for.</param>
+        /// <returns>The elements bounding rectangle.</returns>
+        public static Rectangle GetBoundingRect<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return element.Element.GetBoundingRect();
+        }
+
+        /// <summary>
+        /// Finds the first element in the given element that matches the <see cref="By" /> locator.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web element.</param>
+        /// <param name="locator">The locator to find the element.</param>
+        /// <returns>A <see cref="RemoteWebElement"/>.</returns>
+        public static RemoteWebElement FindWebElement<TElement>(this IElementWrapper<TElement> element, By locator)
+            where TElement : IWebElement
+        {
+            return element.Element.FindWebElement(locator);
+        }
+
+        /// <summary>
+        /// Finds all the elements in the given element that matches the <see cref="By" /> locator.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web element.</param>
+        /// <param name="locator">The locator to find the elements.</param>
+        /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
+        public static ReadOnlyCollection<RemoteWebElement> FindWebElements<TElement>(this IElementWrapper<TElement> element, By locator)
+            where TElement : IWebElement
+        {
+            return element.Element.FindWebElements(locator);
+        }
+
+        /// <summary>
+        /// Finds the first element in the given element that matches the specified text.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web element.</param>
+        /// <param name="text">The text to find.</param>
+        /// <returns>A <see cref="IWebElement"/>.</returns>
+        public static IWebElement FindElementByText<TElement>(this IElementWrapper<TElement> element, string text)
+            where TElement : IWebElement
+        {
+            return element.Element.FindElementByText(text);
+        }
+
+        /// <summary>
+        /// Finds all the elements in the given element that matches the specified text.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web element.</param>
+        /// <param name="text">The text to find.</param>
+        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+        public static ReadOnlyCollection<IWebElement> FindElementsByText<TElement>(this IElementWrapper<TElement> element, string text)
+            where TElement : IWebElement
+        {
+            return element.Element.FindElementsByText(text);
+        }
+
+        /// <summary>
+        /// Finds the first element in the given element that matches the specified text partially.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web element.</param>
+        /// <param name="text">The partial text to find.</param>
+        /// <returns>A <see cref="IWebElement"/>.</returns>
+        public static IWebElement FindElementByPartialText<TElement>(this IElementWrapper<TElement> element, string text)
+            where TElement : IWebElement
+        {
+            return element.Element.FindElementByPartialText(text);
+        }
+
+        /// <summary>
+        /// Finds all the elements in the given element that matches the specified text partially.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web element.</param>
+        /// <param name="text">The partial text to find.</param>
+        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText<TElement>(this IElementWrapper<TElement> element, string text)
+            where TElement : IWebElement
+        {
+            return element.Element.FindElementsByPartialText(text);
+        }
+
+        /// <summary>
+        /// Retrieves all elements that can be located by the driver for the given element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The remote web driver.</param>
+        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+        public static ReadOnlyCollection<IWebElement> GetAllElements<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return element.Element.GetAllElements();
+        }
+
+        /// <summary>
+        /// Waits until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+        public static void WaitUntil<TElement>(this IElementWrapper<TElement> element, Func<IElementWrapper<TElement>, bool> condition, TimeSpan? timeout = default)
+            where TElement : IWebElement
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(element);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
+        }
+    }
+}

--- a/src/Legerity.Core/Extensions/PageExtensions.cs
+++ b/src/Legerity.Core/Extensions/PageExtensions.cs
@@ -1,0 +1,39 @@
+namespace Legerity.Extensions
+{
+    using System;
+    using Legerity.Pages;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a collection of extensions for page objects.
+    /// </summary>
+    public static class PageExtensions
+    {
+        /// <summary>
+        /// Waits until a specified page condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="page">The page to wait on.</param>
+        /// <param name="condition">The condition of the page to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+        /// <returns>The instance of the page.</returns>
+        public static TPage WaitUntil<TPage>(this TPage page, Func<TPage, bool> condition, TimeSpan? timeout = default)
+            where TPage : BasePage
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(page);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
+
+            return page;
+        }
+    }
+}

--- a/src/Legerity.Core/Helpers/WaitUntilConditions.cs
+++ b/src/Legerity.Core/Helpers/WaitUntilConditions.cs
@@ -1,0 +1,112 @@
+namespace Legerity.Helpers
+{
+    using System;
+    using Legerity.Pages;
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines a set of conditions that can be used with the WaitUntil methods of elements and pages.
+    /// </summary>
+    public static class WaitUntilConditions
+    {
+        /// <summary>
+        /// A condition for validating whether the title of the current Window matches the specified title.
+        /// </summary>
+        /// <param name="title">The expected title, which must be an exact match.</param>
+        /// <param name="comparison">The comparison for validating equality.</param>
+        /// <returns>True if the title matches; otherwise, false.</returns>
+        public static Func<IWebDriver, bool> TitleIs(string title, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            return driver => driver.Title.Equals(title, comparison);
+        }
+
+        /// <summary>
+        /// A condition for validating whether the title of the current Window contains a case-sensitive substring.
+        /// </summary>
+        /// <param name="title">The fragment of title expected.</param>
+        /// <returns>True if the title contains the text; otherwise, false.</returns>
+        public static Func<IWebDriver, bool> TitleContains(string title)
+        {
+            return driver => driver.Title.Contains(title);
+        }
+
+        /// <summary>
+        /// A condition for validating whether the URL of the current Window matches the specified URL.
+        /// </summary>
+        /// <param name="url">The URL that the page should be on.</param>
+        /// <param name="comparison">The comparison for validating equality.</param>
+        /// <returns>True if the URL matches; otherwise, false.</returns>
+        public static Func<IWebDriver, bool> UrlIs(string url, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            return driver => driver.Url.Equals(url, comparison);
+        }
+
+        /// <summary>
+        /// A condition for validating whether the URL of the current Window contains a case-sensitive substring.
+        /// </summary>
+        /// <param name="url">The fragment of URL expected.</param>
+        /// <returns>True if the URL contains the text; otherwise, false.</returns>
+        public static Func<IWebDriver, bool> UrlContains(string url)
+        {
+            return driver => driver.Url.Contains(url);
+        }
+
+        /// <summary>
+        /// A condition for validating whether a specified element found by a locator exists within the context of the page.
+        /// <para>
+        /// Note, the element may exist but may not be visible.
+        /// </para>
+        /// </summary>
+        /// <param name="locator">The locator to find the element.</param>
+        /// <returns>True if the element exists; otherwise, false.</returns>
+        public static Func<IWebDriver, bool> ElementExists(By locator)
+        {
+            return driver => driver.FindElement(locator) != null;
+        }
+
+        /// <summary>
+        /// A condition for validating whether a specified element found by a locator exists within the context of an element.
+        /// <para>
+        /// Note, the element may exist but may not be visible.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+        /// <param name="locator">The locator to find the element.</param>
+        /// <returns>True if the element exists; otherwise, false.</returns>
+        public static Func<TElement, bool> ElementExistsInElement<TElement>(By locator)
+            where TElement : IWebElement
+        {
+            return element => element.FindElement(locator) != null;
+        }
+
+        /// <summary>
+        /// A condition for validating whether a specified element found by a locator exists within the context of an element wrapper.
+        /// <para>
+        /// Note, the element may exist but may not be visible.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+        /// <param name="locator">The locator to find the element.</param>
+        /// <returns>True if the element exists; otherwise, false.</returns>
+        public static Func<IElementWrapper<TElement>, bool> ElementExistsInElementWrapper<TElement>(By locator)
+            where TElement : IWebElement
+        {
+            return wrapper => wrapper.Element.FindElement(locator) != null;
+        }
+
+        /// <summary>
+        /// A condition for validating whether a specified element found by a locator exists within the context of a page object.
+        /// <para>
+        /// Note, the element may exist but may not be visible.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+        /// <param name="locator">The locator to find the element.</param>
+        /// <returns>True if the element exists; otherwise, false.</returns>
+        public static Func<TPage, bool> ElementExistsInPage<TPage>(By locator)
+            where TPage : BasePage
+        {
+            return page => page.App.FindElement(locator) != null;
+        }
+    }
+}

--- a/src/Legerity.Core/IElementWrapper.cs
+++ b/src/Legerity.Core/IElementWrapper.cs
@@ -2,13 +2,12 @@ namespace Legerity
 {
     using System;
     using OpenQA.Selenium;
-    using OpenQA.Selenium.Remote;
 
     /// <summary>
     /// Defines an interface for a Selenium/Appium element wrapper.
     /// </summary>
     /// <typeparam name="TElement">
-    /// The type of <see cref="RemoteWebElement"/>.
+    /// The type of <see cref="IWebElement"/>.
     /// </typeparam>
     public interface IElementWrapper<TElement>
         where TElement : IWebElement

--- a/src/Legerity.Core/IElementWrapper.cs
+++ b/src/Legerity.Core/IElementWrapper.cs
@@ -1,0 +1,68 @@
+namespace Legerity
+{
+    using System;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines an interface for a Selenium/Appium element wrapper.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="RemoteWebElement"/>.
+    /// </typeparam>
+    public interface IElementWrapper<TElement>
+        where TElement : IWebElement
+    {
+        /// <summary>Gets the original <typeparamref name="TElement"/> reference object.</summary>
+        TElement Element { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the element is visible.
+        /// </summary>
+        bool IsVisible { get; }
+
+        /// <summary>
+        /// Determines whether the given element is shown.
+        /// </summary>
+        /// <param name="locator">
+        /// The locator for the element to find.
+        /// </param>
+        void VerifyElementShown(By locator);
+
+        /// <summary>
+        /// Determines whether the specified element is shown with the specified timeout.
+        /// </summary>
+        /// <param name="locator">The locator to find a specific element.</param>
+        /// <param name="timeout">
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
+        /// </param>
+        void VerifyElementShown(By locator, TimeSpan? timeout);
+
+        /// <summary>
+        /// Determines whether the given element is not shown.
+        /// </summary>
+        /// <param name="locator">
+        /// The locator for the element to locate.
+        /// </param>
+        void VerifyElementNotShown(By locator);
+
+        /// <summary>
+        /// Determines whether the specified elements are shown.
+        /// </summary>
+        /// <param name="locator">
+        /// The locator for the element to find.
+        /// </param>
+        void VerifyElementsShown(By locator);
+
+        /// <summary>
+        /// Determines whether the specified elements are shown with the specified timeout.
+        /// </summary>
+        /// <param name="locator">
+        /// The locator to find a collection of elements.
+        /// </param>
+        /// <param name="timeout">
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
+        /// </param>
+        void VerifyElementsShown(By locator, TimeSpan? timeout);
+    }
+}

--- a/src/Legerity.Core/Legerity.Core.csproj
+++ b/src/Legerity.Core/Legerity.Core.csproj
@@ -9,7 +9,7 @@
       - Page Object Pattern classes, for providing the base framework to build maintainable UI tests
       - AppManager, for configuring, launching, and managing the lifecycle of the application driver
       - ElementWrapper, for providing a base to build custom element wrappers for platform-specific elements
-      - ByExtras, for providing additional query constraints for finding elements
+      - ByExtras, for providing additional locator constraints for finding elements
     </Description>
     <PackageTags>Appium Selenium WinAppDriver POP Windows UWP Web Android IOS Xamarin Uno</PackageTags>
     <RootNamespace>Legerity</RootNamespace>

--- a/src/Legerity.Core/Pages/BasePage.cs
+++ b/src/Legerity.Core/Pages/BasePage.cs
@@ -120,28 +120,28 @@ namespace Legerity.Pages
         /// <summary>
         /// Determines whether the given element is shown.
         /// </summary>
-        /// <param name="by">
-        /// The query for the element to find.
+        /// <param name="locator">
+        /// The locator for the element to find.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.DriverNotInitializedException">Thrown if AppManager.StartApp() has not been called.</exception>
         /// <exception cref="T:Legerity.Exceptions.ElementNotShownException">Thrown if the element is not shown.</exception>
-        public void VerifyElementShown(By by)
+        public void VerifyElementShown(By locator)
         {
-            this.VerifyElementShown(by, null);
+            this.VerifyElementShown(locator, null);
         }
 
         /// <summary>
         /// Determines whether the given element is shown with the specified timeout.
         /// </summary>
-        /// <param name="by">
-        /// The query for the element to find.
+        /// <param name="locator">
+        /// The locator for the element to find.
         /// </param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="by"/> element if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> element if it is not immediately present.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.DriverNotInitializedException">Thrown if AppManager.StartApp() has not been called.</exception>
         /// <exception cref="T:Legerity.Exceptions.ElementNotShownException">Thrown if the element is not shown.</exception>
-        public void VerifyElementShown(By by, TimeSpan? timeout)
+        public void VerifyElementShown(By locator, TimeSpan? timeout)
         {
             if (this.App == null)
             {
@@ -151,16 +151,16 @@ namespace Legerity.Pages
 
             if (timeout == null)
             {
-                if (this.App != null && this.App.FindElement(by) == null)
+                if (this.App != null && this.App.FindElement(locator) == null)
                 {
-                    throw new ElementNotShownException(by.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 if (this.App != null)
                 {
-                    AttemptWaitForDriverElement(by, timeout.Value, this.App);
+                    AttemptWaitForDriverElement(locator, timeout.Value, this.App);
                 }
             }
         }
@@ -168,11 +168,11 @@ namespace Legerity.Pages
         /// <summary>
         /// Determines whether the given element is not shown.
         /// </summary>
-        /// <param name="by">
-        /// The query for the element to locate.
+        /// <param name="locator">
+        /// The locator for the element to locate.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.DriverNotInitializedException">Thrown if AppManager.StartApp() has not been called.</exception>
-        public void VerifyElementNotShown(By by)
+        public void VerifyElementNotShown(By locator)
         {
             if (this.App == null)
             {
@@ -182,7 +182,7 @@ namespace Legerity.Pages
 
             try
             {
-                this.VerifyElementShown(by);
+                this.VerifyElementShown(locator);
             }
             catch (ElementNotShownException)
             {
@@ -192,10 +192,10 @@ namespace Legerity.Pages
             }
         }
 
-        private static void AttemptWaitForDriverElement(By by, TimeSpan timeout, IWebDriver appDriver)
+        private static void AttemptWaitForDriverElement(By locator, TimeSpan timeout, IWebDriver appDriver)
         {
             var wait = new WebDriverWait(appDriver, timeout);
-            wait.Until(driver => driver.FindElement(by) != null);
+            wait.Until(driver => driver.FindElement(locator) != null);
         }
     }
 }

--- a/src/Legerity.Core/Pages/BasePage.cs
+++ b/src/Legerity.Core/Pages/BasePage.cs
@@ -40,6 +40,17 @@ namespace Legerity.Pages
         }
 
         /// <summary>
+        /// Gets the instance of the started application.
+        /// <para>
+        /// The <see cref="App"/> instance serves as base for the drivers and can be referenced for basic Selenium functions.
+        /// </para>
+        /// <para>
+        /// This could be a <see cref="WindowsDriver{W}"/>, <see cref="AndroidDriver{W}"/>, <see cref="IOSDriver{W}"/>, or web driver.
+        /// </para>
+        /// </summary>
+        public RemoteWebDriver App => AppManager.App;
+
+        /// <summary>
         /// Gets the instance of the started Windows application.
         /// </summary>
         protected WindowsDriver<WindowsElement> WindowsApp => AppManager.WindowsApp;
@@ -58,17 +69,6 @@ namespace Legerity.Pages
         /// Gets the instance of the started web application.
         /// </summary>
         protected RemoteWebDriver WebApp => AppManager.WebApp;
-
-        /// <summary>
-        /// Gets the instance of the started application.
-        /// <para>
-        /// The <see cref="App"/> instance serves as base for the drivers and can be referenced for basic Selenium functions.
-        /// </para>
-        /// <para>
-        /// This could be a <see cref="WindowsDriver{W}"/>, <see cref="AndroidDriver{W}"/>, <see cref="IOSDriver{W}"/>, or web driver.
-        /// </para>
-        /// </summary>
-        protected RemoteWebDriver App => AppManager.App;
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/src/Legerity.IOS/Elements/IOSElementWrapper.cs
+++ b/src/Legerity.IOS/Elements/IOSElementWrapper.cs
@@ -37,48 +37,48 @@ namespace Legerity.IOS.Elements
         /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
-        /// <param name="query">The query to find a specific element.</param>
+        /// <param name="locator">The locator to find a specific element.</param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
-        protected void VerifyDriverElementShown(By query, TimeSpan? timeout)
+        protected void VerifyDriverElementShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Driver.FindElement(query) == null)
+                if (this.Driver.FindElement(locator) == null)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElement(query) != null);
+                wait.Until(driver => driver.FindElement(locator) != null);
             }
         }
 
         /// <summary>
         /// Determines whether the specified elements are shown with the specified timeout.
         /// </summary>
-        /// <param name="query">
-        /// The query to find a collection of elements.
+        /// <param name="locator">
+        /// The locator to find a collection of elements.
         /// </param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
-        protected void VerifyDriverElementsShown(By query, TimeSpan? timeout)
+        protected void VerifyDriverElementsShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Driver.FindElements(query).Count == 0)
+                if (this.Driver.FindElements(locator).Count == 0)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElements(query).Count != 0);
+                wait.Until(driver => driver.FindElements(locator).Count != 0);
             }
         }
     }

--- a/src/Legerity.MADE/DropDownList.cs
+++ b/src/Legerity.MADE/DropDownList.cs
@@ -12,8 +12,6 @@ namespace Legerity.Windows.Elements.MADE
     /// </summary>
     public class DropDownList : WindowsElementWrapper
     {
-        private readonly By dropDownContentQuery = ByExtensions.AutomationId("DropDownContent");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DropDownList"/> class.
         /// </summary>
@@ -28,7 +26,7 @@ namespace Legerity.Windows.Elements.MADE
         /// <summary>
         /// Gets the <see cref="ListView"/> element associated with the drop down content.
         /// </summary>
-        public ListView DropDown => this.Element.FindElement(this.dropDownContentQuery);
+        public ListView DropDown => this.Element.FindElement(ByExtensions.AutomationId("DropDownContent"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="DropDownList"/> without direct casting.

--- a/src/Legerity.MADE/InputValidator.cs
+++ b/src/Legerity.MADE/InputValidator.cs
@@ -11,8 +11,6 @@ namespace Legerity.Windows.Elements.MADE
     /// </summary>
     public class InputValidator : WindowsElementWrapper
     {
-        private readonly By validationFeedbackQuery = ByExtensions.AutomationId("ValidatorFeedbackMessage");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InputValidator"/> class.
         /// </summary>
@@ -27,7 +25,7 @@ namespace Legerity.Windows.Elements.MADE
         /// <summary>
         /// Gets the <see cref="TextBlock"/> associated with the validation feedback message.
         /// </summary>
-        public TextBlock ValidationFeedback => this.Element.FindElement(this.validationFeedbackQuery);
+        public TextBlock ValidationFeedback => this.Element.FindElement(ByExtensions.AutomationId("ValidatorFeedbackMessage"));
 
         /// <summary>
         /// Gets the validation feedback message associated with the <see cref="ValidationFeedback"/> element.
@@ -63,13 +61,13 @@ namespace Legerity.Windows.Elements.MADE
         }
 
         /// <summary>
-        /// Retrieves the input element with the given query.
+        /// Retrieves the input element with the given locator.
         /// </summary>
-        /// <param name="query">The query to find the input element.</param>
+        /// <param name="locator">The locator to find the input element.</param>
         /// <returns>The <see cref="AppiumWebElement"/> if found; otherwise, throws <see cref="WebDriverException"/>.</returns>
-        public AppiumWebElement Input(By query)
+        public AppiumWebElement Input(By locator)
         {
-            return this.Element.FindElement(query);
+            return this.Element.FindElement(locator);
         }
 
         /// <summary>

--- a/src/Legerity.Telerik.Uwp/RadAutoCompleteBox.cs
+++ b/src/Legerity.Telerik.Uwp/RadAutoCompleteBox.cs
@@ -12,9 +12,7 @@ namespace Legerity.Windows.Elements.Telerik
     /// </summary>
     public class RadAutoCompleteBox : WindowsElementWrapper
     {
-        private readonly By textBoxQuery = By.ClassName("TextBox");
-
-        private readonly By listBoxQuery = ByExtensions.AutomationId("PART_SuggestionsControl");
+        private readonly By suggestionsControlLocator = ByExtensions.AutomationId("PART_SuggestionsControl");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RadAutoCompleteBox"/> class.
@@ -30,7 +28,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Gets the element associated with the text box.
         /// </summary>
-        public TextBox TextBox => this.Element.FindElement(this.textBoxQuery);
+        public TextBox TextBox => this.Element.FindElement(By.ClassName("TextBox"));
 
         /// <summary>
         /// Gets the value of the auto-suggest box.
@@ -83,9 +81,9 @@ namespace Legerity.Windows.Elements.Telerik
         {
             this.SetText(value);
 
-            this.VerifyElementShown(this.listBoxQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementShown(this.suggestionsControlLocator, TimeSpan.FromSeconds(2));
 
-            ListBox suggestionList = this.Element.FindElement(this.listBoxQuery);
+            ListBox suggestionList = this.Element.FindElement(this.suggestionsControlLocator);
             suggestionList.ClickItem(suggestion);
         }
 

--- a/src/Legerity.WCT/BladeView.cs
+++ b/src/Legerity.WCT/BladeView.cs
@@ -12,8 +12,6 @@ namespace Legerity.Windows.Elements.WCT
     /// </summary>
     public class BladeView : WindowsElementWrapper
     {
-        private readonly By bladeViewItemQuery = By.ClassName("BladeItem");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BladeView"/> class.
         /// </summary>
@@ -29,7 +27,7 @@ namespace Legerity.Windows.Elements.WCT
         /// Gets the UI components associated with the child blades.
         /// </summary>
         public IEnumerable<BladeViewItem> Blades =>
-            this.Element.FindElements(this.bladeViewItemQuery)
+            this.Element.FindElements(By.ClassName("BladeItem"))
                 .Select(element => new BladeViewItem(this, element as WindowsElement));
 
         /// <summary>

--- a/src/Legerity.WCT/BladeViewItem.cs
+++ b/src/Legerity.WCT/BladeViewItem.cs
@@ -3,7 +3,6 @@ namespace Legerity.Windows.Elements.WCT
     using System;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Extensions;
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
 
     /// <summary>
@@ -11,10 +10,6 @@ namespace Legerity.Windows.Elements.WCT
     /// </summary>
     public class BladeViewItem : WindowsElementWrapper
     {
-        private readonly By enlargeButtonQuery = ByExtensions.AutomationId("EnlargeButton");
-
-        private readonly By closeButtonQuery = ByExtensions.AutomationId("CloseButton");
-
         private readonly WeakReference parentBladeViewReference;
 
         /// <summary>
@@ -57,12 +52,12 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the <see cref="Button"/> element associated with the blade enlarge option.
         /// </summary>
-        public Button EnlargeButton => this.Element.FindElement(this.enlargeButtonQuery);
+        public Button EnlargeButton => this.Element.FindElement(ByExtensions.AutomationId("EnlargeButton"));
 
         /// <summary>
         /// Gets the <see cref="Button"/> element associated with the blade close option.
         /// </summary>
-        public Button CloseButton => this.Element.FindElement(this.closeButtonQuery);
+        public Button CloseButton => this.Element.FindElement(ByExtensions.AutomationId("CloseButton"));
 
         /// <summary>
         /// Closes the blade item.

--- a/src/Legerity.WCT/Carousel.cs
+++ b/src/Legerity.WCT/Carousel.cs
@@ -14,7 +14,7 @@ namespace Legerity.Windows.Elements.WCT
     /// </summary>
     public class Carousel : WindowsElementWrapper
     {
-        private readonly By carouselItemQuery = By.ClassName("CarouselItem");
+        private readonly By carouselItemLocator = By.ClassName("CarouselItem");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Carousel"/> class.
@@ -30,7 +30,7 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the collection of items associated with the carousel.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.carouselItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.carouselItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
@@ -82,7 +82,7 @@ namespace Legerity.Windows.Elements.WCT
         /// </param>
         public void SelectItem(string name)
         {
-            this.VerifyElementsShown(this.carouselItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.carouselItemLocator, TimeSpan.FromSeconds(2));
 
             int index = this.Items.IndexOf(this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name)));
             int selectedIndex = this.SelectedIndex;
@@ -108,7 +108,7 @@ namespace Legerity.Windows.Elements.WCT
                     "Cannot select an element that is outside the range of items available.");
             }
 
-            this.VerifyElementsShown(this.carouselItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.carouselItemLocator, TimeSpan.FromSeconds(2));
 
             int selectedIndex = this.SelectedIndex;
             while (Math.Abs(index - selectedIndex) > double.Epsilon)

--- a/src/Legerity.WCT/Expander.cs
+++ b/src/Legerity.WCT/Expander.cs
@@ -2,7 +2,6 @@ namespace Legerity.Windows.Elements.WCT
 {
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Extensions;
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -12,8 +11,6 @@ namespace Legerity.Windows.Elements.WCT
     public class Expander : WindowsElementWrapper
     {
         private const string ToggleOnValue = "1";
-
-        private readonly By toggleButtonQuery = ByExtensions.AutomationId("PART_ExpanderToggleButton");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Expander"/> class.
@@ -31,7 +28,7 @@ namespace Legerity.Windows.Elements.WCT
         /// </summary>
         public bool IsExpanded => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
 
-        private ToggleButton ToggleButton => this.Element.FindElement(this.toggleButtonQuery);
+        private ToggleButton ToggleButton => this.Element.FindElement(ByExtensions.AutomationId("PART_ExpanderToggleButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Expander"/> without direct casting.

--- a/src/Legerity.WCT/InAppNotification.cs
+++ b/src/Legerity.WCT/InAppNotification.cs
@@ -3,7 +3,6 @@ namespace Legerity.Windows.Elements.WCT
     using System.Linq;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Extensions;
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -12,8 +11,6 @@ namespace Legerity.Windows.Elements.WCT
     /// </summary>
     public class InAppNotification : WindowsElementWrapper
     {
-        private readonly By dismissButtonQuery = ByExtensions.AutomationId("PART_DismissButton");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InAppNotification"/> class.
         /// </summary>
@@ -28,7 +25,7 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the dismiss button.
         /// </summary>
-        public virtual Button DismissButton => this.Element.FindElement(this.dismissButtonQuery);
+        public virtual Button DismissButton => this.Element.FindElement(ByExtensions.AutomationId("PART_DismissButton"));
 
         /// <summary>
         /// Gets the message displayed.

--- a/src/Legerity.Web/Elements/Core/List.cs
+++ b/src/Legerity.Web/Elements/Core/List.cs
@@ -10,8 +10,6 @@ namespace Legerity.Web.Elements.Core
     /// </summary>
     public class List : WebElementWrapper
     {
-        private readonly By listItemQuery = By.TagName("li");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="List"/> class.
         /// </summary>
@@ -37,7 +35,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the list.
         /// </summary>
-        public ReadOnlyCollection<IWebElement> Items => this.Element.FindElements(this.listItemQuery);
+        public ReadOnlyCollection<IWebElement> Items => this.Element.FindElements(By.TagName("li"));
 
         /// <summary>
         /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="List"/> without direct casting.

--- a/src/Legerity.Web/Elements/Core/Select.cs
+++ b/src/Legerity.Web/Elements/Core/Select.cs
@@ -12,8 +12,6 @@ namespace Legerity.Web.Elements.Core
     /// </summary>
     public class Select : WebElementWrapper
     {
-        private readonly By selectItemQuery = By.TagName("option");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Select"/> class.
         /// </summary>
@@ -44,7 +42,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the select.
         /// </summary>
-        public IEnumerable<Option> Options => this.Element.FindElements(this.selectItemQuery).Select(e => new Option(e));
+        public IEnumerable<Option> Options => this.Element.FindElements(By.TagName("option")).Select(e => new Option(e));
 
         /// <summary>
         /// Gets the selected item when in a single selection state.

--- a/src/Legerity.Web/Elements/WebElementWrapper.cs
+++ b/src/Legerity.Web/Elements/WebElementWrapper.cs
@@ -11,7 +11,7 @@ namespace Legerity.Web.Elements
     /// <summary>
     /// Defines an element wrapper for a <see cref="RemoteWebElement"/>.
     /// </summary>
-    public abstract class WebElementWrapper
+    public abstract class WebElementWrapper : IElementWrapper<RemoteWebElement>
     {
         private readonly WeakReference elementReference;
 
@@ -39,7 +39,7 @@ namespace Legerity.Web.Elements
 
         /// <summary>Gets the original <see cref="RemoteWebElement"/> reference object.</summary>
         public RemoteWebElement Element =>
-            this.elementReference != null && this.elementReference.IsAlive
+            this.elementReference is { IsAlive: true }
                 ? this.elementReference.Target as RemoteWebElement
                 : null;
 
@@ -59,36 +59,36 @@ namespace Legerity.Web.Elements
         public bool IsVisible => this.Element.Displayed;
 
         /// <summary>
-        /// Finds a child element by the specified query.
+        /// Finds a child element by the specified locator.
         /// </summary>
-        /// <param name="by">The query to find a child element by.</param>
+        /// <param name="locator">The locator to find a child element by.</param>
         /// <returns>The <see cref="RemoteWebElement"/>.</returns>
-        public RemoteWebElement FindElement(By by)
+        public RemoteWebElement FindElement(By locator)
         {
-            return this.Element.FindWebElement(by);
+            return this.Element.FindWebElement(locator);
         }
 
         /// <summary>
-        /// Finds a collection of child elements by the specified query.
+        /// Finds a collection of child elements by the specified locator.
         /// </summary>
-        /// <param name="by">The query to find a child element by.</param>
+        /// <param name="locator">The locator to find a child element by.</param>
         /// <returns>The readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public ReadOnlyCollection<RemoteWebElement> FindElements(By by)
+        public ReadOnlyCollection<RemoteWebElement> FindElements(By locator)
         {
-            return this.Element.FindWebElements(by);
+            return this.Element.FindWebElements(locator);
         }
 
         /// <summary>
         /// Determines whether the given element is not shown.
         /// </summary>
-        /// <param name="by">
-        /// The query for the element to locate.
+        /// <param name="locator">
+        /// The locator for the element to locate.
         /// </param>
-        public void VerifyElementNotShown(By by)
+        public void VerifyElementNotShown(By locator)
         {
             try
             {
-                this.VerifyElementShown(by);
+                this.VerifyElementShown(locator);
             }
             catch (ElementNotShownException)
             {
@@ -98,74 +98,74 @@ namespace Legerity.Web.Elements
         /// <summary>
         /// Determines whether the given element is shown.
         /// </summary>
-        /// <param name="by">
-        /// The query for the element to find.
+        /// <param name="locator">
+        /// The locator for the element to find.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.ElementNotShownException">Thrown if the element is not shown.</exception>
-        protected void VerifyElementShown(By by)
+        public void VerifyElementShown(By locator)
         {
-            this.VerifyElementShown(by, null);
+            this.VerifyElementShown(locator, null);
         }
 
         /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
-        /// <param name="query">The query to find a specific element.</param>
+        /// <param name="locator">The locator to find a specific element.</param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.ElementNotShownException">Thrown if the element is not shown.</exception>
-        protected void VerifyElementShown(By query, TimeSpan? timeout)
+        public void VerifyElementShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Element.FindElement(query) == null)
+                if (this.Element.FindElement(locator) == null)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElement(query) != null);
+                wait.Until(driver => driver.FindElement(locator) != null);
             }
         }
 
         /// <summary>
         /// Determines whether the specified elements are shown.
         /// </summary>
-        /// <param name="by">
-        /// The query for the element to find.
+        /// <param name="locator">
+        /// The locator for the element to find.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.ElementNotShownException">Thrown if the elements are not shown.</exception>
-        protected void VerifyElementsShown(By by)
+        public void VerifyElementsShown(By locator)
         {
-            this.VerifyElementsShown(by, null);
+            this.VerifyElementsShown(locator, null);
         }
 
         /// <summary>
         /// Determines whether the specified elements are shown with the specified timeout.
         /// </summary>
-        /// <param name="query">
-        /// The query to find a collection of elements.
+        /// <param name="locator">
+        /// The locator to find a collection of elements.
         /// </param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
         /// <exception cref="T:Legerity.Exceptions.ElementNotShownException">Thrown if the elements are not shown.</exception>
-        protected void VerifyElementsShown(By query, TimeSpan? timeout)
+        public void VerifyElementsShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Element.FindElements(query).Count == 0)
+                if (this.Element.FindElements(locator).Count == 0)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElements(query).Count != 0);
+                wait.Until(driver => driver.FindElements(locator).Count != 0);
             }
         }
     }

--- a/src/Legerity.WinUI/MenuBar.cs
+++ b/src/Legerity.WinUI/MenuBar.cs
@@ -3,6 +3,7 @@ namespace Legerity.Windows.Elements.WinUI
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Legerity.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -12,8 +13,6 @@ namespace Legerity.Windows.Elements.WinUI
     /// </summary>
     public class MenuBar : WindowsElementWrapper
     {
-        private readonly By menuBarItemsQuery = By.ClassName("Microsoft.UI.Xaml.Controls.MenuBarItem");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MenuBar"/> class.
         /// </summary>
@@ -29,7 +28,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// Gets the UI components associated with the menu items.
         /// </summary>
         public IEnumerable<MenuBarItem> MenuItems =>
-            this.Element.FindElements(this.menuBarItemsQuery)
+            this.Element.FindElements(By.ClassName("Microsoft.UI.Xaml.Controls.MenuBarItem"))
                 .Select(element => new MenuBarItem(this, element as WindowsElement));
 
         /// <summary>
@@ -72,7 +71,7 @@ namespace Legerity.Windows.Elements.WinUI
         public MenuBarItem ClickOption(string name)
         {
             MenuBarItem item = this.MenuItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name")
+                element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
             item.Click();
             return item;

--- a/src/Legerity.WinUI/MenuBarItem.cs
+++ b/src/Legerity.WinUI/MenuBarItem.cs
@@ -3,6 +3,7 @@ namespace Legerity.Windows.Elements.WinUI
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
@@ -12,10 +13,6 @@ namespace Legerity.Windows.Elements.WinUI
     /// </summary>
     public class MenuBarItem : WindowsElementWrapper
     {
-        private readonly By menuFlyoutItemQuery = By.ClassName("MenuFlyoutItem");
-
-        private readonly By menuFlyoutSubItemQuery = By.ClassName("MenuFlyoutSubItem");
-
         private readonly WeakReference parentMenuBarReference;
 
         /// <summary>
@@ -85,7 +82,7 @@ namespace Legerity.Windows.Elements.WinUI
         public MenuFlyoutItem ClickChildOption(string name)
         {
             MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name")
+                element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
             item.Click();
             return item;
@@ -99,7 +96,7 @@ namespace Legerity.Windows.Elements.WinUI
         public MenuFlyoutSubItem ClickChildSubOption(string name)
         {
             MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name")
+                element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
             item.Click();
             return item;
@@ -108,14 +105,14 @@ namespace Legerity.Windows.Elements.WinUI
         private IEnumerable<MenuFlyoutItem> GetChildMenuItems()
         {
             return this.Driver.FindElement(By.ClassName("MenuFlyout"))
-                .FindElements(this.menuFlyoutItemQuery).Select(
+                .FindElements(By.ClassName(nameof(MenuFlyoutItem))).Select(
                     element => new MenuFlyoutItem(element as WindowsElement));
         }
 
         private IEnumerable<MenuFlyoutSubItem> GetChildMenuSubItems()
         {
             return this.Driver.FindElement(By.ClassName("MenuFlyout"))
-                .FindElements(this.menuFlyoutSubItemQuery).Select(
+                .FindElements(By.ClassName(nameof(MenuFlyoutSubItem))).Select(
                     element => new MenuFlyoutSubItem(element as WindowsElement));
         }
     }

--- a/src/Legerity.WinUI/NavigationView.cs
+++ b/src/Legerity.WinUI/NavigationView.cs
@@ -3,7 +3,7 @@ namespace Legerity.Windows.Elements.WinUI
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Extensions;
 
@@ -16,18 +16,6 @@ namespace Legerity.Windows.Elements.WinUI
     /// </summary>
     public class NavigationView : WindowsElementWrapper
     {
-        private readonly By paneRootQuery = ByExtensions.AutomationId("PaneRoot");
-
-        private readonly By menuItemsHostQuery = ByExtensions.AutomationId("MenuItemsHost");
-
-        private readonly By navigationViewItemQuery = By.ClassName("Microsoft.UI.Xaml.Controls.NavigationViewItem");
-
-        private readonly By settingsMenuItemQuery = ByExtensions.AutomationId("SettingsItem");
-
-        private readonly By togglePaneButtonItemQuery = ByExtensions.AutomationId("TogglePaneButton");
-
-        private readonly By navigationViewBackButtonQuery = ByExtensions.AutomationId("NavigationViewBackButton");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NavigationView"/> class.
         /// </summary>
@@ -42,39 +30,39 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI component associated with displaying the menu items.
         /// </summary>
-        public AppiumWebElement MenuItemsView => this.Element.FindElement(this.menuItemsHostQuery);
+        public AppiumWebElement MenuItemsView => this.Element.FindElement(ByExtensions.AutomationId("MenuItemsHost"));
 
         /// <summary>
         /// Gets the UI components associated with the menu items.
         /// </summary>
         public IEnumerable<NavigationViewItem> MenuItems =>
-            this.MenuItemsView.FindElements(this.navigationViewItemQuery)
+            this.MenuItemsView.FindElements(By.ClassName("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
                 .Select(element => new NavigationViewItem(this, element as WindowsElement));
 
         /// <summary>
         /// Gets the UI component associated with the settings menu item.
         /// </summary>
-        public AppiumWebElement SettingsMenuItem => this.Element.FindElement(this.settingsMenuItemQuery);
+        public AppiumWebElement SettingsMenuItem => this.Element.FindElement(ByExtensions.AutomationId("SettingsItem"));
 
         /// <summary>
         /// Gets the UI component associated with the navigation pane toggle button.
         /// </summary>
-        public Button ToggleNavigationPaneButton => this.Element.FindElement(this.togglePaneButtonItemQuery);
+        public Button ToggleNavigationPaneButton => this.Element.FindElement(ByExtensions.AutomationId("TogglePaneButton"));
 
         /// <summary>
         /// Gets the UI component associated with the navigation back button.
         /// </summary>
-        public Button BackButton => this.Element.FindElement(this.navigationViewBackButtonQuery);
+        public Button BackButton => this.Element.FindElement(ByExtensions.AutomationId("NavigationViewBackButton"));
 
         /// <summary>
         /// Gets a value indicating whether the pane is currently open.
         /// </summary>
-        public bool IsPaneOpen => this.VerifyPaneOpen();
+        public bool IsPaneOpen => this.VerifyPaneOpen(this.ExpectedCompactPaneWidth);
 
         /// <summary>
         /// Gets or sets the expected compact pane width used to determine the pane open state.
         /// </summary>
-        public int ExpectedCompactPaneWidth { get; set; } = 50;
+        public int ExpectedCompactPaneWidth { get; set; } = 72;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="NavigationView"/> without direct casting.
@@ -153,7 +141,7 @@ namespace Legerity.Windows.Elements.WinUI
         public NavigationViewItem ClickMenuOption(string name)
         {
             NavigationViewItem item = this.MenuItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name").Equals(name, StringComparison.CurrentCultureIgnoreCase));
+                element => element.GetName().Equals(name, StringComparison.CurrentCultureIgnoreCase));
             item.Click();
             return item;
         }
@@ -166,11 +154,16 @@ namespace Legerity.Windows.Elements.WinUI
             this.SettingsMenuItem.Click();
         }
 
-        private bool VerifyPaneOpen()
+        /// <summary>
+        /// Determines whether the navigation pane is open based on the specified compact pane width.
+        /// </summary>
+        /// <param name="expectedCompactPaneWidth">The expected compact pane width when closed.</param>
+        /// <returns>True if the pane is open; otherwise, false.</returns>
+        public bool VerifyPaneOpen(int expectedCompactPaneWidth)
         {
-            AppiumWebElement pane = this.Element.FindElement(this.paneRootQuery);
+            AppiumWebElement pane = this.Element.FindElement(ByExtensions.AutomationId("PaneRoot"));
             int paneWidth = pane.Rect.Width;
-            return paneWidth > this.ExpectedCompactPaneWidth;
+            return paneWidth > expectedCompactPaneWidth;
         }
     }
 }

--- a/src/Legerity.WinUI/NavigationViewItem.cs
+++ b/src/Legerity.WinUI/NavigationViewItem.cs
@@ -3,7 +3,7 @@ namespace Legerity.Windows.Elements.WinUI
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using Legerity.Extensions;
     using Legerity.Windows.Extensions;
 
     using OpenQA.Selenium;
@@ -14,7 +14,7 @@ namespace Legerity.Windows.Elements.WinUI
     /// </summary>
     public class NavigationViewItem : WindowsElementWrapper
     {
-        private readonly By navigationViewItemQuery = By.ClassName("Microsoft.UI.Xaml.Controls.NavigationViewItem");
+        private readonly By navigationViewItemLocator = By.ClassName("Microsoft.UI.Xaml.Controls.NavigationViewItem");
 
         private readonly WeakReference parentNavigationViewReference;
 
@@ -90,13 +90,13 @@ namespace Legerity.Windows.Elements.WinUI
 
         /// <summary>Gets the original parent <see cref="NavigationView"/> reference object.</summary>
         public NavigationView ParentNavigationView =>
-            this.parentNavigationViewReference != null && this.parentNavigationViewReference.IsAlive
+            this.parentNavigationViewReference is { IsAlive: true }
                 ? this.parentNavigationViewReference.Target as NavigationView
                 : null;
 
         /// <summary>Gets the original parent <see cref="NavigationViewItem"/> reference object.</summary>
         public NavigationViewItem ParentItem =>
-            this.parentItemReference != null && this.parentItemReference.IsAlive
+            this.parentItemReference is { IsAlive: true }
                 ? this.parentItemReference.Target as NavigationViewItem
                 : null;
 
@@ -125,7 +125,7 @@ namespace Legerity.Windows.Elements.WinUI
         public NavigationViewItem ClickChildOption(string name)
         {
             NavigationViewItem item = this.ChildMenuItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name")
+                element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
             item.Click();
             return item;
@@ -135,15 +135,13 @@ namespace Legerity.Windows.Elements.WinUI
         {
             if (this.ParentNavigationView == null || this.ParentNavigationView.IsPaneOpen)
             {
-                return this.Element.FindElements(this.navigationViewItemQuery).Select(
+                return this.Element.FindElements(this.navigationViewItemLocator).Select(
                     element => new NavigationViewItem(this.ParentNavigationView, this, element as WindowsElement));
             }
-            else
-            {
-                return this.Driver.FindElement(ByExtensions.AutomationId("ChildrenFlyout"))
-                    .FindElements(this.navigationViewItemQuery).Select(
-                        element => new NavigationViewItem(this.ParentNavigationView, this, element as WindowsElement));
-            }
+
+            return this.Driver.FindElement(ByExtensions.AutomationId("ChildrenFlyout"))
+                .FindElements(this.navigationViewItemLocator).Select(
+                    element => new NavigationViewItem(this.ParentNavigationView, this, element as WindowsElement));
         }
     }
 }

--- a/src/Legerity.WinUI/TabView.cs
+++ b/src/Legerity.WinUI/TabView.cs
@@ -16,11 +16,7 @@ namespace Legerity.Windows.Elements.WinUI
     /// </summary>
     public class TabView : WindowsElementWrapper
     {
-        private readonly By tabListViewQuery = ByExtensions.AutomationId("TabListView");
-
-        private readonly By addTabButtonQuery = ByExtensions.AutomationId("AddButton");
-
-        private readonly By closeTabButtonQuery = ByExtensions.AutomationId("CloseButton");
+        private readonly By tabListViewLocator = ByExtensions.AutomationId("TabListView");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TabView"/> class.
@@ -36,7 +32,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the element associated with the add tab button.
         /// </summary>
-        public Button AddTabButton => this.Element.FindElement(this.addTabButtonQuery);
+        public Button AddTabButton => this.Element.FindElement(ByExtensions.AutomationId("AddButton"));
 
         /// <summary>
         /// Gets the collection of items associated with the pivot.
@@ -48,7 +44,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// </summary>
         public AppiumWebElement SelectedItem => this.TabsListView.SelectedItem;
 
-        private ListView TabsListView => this.Element.FindElement(this.tabListViewQuery);
+        private ListView TabsListView => this.Element.FindElement(this.tabListViewLocator);
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="TabView"/> without direct casting.
@@ -83,7 +79,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// </summary>
         public void CreateTab()
         {
-            this.VerifyElementShown(this.tabListViewQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             this.AddTabButton.Click();
         }
 
@@ -95,7 +91,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// </param>
         public void SelectTab(string name)
         {
-            this.VerifyElementShown(this.tabListViewQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
             item.Click();
         }
@@ -106,9 +102,9 @@ namespace Legerity.Windows.Elements.WinUI
         /// <param name="name">The name of the item to close.</param>
         public void CloseTab(string name)
         {
-            this.VerifyElementShown(this.tabListViewQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
-            Button closeButton = item.FindElement(this.closeTabButtonQuery);
+            Button closeButton = item.FindElement(ByExtensions.AutomationId("CloseButton"));
             closeButton.Click();
         }
     }

--- a/src/Legerity.Windows/Elements/Core/AutoSuggestBox.cs
+++ b/src/Legerity.Windows/Elements/Core/AutoSuggestBox.cs
@@ -13,9 +13,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class AutoSuggestBox : WindowsElementWrapper
     {
-        private readonly By suggestionsPopupQuery = ByExtensions.AutomationId("SuggestionsPopup");
-
-        private readonly By textBoxQuery = ByExtensions.AutomationId("TextBox");
+        private readonly By suggestionsPopupLocator = ByExtensions.AutomationId("SuggestionsPopup");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoSuggestBox"/> class.
@@ -31,12 +29,17 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the suggestions popup.
         /// </summary>
-        public AppiumWebElement SuggestionsPopup => this.Element.FindElement(this.suggestionsPopupQuery);
+        public AppiumWebElement SuggestionsPopup => this.Element.FindElement(this.suggestionsPopupLocator);
+
+        /// <summary>
+        /// Gets the element associated with the suggestion list when the <see cref="SuggestionsPopup"/> is shown.
+        /// </summary>
+        public ListView SuggestionList => this.SuggestionsPopup.FindElement(ByExtensions.AutomationId("SuggestionsList"));
 
         /// <summary>
         /// Gets the element associated with the text box.
         /// </summary>
-        public TextBox TextBox => this.Element.FindElement(this.textBoxQuery);
+        public TextBox TextBox => this.Element.FindElement(ByExtensions.AutomationId("TextBox"));
 
         /// <summary>
         /// Gets the value of the auto-suggest box.
@@ -89,10 +92,9 @@ namespace Legerity.Windows.Elements.Core
         {
             this.SetText(value);
 
-            this.VerifyElementShown(this.suggestionsPopupQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementShown(this.suggestionsPopupLocator, TimeSpan.FromSeconds(2));
 
-            ListView suggestionList = this.SuggestionsPopup.FindElement(ByExtensions.AutomationId("SuggestionsList"));
-            suggestionList.ClickItem(suggestion);
+            this.SuggestionList.ClickItem(suggestion);
         }
 
         /// <summary>

--- a/src/Legerity.Windows/Elements/Core/CalendarDatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/CalendarDatePicker.cs
@@ -12,7 +12,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class CalendarDatePicker : WindowsElementWrapper
     {
-        private readonly By calendarPopupQuery = By.XPath(".//*[@ClassName='Popup'][@Name='Popup']");
+        private readonly By calendarPopupLocator = By.XPath(".//*[@ClassName='Popup'][@Name='Popup']");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CalendarDatePicker"/> class.
@@ -29,7 +29,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the element associated with the calendar flyout.
         /// </summary>
         public CalendarView CalendarViewFlyout =>
-            this.Driver.FindElement(this.calendarPopupQuery).FindElement(ByExtensions.AutomationId("CalendarView"));
+            this.Driver.FindElement(this.calendarPopupLocator).FindElement(ByExtensions.AutomationId("CalendarView"));
 
         /// <summary>
         /// Gets the value of the calendar date picker.
@@ -72,7 +72,7 @@ namespace Legerity.Windows.Elements.Core
         {
             this.Element.Click();
 
-            this.VerifyDriverElementShown(this.calendarPopupQuery, TimeSpan.FromSeconds(2));
+            this.VerifyDriverElementShown(this.calendarPopupLocator, TimeSpan.FromSeconds(2));
 
             this.CalendarViewFlyout.SetDate(date);
         }

--- a/src/Legerity.Windows/Elements/Core/CalendarView.cs
+++ b/src/Legerity.Windows/Elements/Core/CalendarView.cs
@@ -5,7 +5,7 @@ namespace Legerity.Windows.Elements.Core
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Threading;
-
+    using Legerity.Extensions;
     using Legerity.Windows.Extensions;
 
     using OpenQA.Selenium;
@@ -17,10 +17,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class CalendarView : WindowsElementWrapper
     {
-        private readonly By monthPaneQuery = ByExtensions.AutomationId("MonthViewScrollViewer");
-
-        private readonly By calendarViewDayItemQuery = By.ClassName("CalendarViewDayItem");
-
         private readonly Dictionary<string, string> months = new Dictionary<string, string>()
                                                           {
                                                               { "January", "01" },
@@ -66,7 +62,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of days associated with the current month in the calendar view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Days => this.Element.FindElements(this.calendarViewDayItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Days => this.Element.FindElements(By.ClassName("CalendarViewDayItem"));
 
         /// <summary>
         /// Gets the value of the calendar view.
@@ -110,7 +106,7 @@ namespace Legerity.Windows.Elements.Core
             string expectedDay = date.ToString("%d");
             string expectedHeader = date.ToString("MMMM yyyy");
 
-            string currentHeader = this.HeaderButton.Element.GetAttribute("Name");
+            string currentHeader = this.HeaderButton.GetName();
             DateTime currentViewDate = this.GetCurrentViewDate(currentHeader);
 
             while (!expectedHeader.Equals(currentHeader, StringComparison.CurrentCultureIgnoreCase))
@@ -126,11 +122,11 @@ namespace Legerity.Windows.Elements.Core
 
                 Thread.Sleep(10);
 
-                currentHeader = this.HeaderButton.Element.GetAttribute("Name");
+                currentHeader = this.HeaderButton.GetName();
             }
 
             AppiumWebElement item = this.Days.FirstOrDefault(
-                element => element.GetAttribute("Name").Equals(expectedDay, StringComparison.CurrentCultureIgnoreCase));
+                element => element.GetName().Equals(expectedDay, StringComparison.CurrentCultureIgnoreCase));
 
             item.Click();
         }

--- a/src/Legerity.Windows/Elements/Core/ComboBox.cs
+++ b/src/Legerity.Windows/Elements/Core/ComboBox.cs
@@ -3,6 +3,7 @@ namespace Legerity.Windows.Elements.Core
     using System;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using Legerity.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -12,7 +13,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class ComboBox : WindowsElementWrapper
     {
-        private readonly By comboBoxItemQuery = By.ClassName("ComboBoxItem");
+        private readonly By comboBoxItemLocator = By.ClassName("ComboBoxItem");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ComboBox"/> class.
@@ -68,20 +69,20 @@ namespace Legerity.Windows.Elements.Core
         {
             this.Element.Click();
 
-            this.VerifyElementsShown(this.comboBoxItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.comboBoxItemLocator, TimeSpan.FromSeconds(2));
 
-            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemQuery);
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemLocator);
 
             AppiumWebElement item = listElements.FirstOrDefault(
-                element => element.GetAttribute("Name").Equals(name, StringComparison.CurrentCultureIgnoreCase));
+                element => element.GetName().Equals(name, StringComparison.CurrentCultureIgnoreCase));
 
             item.Click();
         }
 
         private string GetSelectedItem()
         {
-            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemQuery);
-            return listElements.Count == 1 ? listElements.FirstOrDefault().GetAttribute("Name") : null;
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemLocator);
+            return listElements.Count == 1 ? listElements.FirstOrDefault().GetName() : null;
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/CommandBar.cs
+++ b/src/Legerity.Windows/Elements/Core/CommandBar.cs
@@ -15,11 +15,11 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class CommandBar : WindowsElementWrapper
     {
-        private readonly By secondaryOverflowButtonQuery = ByExtensions.AutomationId("MoreButton");
+        private readonly By moreButtonLocator = ByExtensions.AutomationId("MoreButton");
 
-        private readonly By secondaryOverflowPopupQuery = ByExtensions.AutomationId("OverflowPopup");
+        private readonly By overflowPopupLocator = ByExtensions.AutomationId("OverflowPopup");
 
-        private readonly By appBarButtonItemQuery = By.ClassName("AppBarButton");
+        private readonly By appBarButtonLocator = By.ClassName(nameof(AppBarButton));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandBar"/> class.
@@ -36,7 +36,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the collection of primary buttons.
         /// </summary>
         public IEnumerable<AppBarButton> PrimaryButtons =>
-            this.Element.FindElements(this.appBarButtonItemQuery)
+            this.Element.FindElements(this.appBarButtonLocator)
                 .Select<AppiumWebElement, AppBarButton>(element => element);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Legerity.Windows.Elements.Core
         /// </para>
         /// </summary>
         public IEnumerable<AppBarButton> SecondaryButtons =>
-            this.Driver.FindElement(this.secondaryOverflowPopupQuery).FindElements(this.appBarButtonItemQuery)
+            this.Driver.FindElement(this.overflowPopupLocator).FindElements(this.appBarButtonLocator)
                 .Select<AppiumWebElement, AppBarButton>(element => element);
 
         /// <summary>
@@ -99,12 +99,12 @@ namespace Legerity.Windows.Elements.Core
         /// </param>
         public void ClickSecondaryButton(string name)
         {
-            this.VerifyElementShown(this.secondaryOverflowButtonQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementShown(this.moreButtonLocator, TimeSpan.FromSeconds(2));
 
-            AppBarButton secondaryOverflowButton = this.Element.FindElement(this.secondaryOverflowButtonQuery);
+            AppBarButton secondaryOverflowButton = this.Element.FindElement(this.moreButtonLocator);
             secondaryOverflowButton.Click();
 
-            this.VerifyDriverElementShown(this.secondaryOverflowPopupQuery, TimeSpan.FromSeconds(2));
+            this.VerifyDriverElementShown(this.overflowPopupLocator, TimeSpan.FromSeconds(2));
 
             AppBarButton secondaryButton = this.SecondaryButtons.FirstOrDefault(
                 button => button.Element.VerifyNameOrAutomationIdEquals(name));

--- a/src/Legerity.Windows/Elements/Core/DatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/DatePicker.cs
@@ -3,8 +3,6 @@ namespace Legerity.Windows.Elements.Core
     using System;
 
     using Legerity.Windows.Extensions;
-
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -13,18 +11,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class DatePicker : WindowsElementWrapper
     {
-        private readonly By flyoutQuery = ByExtensions.AutomationId("DatePickerFlyoutPresenter");
-
-        private readonly By daySelectorQuery = ByExtensions.AutomationId("DayLoopingSelector");
-
-        private readonly By monthSelectorQuery = ByExtensions.AutomationId("MonthLoopingSelector");
-
-        private readonly By yearSelectorQuery = ByExtensions.AutomationId("YearLoopingSelector");
-
-        private readonly By acceptButtonQuery = ByExtensions.AutomationId("AcceptButton");
-
-        private readonly By dismissButtonQuery = ByExtensions.AutomationId("DismissButton");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DatePicker"/> class.
         /// </summary>
@@ -74,11 +60,11 @@ namespace Legerity.Windows.Elements.Core
             this.Element.Click();
 
             // Finds the popup and changes the time.
-            WindowsElement popup = this.Driver.FindElement(this.flyoutQuery);
-            popup.FindElement(this.daySelectorQuery).FindElementByName(date.ToString("%d")).Click();
-            popup.FindElement(this.monthSelectorQuery).FindElementByName(date.ToString("MMMM")).Click();
-            popup.FindElement(this.yearSelectorQuery).FindElementByName(date.ToString("yyyy")).Click();
-            popup.FindElement(this.acceptButtonQuery).Click();
+            WindowsElement popup = this.Driver.FindElement(ByExtensions.AutomationId("DatePickerFlyoutPresenter"));
+            popup.FindElement(ByExtensions.AutomationId("DayLoopingSelector")).FindElementByName(date.ToString("%d")).Click();
+            popup.FindElement(ByExtensions.AutomationId("MonthLoopingSelector")).FindElementByName(date.ToString("MMMM")).Click();
+            popup.FindElement(ByExtensions.AutomationId("YearLoopingSelector")).FindElementByName(date.ToString("yyyy")).Click();
+            popup.FindElement(ByExtensions.AutomationId("AcceptButton")).Click();
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/FlipView.cs
+++ b/src/Legerity.Windows/Elements/Core/FlipView.cs
@@ -16,12 +16,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class FlipView : WindowsElementWrapper
     {
-        private readonly By flipViewItemQuery = By.ClassName("FlipViewItem");
-
-        private readonly By nextButtonQuery = ByExtensions.AutomationId("NextButtonHorizontal");
-
-        private readonly By previousButtonQuery = ByExtensions.AutomationId("PreviousButtonHorizontal");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FlipView"/> class.
         /// </summary>
@@ -36,17 +30,17 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the flip view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.flipViewItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(By.ClassName("FlipViewItem"));
 
         /// <summary>
         /// Gets the element associated with the next item button.
         /// </summary>
-        public Button NextButton => this.Element.FindElement(this.nextButtonQuery);
+        public Button NextButton => this.Element.FindElement(ByExtensions.AutomationId("NextButtonHorizontal"));
 
         /// <summary>
         /// Gets the element associated with the previous item button.
         /// </summary>
-        public Button PreviousButton => this.Element.FindElement(this.previousButtonQuery);
+        public Button PreviousButton => this.Element.FindElement(ByExtensions.AutomationId("PreviousButtonHorizontal"));
 
         /// <summary>
         /// Gets the currently selected item.

--- a/src/Legerity.Windows/Elements/Core/FlipViewItem.cs
+++ b/src/Legerity.Windows/Elements/Core/FlipViewItem.cs
@@ -1,0 +1,6 @@
+namespace Legerity.Windows.Elements.Core
+{
+    internal class FlipViewItem
+    {
+    }
+}

--- a/src/Legerity.Windows/Elements/Core/GridView.cs
+++ b/src/Legerity.Windows/Elements/Core/GridView.cs
@@ -14,7 +14,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class GridView : WindowsElementWrapper
     {
-        private readonly By gridViewItemQuery = By.ClassName("GridViewItem");
+        private readonly By gridViewItemLocator = By.ClassName("GridViewItem");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GridView"/> class.
@@ -30,7 +30,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the grid view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.gridViewItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.gridViewItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
@@ -77,7 +77,7 @@ namespace Legerity.Windows.Elements.Core
         /// </param>
         public void ClickItem(string name)
         {
-            this.VerifyElementsShown(this.gridViewItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.gridViewItemLocator, TimeSpan.FromSeconds(2));
 
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
 

--- a/src/Legerity.Windows/Elements/Core/Hub.cs
+++ b/src/Legerity.Windows/Elements/Core/Hub.cs
@@ -10,8 +10,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class Hub : WindowsElementWrapper
     {
-        private readonly By hubSectionItemQuery = By.ClassName("HubSection");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Hub"/> class.
         /// </summary>
@@ -26,7 +24,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the hub.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.hubSectionItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(By.ClassName("HubSection"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Hub"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.ColorFlyoutBase.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.ColorFlyoutBase.cs
@@ -2,7 +2,7 @@ namespace Legerity.Windows.Elements.Core
 {
     using System;
     using System.Linq;
-
+    using Legerity.Extensions;
     using Legerity.Windows.Extensions;
 
     using OpenQA.Selenium;
@@ -19,9 +19,7 @@ namespace Legerity.Windows.Elements.Core
         /// </summary>
         private abstract class InkToolbarColorFlyoutBase : WindowsElementWrapper
         {
-            private readonly By colorGridViewQuery = ByExtensions.AutomationId("PenColorPalette");
-
-            private readonly By sizeSliderQuery = ByExtensions.AutomationId("PenStrokeWidthSlider");
+            private readonly By penColorPaletteLocator = ByExtensions.AutomationId("PenColorPalette");
 
             /// <summary>
             /// Initializes a new instance of the <see cref="InkToolbarColorFlyoutBase"/> class.
@@ -37,17 +35,17 @@ namespace Legerity.Windows.Elements.Core
             /// <summary>
             /// Gets the element associated with the color grid.
             /// </summary>
-            public GridView ColorGridView => this.Driver.FindElement(this.colorGridViewQuery);
+            public GridView ColorGridView => this.Driver.FindElement(this.penColorPaletteLocator);
 
             /// <summary>
             /// Gets the element associated with the size of the ink.
             /// </summary>
-            public Slider SizeSlider => this.Driver.FindElement(this.sizeSliderQuery);
+            public Slider SizeSlider => this.Driver.FindElement(ByExtensions.AutomationId("PenStrokeWidthSlider"));
 
             /// <summary>
             /// Gets the currently selected color.
             /// </summary>
-            public string SelectedColor => this.GetSelectedColor().GetAttribute("Name");
+            public string SelectedColor => this.GetSelectedColor().GetName();
 
             /// <summary>
             /// Gets the currently selected size.
@@ -65,7 +63,7 @@ namespace Legerity.Windows.Elements.Core
 
             private AppiumWebElement GetSelectedColor()
             {
-                this.VerifyElementShown(this.colorGridViewQuery, TimeSpan.FromSeconds(2));
+                this.VerifyElementShown(this.penColorPaletteLocator, TimeSpan.FromSeconds(2));
 
                 return this.ColorGridView.Items.FirstOrDefault(
                     i => i.GetAttribute("SelectionItem.IsSelected").Equals(

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.cs
@@ -12,11 +12,11 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public partial class InkToolbar : WindowsElementWrapper
     {
-        private readonly By ballpointPenFlyoutQuery = By.Name("Ballpoint pen flyout");
+        private readonly By ballpointPenFlyoutLocator = By.Name("Ballpoint pen flyout");
 
-        private readonly By pencilFlyoutQuery = By.Name("Pencil flyout");
+        private readonly By pencilFlyoutLocator = By.Name("Pencil flyout");
 
-        private readonly By highlighterFlyoutQuery = By.Name("Highlighter flyout");
+        private readonly By highlighterFlyoutLocator = By.Name("Highlighter flyout");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InkToolbar"/> class.
@@ -69,11 +69,11 @@ namespace Legerity.Windows.Elements.Core
             this.Element.FindElement(ByExtensions.AutomationId("InkToolbarStencilButton"));
 
         private InkToolbarBallpointPenFlyout BallpointPenFlyout =>
-            this.Driver.FindElement(this.ballpointPenFlyoutQuery);
+            this.Driver.FindElement(this.ballpointPenFlyoutLocator);
 
-        private InkToolbarPencilFlyout PencilFlyout => this.Driver.FindElement(this.pencilFlyoutQuery);
+        private InkToolbarPencilFlyout PencilFlyout => this.Driver.FindElement(this.pencilFlyoutLocator);
 
-        private InkToolbarHighlighterFlyout HighlighterFlyout => this.Driver.FindElement(this.highlighterFlyoutQuery);
+        private InkToolbarHighlighterFlyout HighlighterFlyout => this.Driver.FindElement(this.highlighterFlyoutLocator);
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InkToolbar"/> without direct casting.
@@ -122,7 +122,7 @@ namespace Legerity.Windows.Elements.Core
             this.SelectBallpointPen();
 
             this.BallpointPenButton.Click();
-            this.VerifyDriverElementShown(this.ballpointPenFlyoutQuery, TimeSpan.FromSeconds(2));
+            this.VerifyDriverElementShown(this.ballpointPenFlyoutLocator, TimeSpan.FromSeconds(2));
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace Legerity.Windows.Elements.Core
             this.SelectPencil();
 
             this.PencilButton.Click();
-            this.VerifyDriverElementShown(this.pencilFlyoutQuery, TimeSpan.FromSeconds(2));
+            this.VerifyDriverElementShown(this.pencilFlyoutLocator, TimeSpan.FromSeconds(2));
         }
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Legerity.Windows.Elements.Core
             this.SelectHighlighter();
 
             this.HighlighterButton.Click();
-            this.VerifyDriverElementShown(this.highlighterFlyoutQuery, TimeSpan.FromSeconds(2));
+            this.VerifyDriverElementShown(this.highlighterFlyoutLocator, TimeSpan.FromSeconds(2));
         }
 
         /// <summary>

--- a/src/Legerity.Windows/Elements/Core/ListBox.cs
+++ b/src/Legerity.Windows/Elements/Core/ListBox.cs
@@ -14,7 +14,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class ListBox : WindowsElementWrapper
     {
-        private readonly By listBoxItemQuery = By.ClassName("ListBoxItem");
+        private readonly By listBoxItemLocator = By.ClassName("ListBoxItem");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ListBox"/> class.
@@ -30,7 +30,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the list box.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listBoxItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listBoxItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
@@ -77,7 +77,7 @@ namespace Legerity.Windows.Elements.Core
         /// </param>
         public void ClickItem(string name)
         {
-            this.VerifyElementsShown(this.listBoxItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.listBoxItemLocator, TimeSpan.FromSeconds(2));
 
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
 

--- a/src/Legerity.Windows/Elements/Core/ListView.cs
+++ b/src/Legerity.Windows/Elements/Core/ListView.cs
@@ -14,7 +14,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class ListView : WindowsElementWrapper
     {
-        private readonly By listViewItemQuery = By.ClassName("ListViewItem");
+        private readonly By listViewItemLocator = By.ClassName("ListViewItem");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ListView"/> class.
@@ -30,7 +30,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the list view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listViewItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listViewItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
@@ -77,7 +77,7 @@ namespace Legerity.Windows.Elements.Core
         /// </param>
         public void ClickItem(string name)
         {
-            this.VerifyElementsShown(this.listViewItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.listViewItemLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
             item.Click();
         }

--- a/src/Legerity.Windows/Elements/Core/MenuFlyoutSubItem.cs
+++ b/src/Legerity.Windows/Elements/Core/MenuFlyoutSubItem.cs
@@ -3,6 +3,7 @@ namespace Legerity.Windows.Elements.Core
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Legerity.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -11,10 +12,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class MenuFlyoutSubItem : WindowsElementWrapper
     {
-        private readonly By menuFlyoutItemQuery = By.ClassName("MenuFlyoutItem");
-
-        private readonly By menuFlyoutSubItemQuery = By.ClassName("MenuFlyoutSubItem");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MenuFlyoutSubItem"/> class.
         /// </summary>
@@ -56,7 +53,7 @@ namespace Legerity.Windows.Elements.Core
         public MenuFlyoutItem ClickChildOption(string name)
         {
             MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name")
+                element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
 
             item.Click();
@@ -71,7 +68,7 @@ namespace Legerity.Windows.Elements.Core
         public MenuFlyoutSubItem ClickChildSubOption(string name)
         {
             MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
-                element => element.Element.GetAttribute("Name")
+                element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
             item.Click();
             return item;
@@ -80,14 +77,14 @@ namespace Legerity.Windows.Elements.Core
         private IEnumerable<MenuFlyoutItem> GetChildMenuItems()
         {
             return this.Driver.FindElement(By.ClassName("MenuFlyout"))
-                .FindElements(this.menuFlyoutItemQuery).Select(
+                .FindElements(By.ClassName(nameof(MenuFlyoutItem))).Select(
                     element => new MenuFlyoutItem(element as WindowsElement));
         }
 
         private IEnumerable<MenuFlyoutSubItem> GetChildMenuSubItems()
         {
             return this.Driver.FindElement(By.ClassName("MenuFlyout"))
-                .FindElements(this.menuFlyoutSubItemQuery).Select(
+                .FindElements(By.ClassName(nameof(MenuFlyoutSubItem))).Select(
                     element => new MenuFlyoutSubItem(element as WindowsElement));
         }
     }

--- a/src/Legerity.Windows/Elements/Core/Pivot.cs
+++ b/src/Legerity.Windows/Elements/Core/Pivot.cs
@@ -14,7 +14,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class Pivot : WindowsElementWrapper
     {
-        private readonly By pivotItemQuery = By.ClassName("PivotItem");
+        private readonly By pivotItemLocator = By.ClassName("PivotItem");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Pivot"/> class.
@@ -30,7 +30,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the pivot.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.pivotItemQuery);
+        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.pivotItemLocator);
 
         /// <summary>
         /// Gets the currently selected item.
@@ -77,7 +77,7 @@ namespace Legerity.Windows.Elements.Core
         /// </param>
         public void ClickItem(string name)
         {
-            this.VerifyElementsShown(this.pivotItemQuery, TimeSpan.FromSeconds(2));
+            this.VerifyElementsShown(this.pivotItemLocator, TimeSpan.FromSeconds(2));
 
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
 

--- a/src/Legerity.Windows/Elements/Core/TimePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/TimePicker.cs
@@ -1,10 +1,7 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
-
     using Legerity.Windows.Extensions;
-
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -13,16 +10,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class TimePicker : WindowsElementWrapper
     {
-        private readonly By flyoutQuery = ByExtensions.AutomationId("TimePickerFlyoutPresenter");
-
-        private readonly By hourSelectorQuery = ByExtensions.AutomationId("HourLoopingSelector");
-
-        private readonly By minuteSelectorQuery = ByExtensions.AutomationId("MinuteLoopingSelector");
-
-        private readonly By acceptButtonQuery = ByExtensions.AutomationId("AcceptButton");
-
-        private readonly By dismissButtonQuery = ByExtensions.AutomationId("DismissButton");
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TimePicker"/> class.
         /// </summary>
@@ -74,10 +61,10 @@ namespace Legerity.Windows.Elements.Core
             this.Element.Click();
 
             // Finds the popup and changes the time.
-            WindowsElement popup = this.Driver.FindElement(this.flyoutQuery);
-            popup.FindElement(this.hourSelectorQuery).FindElementByName(time.ToString("%h")).Click();
-            popup.FindElement(this.minuteSelectorQuery).FindElementByName(time.ToString("mm")).Click();
-            popup.FindElement(this.acceptButtonQuery).Click();
+            WindowsElement popup = this.Driver.FindElement(ByExtensions.AutomationId("TimePickerFlyoutPresenter"));
+            popup.FindElement(ByExtensions.AutomationId("HourLoopingSelector")).FindElementByName(time.ToString("%h")).Click();
+            popup.FindElement(ByExtensions.AutomationId("MinuteLoopingSelector")).FindElementByName(time.ToString("mm")).Click();
+            popup.FindElement(ByExtensions.AutomationId("AcceptButton")).Click();
         }
     }
 }

--- a/src/Legerity.Windows/Elements/WindowsElementWrapper.cs
+++ b/src/Legerity.Windows/Elements/WindowsElementWrapper.cs
@@ -1,7 +1,6 @@
 namespace Legerity.Windows.Elements
 {
     using System;
-
     using Legerity.Exceptions;
 
     using OpenQA.Selenium;
@@ -37,48 +36,48 @@ namespace Legerity.Windows.Elements
         /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
-        /// <param name="query">The query to find a specific element.</param>
+        /// <param name="locator">The locator to find a specific element.</param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
-        protected void VerifyDriverElementShown(By query, TimeSpan? timeout)
+        protected void VerifyDriverElementShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Driver.FindElement(query) == null)
+                if (this.Driver.FindElement(locator) == null)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElement(query) != null);
+                wait.Until(driver => driver.FindElement(locator) != null);
             }
         }
 
         /// <summary>
         /// Determines whether the specified elements are shown with the specified timeout.
         /// </summary>
-        /// <param name="query">
-        /// The query to find a collection of elements.
+        /// <param name="locator">
+        /// The locator to find a collection of elements.
         /// </param>
         /// <param name="timeout">
-        /// The amount of time the driver should wait when searching for the <paramref name="query"/> if it is not immediately present.
+        /// The amount of time the driver should wait when searching for the <paramref name="locator"/> if it is not immediately present.
         /// </param>
-        protected void VerifyDriverElementsShown(By query, TimeSpan? timeout)
+        protected void VerifyDriverElementsShown(By locator, TimeSpan? timeout)
         {
             if (timeout == null)
             {
-                if (this.Driver.FindElements(query).Count == 0)
+                if (this.Driver.FindElements(locator).Count == 0)
                 {
-                    throw new ElementNotShownException(query.ToString());
+                    throw new ElementNotShownException(locator.ToString());
                 }
             }
             else
             {
                 var wait = new WebDriverWait(this.Driver, timeout.Value);
-                wait.Until(driver => driver.FindElements(query).Count != 0);
+                wait.Until(driver => driver.FindElements(locator).Count != 0);
             }
         }
     }

--- a/src/Legerity.Windows/Extensions/AttributeExtensions.cs
+++ b/src/Legerity.Windows/Extensions/AttributeExtensions.cs
@@ -1,0 +1,35 @@
+namespace Legerity.Windows.Extensions
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a collection of extensions for retrieving element attributes.
+    /// </summary>
+    public static class AttributeExtensions
+    {
+        /// <summary>
+        /// Retrieves the AutomationId attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve an AutomationId from.</param>
+        /// <returns>The AutomationId of the element.</returns>
+        public static string GetAutomationId(this IWebElement element)
+        {
+            return element.GetAttribute("AutomationId");
+        }
+
+        /// <summary>
+        /// Retrieves the AutomationId attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve an AutomationId from.</param>
+        /// <returns>The AutomationId of the element.</returns>
+        public static string GetAutomationId<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetAutomationId(element.Element);
+        }
+    }
+}

--- a/src/Legerity.Windows/Extensions/ByExtensions.cs
+++ b/src/Legerity.Windows/Extensions/ByExtensions.cs
@@ -10,13 +10,13 @@ namespace Legerity.Windows.Extensions
     public static class ByExtensions
     {
         /// <summary>
-        /// Provides a query for retrieving an element by a Windows AutomationId.
+        /// Provides a locator for retrieving an element by a Windows AutomationId.
         /// </summary>
         /// <param name="automationId">
         /// The automation ID of the element to retrieve.
         /// </param>
         /// <returns>
-        /// The <see cref="By"/> query for the Windows element.
+        /// The <see cref="By"/> locator for the Windows element.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// Thrown if the <paramref name="automationId"/> is null.

--- a/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Extensions
 {
     using System;
+    using Legerity.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -50,8 +51,8 @@ namespace Legerity.Windows.Extensions
         /// </returns>
         public static bool VerifyNameOrAutomationIdEquals(this AppiumWebElement element, string compare)
         {
-            string name = element.GetAttribute("Name");
-            string automationId = element.GetAttribute("AutomationId");
+            string name = element.GetName();
+            string automationId = element.GetAutomationId();
 
             return string.Equals(compare, name, StringComparison.CurrentCultureIgnoreCase) || string.Equals(
                        compare,
@@ -73,8 +74,8 @@ namespace Legerity.Windows.Extensions
         /// </returns>
         public static bool VerifyNameOrAutomationIdEquals(this WindowsElement element, string compare)
         {
-            string name = element.GetAttribute("Name");
-            string automationId = element.GetAttribute("AutomationId");
+            string name = element.GetName();
+            string automationId = element.GetAutomationId();
 
             return string.Equals(compare, name, StringComparison.CurrentCultureIgnoreCase) || string.Equals(
                        compare,


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to introduce `WaitUntil` conditions for the driver, elements, element wrappers, and page objects. 

The extension methods provide the capability to wait on the driver until a condition has been met with a timeout. 

The changes also include a set of common, predefined set of conditions that can be used in conjunction with the methods.

A consistency change has also been made in the naming of By locators across the framework to ensure that all parameters are locator, and the term **query** has been updated to **locator**.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
