### PR TITLE
#82 - Added wait until on application start

### DIFF
--- a/src/Legerity.Core/AppManager.cs
+++ b/src/Legerity.Core/AppManager.cs
@@ -3,11 +3,13 @@ namespace Legerity
     using System;
     using Legerity.Android;
     using Legerity.Exceptions;
+    using Legerity.Extensions;
     using Legerity.Helpers;
     using Legerity.IOS;
     using Legerity.Web;
     using Legerity.Windows;
     using Legerity.Windows.Helpers;
+    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Android;
     using OpenQA.Selenium.Appium.iOS;
     using OpenQA.Selenium.Appium.Windows;
@@ -58,13 +60,23 @@ namespace Legerity
         /// <param name="opts">
         /// The options to configure the driver with.
         /// </param>
+        /// <param name="waitUntil">
+        /// An optional condition of the driver to wait on until it is met.
+        /// </param>
+        /// <param name="waitUntilTimeout">
+        /// An optional timeout wait on the conditional wait until being true. If not set, the wait will run immediately, and if not valid, will throw an exception.
+        /// </param>
+        /// <param name="waitUntilRetries">
+        /// An optional count of retries after a timeout on the wait until condition before accepting the failure.
+        /// </param>
         /// <exception cref="DriverLoadFailedException">
         /// Thrown if the application is null or the session ID is null once initialized.
         /// </exception>
         /// <exception cref="T:Legerity.Exceptions.AppiumServerLoadFailedException">Thrown if the Appium server could not be found when running with <see cref="AndroidAppManagerOptions.LaunchAppiumServer"/> or <see cref="IOSAppManagerOptions.LaunchAppiumServer"/> true.</exception>
         /// <exception cref="T:Legerity.Windows.Exceptions.WinAppDriverNotFoundException">Thrown if the WinAppDriver could not be found when running with <see cref="WindowsAppManagerOptions.LaunchWinAppDriver"/> true.</exception>
         /// <exception cref="T:Legerity.Windows.Exceptions.WinAppDriverLoadFailedException">Thrown if the WinAppDriver failed to load when running with <see cref="WindowsAppManagerOptions.LaunchWinAppDriver"/> true.</exception>
-        public static void StartApp(AppManagerOptions opts)
+        /// <exception cref="WebDriverException">Thrown if the wait until condition is not met in the allocated timeout period if provided.</exception>
+        public static void StartApp(AppManagerOptions opts, Func<IWebDriver, bool> waitUntil = default, TimeSpan? waitUntilTimeout = default, int waitUntilRetries = 0)
         {
             StopApp();
 
@@ -147,6 +159,11 @@ namespace Legerity
                         VerifyAppDriver(IOSApp, iosOpts);
                         break;
                     }
+            }
+
+            if (waitUntil != null)
+            {
+                App.WaitUntil(waitUntil, waitUntilTimeout, waitUntilRetries);
             }
         }
 

--- a/src/Legerity.Core/Extensions/DriverExtensions.cs
+++ b/src/Legerity.Core/Extensions/DriverExtensions.cs
@@ -94,9 +94,23 @@ namespace Legerity.Extensions
         /// <param name="appDriver">The driver to wait on.</param>
         /// <param name="condition">The condition of the element to wait on.</param>
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        public static void WaitUntil(this IWebDriver appDriver, Func<IWebDriver, bool> condition, TimeSpan? timeout = default)
+        /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+        /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+        public static void WaitUntil(this IWebDriver appDriver, Func<IWebDriver, bool> condition, TimeSpan? timeout = default, int retries = 0)
         {
-            new WebDriverWait(appDriver, timeout ?? TimeSpan.Zero).Until(condition);
+            try
+            {
+                new WebDriverWait(appDriver, timeout ?? TimeSpan.Zero).Until(condition);
+            }
+            catch (WebDriverException)
+            {
+                if (retries <= 0)
+                {
+                    throw;
+                }
+
+                WaitUntil(appDriver, condition, timeout, retries - 1);
+            }
         }
     }
 }

--- a/src/Legerity.Core/Helpers/AppiumServerHelper.cs
+++ b/src/Legerity.Core/Helpers/AppiumServerHelper.cs
@@ -17,7 +17,7 @@ namespace Legerity.Helpers
         /// <exception cref="T:Legerity.Exceptions.AppiumServerLoadFailedException">Thrown if the Appium server failed to load.</exception>
         public static void Run()
         {
-            if (AppiumServer?.IsRunning ?? false)
+            if (AppiumServer is { IsRunning: true })
             {
                 return;
             }
@@ -40,7 +40,7 @@ namespace Legerity.Helpers
         {
             try
             {
-                if (AppiumServer.IsRunning)
+                if (AppiumServer is { IsRunning: true })
                 {
                     AppiumServer.Dispose();
                 }


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to the `AppManager` to support the ability to provide a driver condition for waiting until a specific condition is met. This includes a timeout and a retry count.

## PR checklist

- [ ] Sample tests have been added/updated and pass
- [ ] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
