### PR TITLE
Introduced LegerityTestClass & platform WaitUntil conditions

### DIFF
--- a/samples/AndroidCoreSamples/BaseTestClass.cs
+++ b/samples/AndroidCoreSamples/BaseTestClass.cs
@@ -14,7 +14,7 @@ namespace AndroidCoreSamples
             AppManager.StartApp(
                 new AndroidAppManagerOptions(Path.Combine(Environment.CurrentDirectory, "Tools\\com.companyname.app2.apk"))
                 {
-                    LaunchAppiumServer = true,
+                    LaunchAppiumServer = false,
                     DriverUri = "http://localhost:4723/wd/hub"
                 });
         }

--- a/samples/W3SchoolsWebTests/BaseTestClass.cs
+++ b/samples/W3SchoolsWebTests/BaseTestClass.cs
@@ -1,25 +1,24 @@
 namespace W3SchoolsWebTests
 {
     using System;
-    using System.IO;
     using Legerity;
-    using Legerity.Web;
     using NUnit.Framework;
     using OpenQA.Selenium;
 
-    public abstract class BaseTestClass
+    public abstract class BaseTestClass : LegerityTestClass
     {
-        public abstract string Url { get; }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseTestClass"/> class with application launch option.
+        /// </summary>
+        /// <param name="options">The application launch options.</param>
+        protected BaseTestClass(AppManagerOptions options) : base(options)
+        {
+        }
 
         [SetUp]
         public virtual void Initialize()
         {
-            AppManager.StartApp(
-                new WebAppManagerOptions(WebAppDriverType.EdgeChromium, Environment.CurrentDirectory)
-                {
-                    Maximize = true,
-                    Url = this.Url
-                });
+            base.StartApp();
 
             try
             {
@@ -37,7 +36,7 @@ namespace W3SchoolsWebTests
         [TearDown]
         public virtual void Cleanup()
         {
-            AppManager.StopApp();
+            base.StopApp();
         }
     }
 }

--- a/samples/W3SchoolsWebTests/Tests/ButtonTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/ButtonTests.cs
@@ -1,15 +1,39 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class ButtonTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_button_test";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_button_test";
+
+        public ButtonTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldClickButton()

--- a/samples/W3SchoolsWebTests/Tests/CheckBoxTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/CheckBoxTests.cs
@@ -1,16 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class CheckBoxTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_checkbox";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_checkbox";
+
+        public CheckBoxTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [TestCase("vehicle1")]
         [TestCase("vehicle2")]

--- a/samples/W3SchoolsWebTests/Tests/FileInputTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/FileInputTests.cs
@@ -1,18 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class FileInputTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_file";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_file";
+
+        public FileInputTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldSetAbsoluteFilePath()

--- a/samples/W3SchoolsWebTests/Tests/ImageTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/ImageTests.cs
@@ -1,16 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class ImageTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_image_test";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_image_test";
+
+        public ImageTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldGetImageSource()

--- a/samples/W3SchoolsWebTests/Tests/NumberInputTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/NumberInputTests.cs
@@ -1,16 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class NumberInputTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/html/tryit.asp?filename=tryhtml_input_number";
+        private const string Url = "https://www.w3schools.com/html/tryit.asp?filename=tryhtml_input_number";
+
+        public NumberInputTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldGetValueRange()

--- a/samples/W3SchoolsWebTests/Tests/OrderedListTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/OrderedListTests.cs
@@ -1,9 +1,12 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.IO;
     using System.Linq;
     using Legerity;
+    using Legerity.Web;
     using NUnit.Framework;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
@@ -11,10 +14,30 @@ namespace W3SchoolsWebTests.Tests
     using W3SchoolsWebTests;
     using List = Legerity.Web.Elements.Core.List;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class OrderedListTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_lists";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_lists";
+
+        public OrderedListTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldContainItems()

--- a/samples/W3SchoolsWebTests/Tests/RadioButtonTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/RadioButtonTests.cs
@@ -1,8 +1,12 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.IO;
     using System.Linq;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium;
@@ -10,10 +14,30 @@ namespace W3SchoolsWebTests.Tests
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class RadioButtonTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio";
+
+        public RadioButtonTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [TestCase("html")]
         [TestCase("css")]

--- a/samples/W3SchoolsWebTests/Tests/RangeInputTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/RangeInputTests.cs
@@ -1,16 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class RangeInputTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_range";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_range";
+
+        public RangeInputTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldGetValueRange()

--- a/samples/W3SchoolsWebTests/Tests/SelectTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/SelectTests.cs
@@ -1,17 +1,41 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class SelectTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select";
+
+        public SelectTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldGetItems()

--- a/samples/W3SchoolsWebTests/Tests/TableTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/TableTests.cs
@@ -1,18 +1,41 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using Legerity;
     using Legerity.Extensions;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium;
     using Shouldly;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class TableTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/html/tryit.asp?filename=tryhtml_table_intro";
+        private const string Url = "https://www.w3schools.com/html/tryit.asp?filename=tryhtml_table_intro";
+
+        public TableTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldGetHeaders()

--- a/samples/W3SchoolsWebTests/Tests/TextAreaTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/TextAreaTests.cs
@@ -1,16 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class TextAreaTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_textarea";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_textarea";
+
+        public TextAreaTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldSetText()

--- a/samples/W3SchoolsWebTests/Tests/TextInputTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/TextInputTests.cs
@@ -1,16 +1,40 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using Legerity;
+    using Legerity.Web;
     using Legerity.Web.Elements.Core;
     using NUnit.Framework;
     using OpenQA.Selenium.Remote;
     using Shouldly;
     using W3SchoolsWebTests;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class TextInputTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/html/tryit.asp?filename=tryhtml_input_text";
+        private const string Url = "https://www.w3schools.com/html/tryit.asp?filename=tryhtml_input_text";
+
+        public TextInputTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldSetText()

--- a/samples/W3SchoolsWebTests/Tests/UnorderedListTests.cs
+++ b/samples/W3SchoolsWebTests/Tests/UnorderedListTests.cs
@@ -1,9 +1,12 @@
 namespace W3SchoolsWebTests.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.IO;
     using System.Linq;
     using Legerity;
+    using Legerity.Web;
     using NUnit.Framework;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
@@ -11,10 +14,30 @@ namespace W3SchoolsWebTests.Tests
     using W3SchoolsWebTests;
     using List = Legerity.Web.Elements.Core.List;
 
-    [TestFixture]
+    [TestFixtureSource(nameof(TestPlatformOptions))]
     public class UnorderedListTests : BaseTestClass
     {
-        public override string Url => "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_lists4";
+        private const string Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_lists4";
+
+        public UnorderedListTests(AppManagerOptions options) : base(options)
+        {
+        }
+
+        static IEnumerable<AppManagerOptions> TestPlatformOptions => new List<AppManagerOptions>
+        {
+            new WebAppManagerOptions(
+                WebAppDriverType.EdgeChromium,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            },
+            new WebAppManagerOptions(
+                WebAppDriverType.Chrome,
+                Path.Combine(Environment.CurrentDirectory))
+            {
+                Maximize = true, Url = Url, ImplicitWait = TimeSpan.FromSeconds(10)
+            }
+        };
 
         [Test]
         public void ShouldContainItems()

--- a/samples/W3SchoolsWebTests/W3SchoolsWebTests.csproj
+++ b/samples/W3SchoolsWebTests/W3SchoolsWebTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="99.0.4844.5100" />
     <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="99.0.1150.25" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>

--- a/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
@@ -5,14 +5,12 @@ namespace WindowsAlarmsAndClock.Pages
     using System.Linq;
     using Elements;
     using Legerity.Extensions;
-    using Legerity.Pages;
     using Legerity.Windows.Extensions;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
-    using OpenQA.Selenium.Remote;
 
     /// <summary>
     /// Defines the alarm page of the Windows Alarms &amp; Clock application.

--- a/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
+++ b/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
@@ -1,0 +1,36 @@
+namespace Legerity.Android.Extensions
+{
+    using System;
+    using Legerity.Android.Elements;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="AndroidElementWrapper"/> objects.
+    /// </summary>
+    public static class AndroidElementWrapperExtensions
+    {
+        /// <summary>
+        /// Waits until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
+        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+            where TElementWrapper : AndroidElementWrapper
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(element);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
+        }
+    }
+}

--- a/src/Legerity.Core/Android/AndroidAppManagerOptions.cs
+++ b/src/Legerity.Core/Android/AndroidAppManagerOptions.cs
@@ -174,7 +174,7 @@ namespace Legerity.Android
             this.OSVersion = osVersion;
             this.DeviceName = deviceName;
             this.DeviceId = deviceId;
-            this.Configure(additionalOptions);
+            this.AdditionalOptions = additionalOptions;
         }
 
         /// <summary>
@@ -213,59 +213,55 @@ namespace Legerity.Android
         public bool LaunchAppiumServer { get; set; }
 
         /// <summary>
+        /// Configures the <see cref="AppiumManagerOptions.AppiumOptions"/> with the specified additional options.
+        /// </summary>
+        public override void Configure()
+        {
+            base.Configure();
+
+            this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.PlatformName, "Android");
+
+            if (!string.IsNullOrWhiteSpace(this.OSVersion))
+            {
+                this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.PlatformVersion, this.OSVersion);
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.DeviceName))
+            {
+                this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.DeviceName, this.DeviceName);
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.DeviceId))
+            {
+                this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.Udid, this.DeviceId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.AppId))
+            {
+                this.AppiumOptions.AddAdditionalCapability("appPackage", this.AppId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.AppActivity))
+            {
+                this.AppiumOptions.AddAdditionalCapability("appActivity", this.AppActivity);
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.AppPath))
+            {
+                this.AppiumOptions.AddAdditionalCapability("app", this.AppPath);
+            }
+        }
+
+        /// <summary>
         /// Configures the <see cref="AppiumOptions"/> with the specified additional options.
-        /// <para>
-        /// By default, the <see cref="AppId"/> will be added to the options as capability 'app'.
-        /// </para>
         /// </summary>
         /// <param name="additionalOptions">
         /// The additional options to apply to the <see cref="AppiumOptions"/>.
         /// </param>
         public void Configure((string, object)[] additionalOptions)
         {
-            var options = new AppiumOptions();
-
-            options.AddAdditionalCapability(MobileCapabilityType.PlatformName, "Android");
-
-            if (!string.IsNullOrWhiteSpace(this.OSVersion))
-            {
-                options.AddAdditionalCapability(MobileCapabilityType.PlatformVersion, this.OSVersion);
-            }
-
-            if (!string.IsNullOrWhiteSpace(this.DeviceName))
-            {
-                options.AddAdditionalCapability(MobileCapabilityType.DeviceName, this.DeviceName);
-            }
-
-            if (!string.IsNullOrWhiteSpace(this.DeviceId))
-            {
-                options.AddAdditionalCapability(MobileCapabilityType.Udid, this.DeviceId);
-            }
-
-            if (!string.IsNullOrWhiteSpace(this.AppId))
-            {
-                options.AddAdditionalCapability("appPackage", this.AppId);
-            }
-
-            if (!string.IsNullOrWhiteSpace(this.AppActivity))
-            {
-                options.AddAdditionalCapability("appActivity", this.AppActivity);
-            }
-
-            if (!string.IsNullOrWhiteSpace(this.AppPath))
-            {
-                options.AddAdditionalCapability("app", this.AppPath);
-            }
-
-            if (additionalOptions != null)
-            {
-                foreach ((string capabilityName, object capabilityValue) in additionalOptions)
-                {
-                    options.AddAdditionalCapability(capabilityName, capabilityValue);
-                }
-            }
-
-            this.AppiumOptions = options;
+            this.AdditionalOptions = additionalOptions;
+            this.Configure();
         }
 
         /// <summary>Returns a string that represents the current object.</summary>
@@ -297,6 +293,14 @@ namespace Legerity.Android
             if (!string.IsNullOrWhiteSpace(this.DeviceName))
             {
                 options.Add($"Device Name [{this.DeviceName}]");
+            }
+
+            if (this.AdditionalOptions != null)
+            {
+                foreach ((string name, object value) in this.AdditionalOptions)
+                {
+                    options.Add($"{name} [{value}]");
+                }
             }
 
             return string.Join(", ", options);

--- a/src/Legerity.Core/AppManager.cs
+++ b/src/Legerity.Core/AppManager.cs
@@ -80,6 +80,11 @@ namespace Legerity
         {
             StopApp();
 
+            if (opts is AppiumManagerOptions appiumOpts)
+            {
+                appiumOpts.Configure();
+            }
+
             switch (opts)
             {
                 case WebAppManagerOptions webOpts:

--- a/src/Legerity.Core/AppiumManagerOptions.cs
+++ b/src/Legerity.Core/AppiumManagerOptions.cs
@@ -8,12 +8,39 @@ namespace Legerity
     public abstract class AppiumManagerOptions : AppManagerOptions
     {
         /// <summary>
+        /// Gets or sets the additional options to apply to the <see cref="AppiumOptions"/>.
+        /// </summary>
+        public (string, object)[] AdditionalOptions { get; set; }
+
+        /// <summary>
         /// Gets or sets the options to configure the Appium driver.
+        /// <para>
+        /// This property is null until the <see cref="Configure"/> method is called.
+        /// <see cref="Configure"/> is called automatically when calling the <see cref="AppManager.StartApp"/> method.
+        /// </para>
         /// </summary>
         public AppiumOptions AppiumOptions
         {
             get => this.DriverOptions as AppiumOptions;
             set => this.DriverOptions = value;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="AppiumOptions"/> with the specified additional options.
+        /// </summary>
+        public virtual void Configure()
+        {
+            this.AppiumOptions = new AppiumOptions();
+
+            if (this.AdditionalOptions == null)
+            {
+                return;
+            }
+
+            foreach ((string capabilityName, object capabilityValue) in this.AdditionalOptions)
+            {
+                this.AppiumOptions.AddAdditionalCapability(capabilityName, capabilityValue);
+            }
         }
     }
 }

--- a/src/Legerity.Core/IOS/IOSAppManagerOptions.cs
+++ b/src/Legerity.Core/IOS/IOSAppManagerOptions.cs
@@ -58,7 +58,7 @@ namespace Legerity.IOS
             this.OSVersion = osVersion;
             this.DeviceName = deviceName;
             this.DeviceId = deviceId;
-            this.Configure(additionalOptions);
+            this.AdditionalOptions = additionalOptions;
         }
 
         /// <summary>
@@ -87,33 +87,29 @@ namespace Legerity.IOS
         public bool LaunchAppiumServer { get; set; }
 
         /// <summary>
+        /// Configures the <see cref="AppiumManagerOptions.AppiumOptions"/> with the specified additional options.
+        /// </summary>
+        public override void Configure()
+        {
+            base.Configure();
+
+            this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.PlatformName, "iOS");
+            this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.PlatformVersion, this.OSVersion);
+            this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.DeviceName, this.DeviceName);
+            this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.Udid, this.DeviceId);
+            this.AppiumOptions.AddAdditionalCapability(MobileCapabilityType.App, this.AppId);
+        }
+
+        /// <summary>
         /// Configures the <see cref="AppiumOptions"/> with the specified additional options.
-        /// <para>
-        /// By default, the <see cref="AppId"/> will be added to the options as capability 'app'.
-        /// </para>
         /// </summary>
         /// <param name="additionalOptions">
         /// The additional options to apply to the <see cref="AppiumOptions"/>.
         /// </param>
         public void Configure((string, object)[] additionalOptions)
         {
-            var options = new AppiumOptions();
-
-            options.AddAdditionalCapability(MobileCapabilityType.PlatformName, "iOS");
-            options.AddAdditionalCapability(MobileCapabilityType.PlatformVersion, this.OSVersion);
-            options.AddAdditionalCapability(MobileCapabilityType.DeviceName, this.DeviceName);
-            options.AddAdditionalCapability(MobileCapabilityType.Udid, this.DeviceId);
-            options.AddAdditionalCapability(MobileCapabilityType.App, this.AppId);
-
-            if (additionalOptions != null)
-            {
-                foreach ((string capabilityName, object capabilityValue) in additionalOptions)
-                {
-                    options.AddAdditionalCapability(capabilityName, capabilityValue);
-                }
-            }
-
-            this.AppiumOptions = options;
+            this.AdditionalOptions = additionalOptions;
+            this.Configure();
         }
 
         /// <summary>Returns a string that represents the current object.</summary>
@@ -140,6 +136,14 @@ namespace Legerity.IOS
             if (!string.IsNullOrWhiteSpace(this.DeviceName))
             {
                 options.Add($"Device Name [{this.DeviceName}]");
+            }
+
+            if (this.AdditionalOptions != null)
+            {
+                foreach ((string name, object value) in this.AdditionalOptions)
+                {
+                    options.Add($"{name} [{value}]");
+                }
             }
 
             return string.Join(", ", options);

--- a/src/Legerity.Core/LegerityTestClass.cs
+++ b/src/Legerity.Core/LegerityTestClass.cs
@@ -1,0 +1,61 @@
+namespace Legerity
+{
+    using OpenQA.Selenium.Appium.Android;
+    using OpenQA.Selenium.Appium.iOS;
+    using OpenQA.Selenium.Appium.Windows;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a base class for running tests with the Legerity framework.
+    /// </summary>
+    public abstract class LegerityTestClass
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LegerityTestClass"/> class.
+        /// <para>
+        /// The <see cref="Options"/> will need to be set before calling <see cref="StartApp"/>.
+        /// </para>
+        /// </summary>
+        protected LegerityTestClass()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LegerityTestClass"/> class with application launch option.
+        /// </summary>
+        /// <param name="options">The application launch options.</param>
+        protected LegerityTestClass(AppManagerOptions options)
+        {
+            this.Options = options;
+        }
+
+        /// <summary>
+        /// Gets the instance of the started application.
+        /// <para>
+        /// This could be a <see cref="WindowsDriver{W}"/>, <see cref="AndroidDriver{W}"/>, <see cref="IOSDriver{W}"/>, or web driver.
+        /// </para>
+        /// </summary>
+        protected static RemoteWebDriver App => AppManager.App;
+
+        /// <summary>
+        /// Gets or sets the model that represents the configuration options for the <see cref="AppManager"/>.
+        /// </summary>
+        protected AppManagerOptions Options { get; set; }
+
+        /// <summary>
+        /// Starts the application ready for testing.
+        /// </summary>
+        public virtual void StartApp()
+        {
+            AppManager.StartApp(this.Options);
+        }
+
+        /// <summary>
+        /// Stops the application.
+        /// </summary>
+        public virtual void StopApp()
+        {
+            AppManager.StopApp();
+        }
+    }
+}

--- a/src/Legerity.Core/Windows/WindowsAppManagerOptions.cs
+++ b/src/Legerity.Core/Windows/WindowsAppManagerOptions.cs
@@ -32,7 +32,7 @@ namespace Legerity.Windows
         public WindowsAppManagerOptions(string appId, params (string, object)[] additionalOptions)
         {
             this.AppId = appId;
-            this.Configure(additionalOptions);
+            this.AdditionalOptions = additionalOptions;
         }
 
         /// <summary>
@@ -59,28 +59,24 @@ namespace Legerity.Windows
         public string WinAppDriverPath { get; set; } = WinAppDriverHelper.DefaultInstallLocation;
 
         /// <summary>
+        /// Configures the <see cref="AppiumManagerOptions.AppiumOptions"/> with the specified additional options.
+        /// </summary>
+        public override void Configure()
+        {
+            base.Configure();
+            this.AppiumOptions.AddAdditionalCapability("app", this.AppId);
+        }
+
+        /// <summary>
         /// Configures the <see cref="AppiumOptions"/> with the specified additional options.
-        /// <para>
-        /// By default, the <see cref="AppId"/> will be added to the options as capability 'app'.
-        /// </para>
         /// </summary>
         /// <param name="additionalOptions">
         /// The additional options to apply to the <see cref="AppiumOptions"/>.
         /// </param>
         public void Configure((string, object)[] additionalOptions)
         {
-            var options = new AppiumOptions();
-            options.AddAdditionalCapability("app", this.AppId);
-
-            if (additionalOptions != null)
-            {
-                foreach ((string capabilityName, object capabilityValue) in additionalOptions)
-                {
-                    options.AddAdditionalCapability(capabilityName, capabilityValue);
-                }
-            }
-
-            this.AppiumOptions = options;
+            this.AdditionalOptions = additionalOptions;
+            this.Configure();
         }
 
         /// <summary>Returns a string that represents the current object.</summary>
@@ -97,6 +93,14 @@ namespace Legerity.Windows
             if (!string.IsNullOrWhiteSpace(this.AppId))
             {
                 options.Add($"App ID [{this.AppId}]");
+            }
+
+            if (this.AdditionalOptions != null)
+            {
+                foreach ((string name, object value) in this.AdditionalOptions)
+                {
+                    options.Add($"{name} [{value}]");
+                }
             }
 
             return string.Join(", ", options);

--- a/src/Legerity.IOS/Extensions/IOSElementWrapperExtensions.cs
+++ b/src/Legerity.IOS/Extensions/IOSElementWrapperExtensions.cs
@@ -1,0 +1,36 @@
+namespace Legerity.IOS.Extensions
+{
+    using System;
+    using Legerity.IOS.Elements;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="IOSElementWrapper"/> objects.
+    /// </summary>
+    public static class IOSElementWrapperExtensions
+    {
+        /// <summary>
+        /// Waits until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="IOSElementWrapper"/>.</typeparam>
+        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+            where TElementWrapper : IOSElementWrapper
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(element);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
+        }
+    }
+}

--- a/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
+++ b/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
@@ -1,0 +1,36 @@
+namespace Legerity.Web.Extensions
+{
+    using System;
+    using Legerity.Web.Elements;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="WebElementWrapper"/> objects.
+    /// </summary>
+    public static class WebElementWrapperExtensions
+    {
+        /// <summary>
+        /// Waits until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
+        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+            where TElementWrapper : WebElementWrapper
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(element);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
+        }
+    }
+}

--- a/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
@@ -1,0 +1,36 @@
+namespace Legerity.Windows.Extensions
+{
+    using System;
+    using Legerity.Windows.Elements;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Support.UI;
+
+    /// <summary>
+    /// Defines a collection of extensions for <see cref="WindowsElementWrapper"/> objects.
+    /// </summary>
+    public static class WindowsElementWrapperExtensions
+    {
+        /// <summary>
+        /// Waits until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
+        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+            where TElementWrapper : WindowsElementWrapper
+        {
+            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            {
+                try
+                {
+                    return condition(element);
+                }
+                catch (StaleElementReferenceException)
+                {
+                    return false;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to introduce a `LegerityTestClass` that can be used to further simplify the setup of UI tests with Legerity.

The `samples/W3SchoolsWebTests/BaseTestClass` serves as a good example of how to use this. The purpose is to reduce the amount of boilerplate setup code is required by instead configuring just the `AppManagerOptions` instance and allowing the base class to start and stop the tests for you.

Also included in this change are platform specific `WaitUntil` extension methods for the element wrappers. This introduction simplifies the need to cast the element wrapper to the specific type in order to wait on the wrapper's specific properties. Now you can directly perform your intent such as:

```csharp
CheckBox checkbox = AppManager.App.FindElement(By.Id("CheckBox1"));
checkbox.CheckOn();
checkbox.WaitUntil(cb => cb.IsChecked);
```

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
