### PR TITLE
Added parameterless constructors for app manager options

### DIFF
--- a/src/Legerity.Core/Android/AndroidAppManagerOptions.cs
+++ b/src/Legerity.Core/Android/AndroidAppManagerOptions.cs
@@ -13,6 +13,13 @@ namespace Legerity.Android
         /// <summary>
         /// Initializes a new instance of the <see cref="AndroidAppManagerOptions"/> class.
         /// </summary>
+        public AndroidAppManagerOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AndroidAppManagerOptions"/> class.
+        /// </summary>
         /// <param name="appPath">
         /// The path of the application under test, e.g. c:/users/legerity/source/myapp/com.instagram.android.apk.
         /// </param>

--- a/src/Legerity.Core/IOS/IOSAppManagerOptions.cs
+++ b/src/Legerity.Core/IOS/IOSAppManagerOptions.cs
@@ -12,6 +12,13 @@ namespace Legerity.IOS
         /// <summary>
         /// Initializes a new instance of the <see cref="IOSAppManagerOptions"/> class.
         /// </summary>
+        public IOSAppManagerOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IOSAppManagerOptions"/> class.
+        /// </summary>
         /// <param name="appId">
         /// The ID of the application under test, e.g. com.instagram.ios.
         /// </param>

--- a/src/Legerity.Core/Web/WebAppManagerOptions.cs
+++ b/src/Legerity.Core/Web/WebAppManagerOptions.cs
@@ -11,6 +11,14 @@ namespace Legerity.Web
         /// <summary>
         /// Initializes a new instance of the <see cref="WebAppManagerOptions"/> class.
         /// </summary>
+
+        public WebAppManagerOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebAppManagerOptions"/> class.
+        /// </summary>
         /// <param name="driverType">The type of web application driver to start.</param>
         /// <param name="driverDirectoryPath">The path to the web application driver directory.</param>
         public WebAppManagerOptions(WebAppDriverType driverType, string driverDirectoryPath)

--- a/src/Legerity.Core/Windows/WindowsAppManagerOptions.cs
+++ b/src/Legerity.Core/Windows/WindowsAppManagerOptions.cs
@@ -12,6 +12,13 @@ namespace Legerity.Windows
         /// <summary>
         /// Initializes a new instance of the <see cref="WindowsAppManagerOptions"/> class.
         /// </summary>
+        public WindowsAppManagerOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WindowsAppManagerOptions"/> class.
+        /// </summary>
         /// <param name="appId">
         /// The ID of the application under test.
         /// </param>


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

To improve support for customising the setup for the `AppManager`, added parameterless constructor options for all `AppManagerOption` implementations.

## PR checklist

- [x] Sample tests have been added/updated and pass [N/A]
- [x] [Documentation](/docs) has been added/updated for changes [N/A]
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
