### PR TITLE
Added new AndroidByExtras and attribute extensions

### DIFF
--- a/samples/MADESampleApp/Pages/AppPage.cs
+++ b/samples/MADESampleApp/Pages/AppPage.cs
@@ -3,6 +3,7 @@ namespace MADESampleApp.Pages
     using System;
     using System.Collections.Generic;
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.MADE;
     using Legerity.Windows.Extensions;
@@ -13,17 +14,17 @@ namespace MADESampleApp.Pages
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
         /// </summary>
-        protected override By Trait => ByExtensions.AutomationId("DropDownList");
+        protected override By Trait => WindowsByExtras.AutomationId("DropDownList");
 
         public InputValidator TextInputValidator =>
-            this.WindowsApp.FindElement(ByExtensions.AutomationId("TextBoxValidator"));
+            this.WindowsApp.FindElement(WindowsByExtras.AutomationId("TextBoxValidator"));
 
-        public TextBox TextInput => this.TextInputValidator.Input(ByExtensions.AutomationId("TextBox"));
+        public TextBox TextInput => this.TextInputValidator.Input(WindowsByExtras.AutomationId("TextBox"));
 
         public InputValidator DateInputValidator =>
-            this.WindowsApp.FindElement(ByExtensions.AutomationId("DatePickerValidator"));
+            this.WindowsApp.FindElement(WindowsByExtras.AutomationId("DatePickerValidator"));
 
-        public DatePicker DateInput => this.DateInputValidator.Input(ByExtensions.AutomationId("DatePicker"));
+        public DatePicker DateInput => this.DateInputValidator.Input(WindowsByExtras.AutomationId("DatePicker"));
 
         public DropDownList DropDownList => this.WindowsApp.FindElementByAutomationId("DropDownList");
 

--- a/samples/WindowsAlarmsAndClock/Elements/AlarmPopup.cs
+++ b/samples/WindowsAlarmsAndClock/Elements/AlarmPopup.cs
@@ -1,9 +1,9 @@
 namespace WindowsAlarmsAndClock.Elements
 {
     using System;
+    using Legerity.Windows;
     using Legerity.Windows.Elements;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -67,11 +67,11 @@ namespace WindowsAlarmsAndClock.Elements
             return new AlarmPopup(element as WindowsElement);
         }
 
-        public CustomTimePicker DurationPicker => this.FindElement(ByExtensions.AutomationId("DurationPicker"));
+        public CustomTimePicker DurationPicker => this.FindElement(WindowsByExtras.AutomationId("DurationPicker"));
 
         public TextBox AlarmNameInput => this.FindElement(By.Name("Alarm name"));
 
-        public Button SaveButton => this.Element.FindElement(ByExtensions.AutomationId("PrimaryButton"));
+        public Button SaveButton => this.Element.FindElement(WindowsByExtras.AutomationId("PrimaryButton"));
 
         public void SetTime(TimeSpan time)
         {

--- a/samples/WindowsAlarmsAndClock/Elements/CustomTimePicker.cs
+++ b/samples/WindowsAlarmsAndClock/Elements/CustomTimePicker.cs
@@ -1,9 +1,8 @@
 namespace WindowsAlarmsAndClock.Elements
 {
     using System;
-
+    using Legerity.Windows;
     using Legerity.Windows.Elements;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
     using OpenQA.Selenium.Remote;
@@ -74,8 +73,8 @@ namespace WindowsAlarmsAndClock.Elements
         /// </param>
         public void SetTime(TimeSpan time)
         {
-            this.Element.FindElement(ByExtensions.AutomationId("HourPicker")).FindElementByName(time.ToString("%h")).Click();
-            this.Element.FindElement(ByExtensions.AutomationId("MinutePicker")).FindElementByName(time.ToString("mm")).Click();
+            this.Element.FindElement(WindowsByExtras.AutomationId("HourPicker")).FindElementByName(time.ToString("%h")).Click();
+            this.Element.FindElement(WindowsByExtras.AutomationId("MinutePicker")).FindElementByName(time.ToString("mm")).Click();
         }
     }
 }

--- a/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AlarmPage.cs
@@ -5,8 +5,7 @@ namespace WindowsAlarmsAndClock.Pages
     using System.Linq;
     using Elements;
     using Legerity.Extensions;
-    using Legerity.Windows.Extensions;
-
+    using Legerity.Windows;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
@@ -26,16 +25,16 @@ namespace WindowsAlarmsAndClock.Pages
         /// </summary>
         public AlarmPage()
         {
-            this.addAlarmButton = ByExtensions.AutomationId("AddAlarmButton");
-            this.alarmList = ByExtensions.AutomationId("AlarmListView");
+            this.addAlarmButton = WindowsByExtras.AutomationId("AddAlarmButton");
+            this.alarmList = WindowsByExtras.AutomationId("AlarmListView");
         }
 
-        public AlarmPopup AlarmPopup => this.WindowsApp.FindElement(ByExtensions.AutomationId("EditFlyout"));
+        public AlarmPopup AlarmPopup => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("EditFlyout"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
         /// </summary>
-        protected override By Trait => ByExtensions.AutomationId("AddAlarmButton");
+        protected override By Trait => WindowsByExtras.AutomationId("AddAlarmButton");
 
         /// <summary>
         /// Navigates to adding an alarm.

--- a/samples/WindowsAlarmsAndClock/Pages/AppPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/AppPage.cs
@@ -2,8 +2,8 @@ namespace WindowsAlarmsAndClock.Pages
 {
     using System;
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
 
     public class AppPage : BasePage
@@ -13,7 +13,7 @@ namespace WindowsAlarmsAndClock.Pages
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
         /// </summary>
-        protected override By Trait => ByExtensions.AutomationId("NavView");
+        protected override By Trait => WindowsByExtras.AutomationId("NavView");
 
         /// <summary>
         /// Selects a sample from the available options with the given name.

--- a/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
+++ b/samples/WindowsAlarmsAndClock/Pages/EditAlarmPage.cs
@@ -3,8 +3,7 @@ namespace WindowsAlarmsAndClock.Pages
     using System;
 
     using Legerity.Pages;
-    using Legerity.Windows.Extensions;
-
+    using Legerity.Windows;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -38,21 +37,21 @@ namespace WindowsAlarmsAndClock.Pages
         /// </summary>
         public EditAlarmPage()
         {
-            this.alarmTimePicker = ByExtensions.AutomationId("AlarmTimePicker");
-            this.alarmNameTextBox = ByExtensions.AutomationId("AlarmNameTextBox");
-            this.alarmRepeatButton = ByExtensions.AutomationId("AlarmRepeatsToggleButton");
-            this.alarmSoundButton = ByExtensions.AutomationId("AlarmSoundButton");
-            this.alarmSnoozeComboBox = ByExtensions.AutomationId("AlarmSnoozeCombobox");
-            this.alarmSaveButton = ByExtensions.AutomationId("AlarmSaveButton");
-            this.alarmCancelButton = ByExtensions.AutomationId("CancelButton");
-            this.alarmDeleteButton = ByExtensions.AutomationId("AlarmDeleteButton");
-            this.alarmDeleteDialog = ByExtensions.AutomationId("DeleteConfirmationDialog");
+            this.alarmTimePicker = WindowsByExtras.AutomationId("AlarmTimePicker");
+            this.alarmNameTextBox = WindowsByExtras.AutomationId("AlarmNameTextBox");
+            this.alarmRepeatButton = WindowsByExtras.AutomationId("AlarmRepeatsToggleButton");
+            this.alarmSoundButton = WindowsByExtras.AutomationId("AlarmSoundButton");
+            this.alarmSnoozeComboBox = WindowsByExtras.AutomationId("AlarmSnoozeCombobox");
+            this.alarmSaveButton = WindowsByExtras.AutomationId("AlarmSaveButton");
+            this.alarmCancelButton = WindowsByExtras.AutomationId("CancelButton");
+            this.alarmDeleteButton = WindowsByExtras.AutomationId("AlarmDeleteButton");
+            this.alarmDeleteDialog = WindowsByExtras.AutomationId("DeleteConfirmationDialog");
         }
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
         /// </summary>
-        protected override By Trait => ByExtensions.AutomationId("EditAlarmHeader");
+        protected override By Trait => WindowsByExtras.AutomationId("EditAlarmHeader");
 
         /// <summary>
         /// Sets the time of the alarm being edited.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/AppPage.cs
@@ -4,9 +4,9 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     using System.Linq;
     using System.Threading;
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
 
@@ -14,17 +14,17 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     {
         public NavigationView NavigationView => this.WindowsApp.FindElement(this.Trait);
 
-        public AutoSuggestBox SampleSearchBox => this.NavigationView.FindElement(ByExtensions.AutomationId("SearchBox"));
+        public AutoSuggestBox SampleSearchBox => this.NavigationView.FindElement(WindowsByExtras.AutomationId("SearchBox"));
 
         /// <summary>
         /// Gets the UI component associated with the sample picker.
         /// </summary>
-        public GridView SamplePicker => this.WindowsApp.FindElement(ByExtensions.AutomationId("SamplePickerGridView"));
+        public GridView SamplePicker => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("SamplePickerGridView"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
         /// </summary>
-        protected override By Trait => ByExtensions.AutomationId("NavView");
+        protected override By Trait => WindowsByExtras.AutomationId("NavView");
 
         /// <summary>
         /// Selects a sample from the available options with the given name.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/BladeViewPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/BladeViewPage.cs
@@ -1,8 +1,8 @@
 namespace WindowsCommunityToolkitSampleApp.Pages
 {
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WCT;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
 
     /// <summary>
@@ -17,7 +17,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         {
         }
 
-        public BladeView BladeView => this.WindowsApp.FindElement(ByExtensions.AutomationId("BladeView"));
+        public BladeView BladeView => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("BladeView"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/CarouselPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/CarouselPage.cs
@@ -1,7 +1,7 @@
 namespace WindowsCommunityToolkitSampleApp.Pages
 {
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WCT;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using Shouldly;
 
@@ -17,7 +17,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
         {
         }
 
-        public Carousel Carousel => this.WindowsApp.FindElement(ByExtensions.AutomationId("CarouselControl"));
+        public Carousel Carousel => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("CarouselControl"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/ExpanderPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/ExpanderPage.cs
@@ -1,7 +1,7 @@
 namespace WindowsCommunityToolkitSampleApp.Pages
 {
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WCT;
-    using Legerity.Windows.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using OpenQA.Selenium;
 
@@ -10,9 +10,9 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     /// </summary>
     public class ExpanderPage : AppPage
     {
-        public Expander VerticalExpander => this.WindowsApp.FindElement(ByExtensions.AutomationId("Expander1"));
+        public Expander VerticalExpander => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("Expander1"));
 
-        public Expander HorizontalExpander => this.WindowsApp.FindElement(ByExtensions.AutomationId("Expander2"));
+        public Expander HorizontalExpander => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("Expander2"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/InAppNotificationPage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/InAppNotificationPage.cs
@@ -4,9 +4,9 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     using Elements;
     using Legerity.Exceptions;
     using Legerity.Extensions;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WCT;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
 
     /// <summary>
@@ -14,10 +14,10 @@ namespace WindowsCommunityToolkitSampleApp.Pages
     /// </summary>
     public class InAppNotificationPage : AppPage
     {
-        private readonly By exampleInAppNotificationLocator = ByExtensions.AutomationId("ExampleInAppNotification");
+        private readonly By exampleInAppNotificationLocator = WindowsByExtras.AutomationId("ExampleInAppNotification");
 
         private readonly By exampleCodeInAppNotificationLocator =
-            ByExtensions.AutomationId("ExampleVSCodeInAppNotification");
+            WindowsByExtras.AutomationId("ExampleVSCodeInAppNotification");
 
         /// <summary>
         /// Gets the example in-app notification element.

--- a/samples/WindowsCommunityToolkitSampleApp/Pages/RadialGaugePage.cs
+++ b/samples/WindowsCommunityToolkitSampleApp/Pages/RadialGaugePage.cs
@@ -1,7 +1,7 @@
 namespace WindowsCommunityToolkitSampleApp.Pages
 {
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WCT;
-    using Legerity.Windows.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using OpenQA.Selenium;
 
@@ -14,7 +14,7 @@ namespace WindowsCommunityToolkitSampleApp.Pages
 
         public RadialGaugePage()
         {
-            this.radialGauge = ByExtensions.AutomationId("RadialGauge");
+            this.radialGauge = WindowsByExtras.AutomationId("RadialGauge");
         }
 
         /// <summary>

--- a/samples/XamlControlsGallery/Pages/BasicInput/RatingControlPage.cs
+++ b/samples/XamlControlsGallery/Pages/BasicInput/RatingControlPage.cs
@@ -1,8 +1,8 @@
 namespace XamlControlsGallery.Pages.BasicInput
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
@@ -19,7 +19,7 @@ namespace XamlControlsGallery.Pages.BasicInput
         /// </summary>
         public RatingControlPage()
         {
-            this.simpleRatingControl = ByExtensions.AutomationId("RatingControl1");
+            this.simpleRatingControl = WindowsByExtras.AutomationId("RatingControl1");
         }
 
         /// <summary>

--- a/samples/XamlControlsGallery/Pages/Collections/ListBoxPage.cs
+++ b/samples/XamlControlsGallery/Pages/Collections/ListBoxPage.cs
@@ -1,8 +1,8 @@
 namespace XamlControlsGallery.Pages.Collections
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using OpenQA.Selenium;
 
@@ -11,7 +11,7 @@ namespace XamlControlsGallery.Pages.Collections
     /// </summary>
     public class ListBoxPage : BasePage
     {
-        private readonly By colorListBox = ByExtensions.AutomationId("ListBox1");
+        private readonly By colorListBox = WindowsByExtras.AutomationId("ListBox1");
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/XamlControlsGallery/Pages/Media/InkToolbarPage.cs
+++ b/samples/XamlControlsGallery/Pages/Media/InkToolbarPage.cs
@@ -1,8 +1,8 @@
 namespace XamlControlsGallery.Pages.Media
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
 
     /// <summary>
@@ -10,7 +10,7 @@ namespace XamlControlsGallery.Pages.Media
     /// </summary>
     public class InkToolbarPage : BasePage
     {
-        public InkToolbar InkToolbar => this.WindowsApp.FindElement(ByExtensions.AutomationId("inkToolbar"));
+        public InkToolbar InkToolbar => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("inkToolbar"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/XamlControlsGallery/Pages/MenusAndToolbars/CommandBarPage.cs
+++ b/samples/XamlControlsGallery/Pages/MenusAndToolbars/CommandBarPage.cs
@@ -1,9 +1,8 @@
 namespace XamlControlsGallery.Pages.MenusAndToolbars
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
 
     /// <summary>
@@ -11,7 +10,7 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
     /// </summary>
     public class CommandBarPage : BasePage
     {
-        public CommandBar PrimaryCommandBar => this.WindowsApp.FindElement(ByExtensions.AutomationId("PrimaryCommandBar"));
+        public CommandBar PrimaryCommandBar => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("PrimaryCommandBar"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/XamlControlsGallery/Pages/MenusAndToolbars/MenuBarPage.cs
+++ b/samples/XamlControlsGallery/Pages/MenusAndToolbars/MenuBarPage.cs
@@ -1,10 +1,9 @@
 namespace XamlControlsGallery.Pages.MenusAndToolbars
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
 
     /// <summary>
@@ -12,9 +11,9 @@ namespace XamlControlsGallery.Pages.MenusAndToolbars
     /// </summary>
     public class MenuBarPage : BasePage
     {
-        public MenuBar SimpleMenuBar => this.WindowsApp.FindElement(ByExtensions.AutomationId("Example1"));
+        public MenuBar SimpleMenuBar => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("Example1"));
 
-        public MenuBar MenuBarWithSubMenus => this.WindowsApp.FindElement(ByExtensions.AutomationId("Example3"));
+        public MenuBar MenuBarWithSubMenus => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("Example3"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/XamlControlsGallery/Pages/Navigation/TabViewPage.cs
+++ b/samples/XamlControlsGallery/Pages/Navigation/TabViewPage.cs
@@ -1,9 +1,8 @@
 namespace XamlControlsGallery.Pages.Navigation
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
-
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
@@ -13,7 +12,7 @@ namespace XamlControlsGallery.Pages.Navigation
     /// </summary>
     public class TabViewPage : BasePage
     {
-        public TabView TabView => this.WindowsApp.FindElement(ByExtensions.AutomationId("TabView1"));
+        public TabView TabView => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("TabView1"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/XamlControlsGallery/Pages/NavigationMenu.cs
+++ b/samples/XamlControlsGallery/Pages/NavigationMenu.cs
@@ -3,8 +3,6 @@ namespace XamlControlsGallery.Pages
     using Legerity.Pages;
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
-
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
@@ -12,6 +10,7 @@ namespace XamlControlsGallery.Pages
     using BasicInput;
     using Collections;
     using DateAndTime;
+    using Legerity.Windows;
     using Media;
     using MenusAndToolbars;
     using Navigation;
@@ -24,12 +23,12 @@ namespace XamlControlsGallery.Pages
     {
         public NavigationView NavigationView => this.WindowsApp.FindElement(this.Trait);
 
-        public AutoSuggestBox ControlsSearchBox => this.NavigationView.FindElement(ByExtensions.AutomationId("controlsSearchBox"));
+        public AutoSuggestBox ControlsSearchBox => this.NavigationView.FindElement(WindowsByExtras.AutomationId("controlsSearchBox"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.
         /// </summary>
-        protected override By Trait => ByExtensions.AutomationId("NavigationViewControl");
+        protected override By Trait => WindowsByExtras.AutomationId("NavigationViewControl");
 
         /// <summary>
         /// Navigates to the app bar toggle button control page.

--- a/samples/XamlControlsGallery/Pages/SettingsPage.cs
+++ b/samples/XamlControlsGallery/Pages/SettingsPage.cs
@@ -1,16 +1,15 @@
 namespace XamlControlsGallery.Pages
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
-
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
 
     public class SettingsPage : BasePage
     {
-        public ToggleSwitch SoundToggle => this.WindowsApp.FindElement(ByExtensions.AutomationId("soundToggle"));
+        public ToggleSwitch SoundToggle => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("soundToggle"));
 
         protected override By Trait => By.XPath(".//*[@Name='Settings'][@AutomationId='TitleTextBlock']");
 

--- a/samples/XamlControlsGallery/Pages/StatusAndInfo/InfoBarPage.cs
+++ b/samples/XamlControlsGallery/Pages/StatusAndInfo/InfoBarPage.cs
@@ -1,8 +1,8 @@
 namespace XamlControlsGallery.Pages.StatusAndInfo
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
 
     /// <summary>
@@ -10,7 +10,7 @@ namespace XamlControlsGallery.Pages.StatusAndInfo
     /// </summary>
     public class InfoBarPage : BasePage
     {
-        public InfoBar CloseableBarWithOpts => this.WindowsApp.FindElement(ByExtensions.AutomationId("TestInfoBar1"));
+        public InfoBar CloseableBarWithOpts => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("TestInfoBar1"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/samples/XamlControlsGallery/Pages/Text/NumberBoxPage.cs
+++ b/samples/XamlControlsGallery/Pages/Text/NumberBoxPage.cs
@@ -1,9 +1,8 @@
 namespace XamlControlsGallery.Pages.Text
 {
     using Legerity.Pages;
+    using Legerity.Windows;
     using Legerity.Windows.Elements.WinUI;
-    using Legerity.Windows.Extensions;
-
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using OpenQA.Selenium;
@@ -16,7 +15,7 @@ namespace XamlControlsGallery.Pages.Text
         /// <summary>
         /// Gets the element associated with the spinner number box.
         /// </summary>
-        public NumberBox SpinnerNumberBox => this.WindowsApp.FindElement(ByExtensions.AutomationId("NumberBoxSpinButtonPlacementExample"));
+        public NumberBox SpinnerNumberBox => this.WindowsApp.FindElement(WindowsByExtras.AutomationId("NumberBoxSpinButtonPlacementExample"));
 
         /// <summary>
         /// Gets a given trait of the page to verify that the page is in view.

--- a/src/Legerity.Android/AndroidByExtras.cs
+++ b/src/Legerity.Android/AndroidByExtras.cs
@@ -7,7 +7,7 @@ namespace Legerity.Android
     /// <summary>
     /// Defines a collection of extra locator constraints for <see cref="By"/>.
     /// </summary>
-    public static class ByExtras
+    public static class AndroidByExtras
     {
         /// <summary>
         /// Gets a mechanism to find elements by an Android content description.

--- a/src/Legerity.Android/ByExtras.cs
+++ b/src/Legerity.Android/ByExtras.cs
@@ -1,0 +1,32 @@
+namespace Legerity.Android
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Android.UiAutomator;
+
+    /// <summary>
+    /// Defines a collection of extra locator constraints for <see cref="By"/>.
+    /// </summary>
+    public static class ByExtras
+    {
+        /// <summary>
+        /// Gets a mechanism to find elements by an Android content description.
+        /// </summary>
+        /// <param name="contentDesc">The content description to match exactly on.</param>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By ContentDescription(string contentDesc)
+        {
+            return new ByAndroidUIAutomator(new AndroidUiSelector().DescriptionEquals(contentDesc));
+        }
+
+        /// <summary>
+        /// Gets a mechanism to find elements by an Android partial content description.
+        /// </summary>
+        /// <param name="contentDesc">The partial content description to match on.</param>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By PartialContentDescription(string contentDesc)
+        {
+            return new ByAndroidUIAutomator(new AndroidUiSelector().DescriptionContains(contentDesc));
+        }
+    }
+}

--- a/src/Legerity.Android/Extensions/AttributeExtensions.cs
+++ b/src/Legerity.Android/Extensions/AttributeExtensions.cs
@@ -16,5 +16,19 @@ namespace Legerity.Android.Extensions
         {
             return element.GetAttribute("content-desc");
         }
+
+        /// <summary>
+        /// Gets the value of the Android content description for this element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="IWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a content description for.</param>
+        /// <returns>The element's content description.</returns>
+        public static string GetContentDescription<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetContentDescription(element.Element);
+        }
     }
 }

--- a/src/Legerity.Android/Extensions/AttributeExtensions.cs
+++ b/src/Legerity.Android/Extensions/AttributeExtensions.cs
@@ -1,0 +1,20 @@
+namespace Legerity.Android.Extensions
+{
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines a collection of extensions for retrieving element attributes.
+    /// </summary>
+    public static class AttributeExtensions
+    {
+        /// <summary>
+        /// Gets the value of the Android content description for this element.
+        /// </summary>
+        /// <param name="element">The element to retrieve a content description for.</param>
+        /// <returns>The element's content description.</returns>
+        public static string GetContentDescription(this IWebElement element)
+        {
+            return element.GetAttribute("content-desc");
+        }
+    }
+}

--- a/src/Legerity.Core/ByExtras.cs
+++ b/src/Legerity.Core/ByExtras.cs
@@ -11,7 +11,7 @@ namespace Legerity
         /// Gets a mechanism to find elements by the text content.
         /// </summary>
         /// <param name="text">The text to find.</param>
-        /// <returns>A <see cref="By"/> object the driver can user to find elements.</returns>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
         public static By Text(string text)
         {
             return By.XPath($".//*[text()='{text}']");
@@ -21,7 +21,7 @@ namespace Legerity
         /// Gets a mechanism to find elements by partial text content.
         /// </summary>
         /// <param name="text">The text to find.</param>
-        /// <returns>A <see cref="By"/> object the driver can user to find elements.</returns>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
         public static By PartialText(string text)
         {
             return By.XPath($".//*[contains(text(),'{text}')]");

--- a/src/Legerity.MADE/DropDownList.cs
+++ b/src/Legerity.MADE/DropDownList.cs
@@ -2,7 +2,6 @@ namespace Legerity.Windows.Elements.MADE
 {
     using Legerity.Exceptions;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -26,7 +25,7 @@ namespace Legerity.Windows.Elements.MADE
         /// <summary>
         /// Gets the <see cref="ListView"/> element associated with the drop down content.
         /// </summary>
-        public ListView DropDown => this.Element.FindElement(ByExtensions.AutomationId("DropDownContent"));
+        public ListView DropDown => this.Element.FindElement(WindowsByExtras.AutomationId("DropDownContent"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="DropDownList"/> without direct casting.

--- a/src/Legerity.MADE/InputValidator.cs
+++ b/src/Legerity.MADE/InputValidator.cs
@@ -1,7 +1,6 @@
 namespace Legerity.Windows.Elements.MADE
 {
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -25,7 +24,7 @@ namespace Legerity.Windows.Elements.MADE
         /// <summary>
         /// Gets the <see cref="TextBlock"/> associated with the validation feedback message.
         /// </summary>
-        public TextBlock ValidationFeedback => this.Element.FindElement(ByExtensions.AutomationId("ValidatorFeedbackMessage"));
+        public TextBlock ValidationFeedback => this.Element.FindElement(WindowsByExtras.AutomationId("ValidatorFeedbackMessage"));
 
         /// <summary>
         /// Gets the validation feedback message associated with the <see cref="ValidationFeedback"/> element.

--- a/src/Legerity.Telerik.Uwp/RadAutoCompleteBox.cs
+++ b/src/Legerity.Telerik.Uwp/RadAutoCompleteBox.cs
@@ -2,7 +2,6 @@ namespace Legerity.Windows.Elements.Telerik
 {
     using System;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -12,7 +11,7 @@ namespace Legerity.Windows.Elements.Telerik
     /// </summary>
     public class RadAutoCompleteBox : WindowsElementWrapper
     {
-        private readonly By suggestionsControlLocator = ByExtensions.AutomationId("PART_SuggestionsControl");
+        private readonly By suggestionsControlLocator = WindowsByExtras.AutomationId("PART_SuggestionsControl");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RadAutoCompleteBox"/> class.

--- a/src/Legerity.Telerik.Uwp/RadNumericBox.cs
+++ b/src/Legerity.Telerik.Uwp/RadNumericBox.cs
@@ -2,7 +2,6 @@ namespace Legerity.Windows.Elements.Telerik
 {
     using System;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -51,17 +50,17 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Gets the element associated with the increase button.
         /// </summary>
-        public Button Increase => this.Element.FindElement(ByExtensions.AutomationId("PART_IncreaseButton"));
+        public Button Increase => this.Element.FindElement(WindowsByExtras.AutomationId("PART_IncreaseButton"));
 
         /// <summary>
         /// Gets the element associated with the decrease button.
         /// </summary>
-        public Button DecreaseButton => this.Element.FindElement(ByExtensions.AutomationId("PART_DecreaseButton"));
+        public Button DecreaseButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_DecreaseButton"));
 
         /// <summary>
         /// Gets the element associated with the input text box.
         /// </summary>
-        public TextBox InputBox => this.Element.FindElement(ByExtensions.AutomationId("PART_TextBox"));
+        public TextBox InputBox => this.Element.FindElement(WindowsByExtras.AutomationId("PART_TextBox"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadNumericBox"/> without direct casting.

--- a/src/Legerity.WCT/BladeViewItem.cs
+++ b/src/Legerity.WCT/BladeViewItem.cs
@@ -2,7 +2,6 @@ namespace Legerity.Windows.Elements.WCT
 {
     using System;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium.Windows;
 
     /// <summary>
@@ -52,12 +51,12 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the <see cref="Button"/> element associated with the blade enlarge option.
         /// </summary>
-        public Button EnlargeButton => this.Element.FindElement(ByExtensions.AutomationId("EnlargeButton"));
+        public Button EnlargeButton => this.Element.FindElement(WindowsByExtras.AutomationId("EnlargeButton"));
 
         /// <summary>
         /// Gets the <see cref="Button"/> element associated with the blade close option.
         /// </summary>
-        public Button CloseButton => this.Element.FindElement(ByExtensions.AutomationId("CloseButton"));
+        public Button CloseButton => this.Element.FindElement(WindowsByExtras.AutomationId("CloseButton"));
 
         /// <summary>
         /// Closes the blade item.

--- a/src/Legerity.WCT/Expander.cs
+++ b/src/Legerity.WCT/Expander.cs
@@ -1,7 +1,6 @@
 namespace Legerity.Windows.Elements.WCT
 {
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -28,7 +27,7 @@ namespace Legerity.Windows.Elements.WCT
         /// </summary>
         public bool IsExpanded => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
 
-        private ToggleButton ToggleButton => this.Element.FindElement(ByExtensions.AutomationId("PART_ExpanderToggleButton"));
+        private ToggleButton ToggleButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_ExpanderToggleButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Expander"/> without direct casting.

--- a/src/Legerity.WCT/InAppNotification.cs
+++ b/src/Legerity.WCT/InAppNotification.cs
@@ -2,7 +2,6 @@ namespace Legerity.Windows.Elements.WCT
 {
     using System.Linq;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -25,7 +24,7 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the dismiss button.
         /// </summary>
-        public virtual Button DismissButton => this.Element.FindElement(ByExtensions.AutomationId("PART_DismissButton"));
+        public virtual Button DismissButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_DismissButton"));
 
         /// <summary>
         /// Gets the message displayed.

--- a/src/Legerity.WinUI/InfoBar.cs
+++ b/src/Legerity.WinUI/InfoBar.cs
@@ -1,7 +1,6 @@
 namespace Legerity.Windows.Elements.WinUI
 {
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -39,17 +38,17 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the element associated with the title <see cref="TextBlock"/>.
         /// </summary>
-        public TextBlock TitleTextBlock => this.FindElement(ByExtensions.AutomationId("Title"));
+        public TextBlock TitleTextBlock => this.FindElement(WindowsByExtras.AutomationId("Title"));
 
         /// <summary>
         /// Gets the element associated with the message <see cref="TextBlock"/>.
         /// </summary>
-        public TextBlock MessageTextBlock => this.FindElement(ByExtensions.AutomationId("Message"));
+        public TextBlock MessageTextBlock => this.FindElement(WindowsByExtras.AutomationId("Message"));
 
         /// <summary>
         /// Gets the element associated with the close <see cref="Button"/>.
         /// </summary>
-        public Button CloseButton => this.FindElement(ByExtensions.AutomationId("CloseButton"));
+        public Button CloseButton => this.FindElement(WindowsByExtras.AutomationId("CloseButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InfoBar"/> without direct casting.

--- a/src/Legerity.WinUI/NavigationView.cs
+++ b/src/Legerity.WinUI/NavigationView.cs
@@ -5,8 +5,6 @@ namespace Legerity.Windows.Elements.WinUI
     using System.Linq;
     using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -30,7 +28,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI component associated with displaying the menu items.
         /// </summary>
-        public AppiumWebElement MenuItemsView => this.Element.FindElement(ByExtensions.AutomationId("MenuItemsHost"));
+        public AppiumWebElement MenuItemsView => this.Element.FindElement(WindowsByExtras.AutomationId("MenuItemsHost"));
 
         /// <summary>
         /// Gets the UI components associated with the menu items.
@@ -42,17 +40,17 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI component associated with the settings menu item.
         /// </summary>
-        public AppiumWebElement SettingsMenuItem => this.Element.FindElement(ByExtensions.AutomationId("SettingsItem"));
+        public AppiumWebElement SettingsMenuItem => this.Element.FindElement(WindowsByExtras.AutomationId("SettingsItem"));
 
         /// <summary>
         /// Gets the UI component associated with the navigation pane toggle button.
         /// </summary>
-        public Button ToggleNavigationPaneButton => this.Element.FindElement(ByExtensions.AutomationId("TogglePaneButton"));
+        public Button ToggleNavigationPaneButton => this.Element.FindElement(WindowsByExtras.AutomationId("TogglePaneButton"));
 
         /// <summary>
         /// Gets the UI component associated with the navigation back button.
         /// </summary>
-        public Button BackButton => this.Element.FindElement(ByExtensions.AutomationId("NavigationViewBackButton"));
+        public Button BackButton => this.Element.FindElement(WindowsByExtras.AutomationId("NavigationViewBackButton"));
 
         /// <summary>
         /// Gets a value indicating whether the pane is currently open.
@@ -161,7 +159,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <returns>True if the pane is open; otherwise, false.</returns>
         public bool VerifyPaneOpen(int expectedCompactPaneWidth)
         {
-            AppiumWebElement pane = this.Element.FindElement(ByExtensions.AutomationId("PaneRoot"));
+            AppiumWebElement pane = this.Element.FindElement(WindowsByExtras.AutomationId("PaneRoot"));
             int paneWidth = pane.Rect.Width;
             return paneWidth > expectedCompactPaneWidth;
         }

--- a/src/Legerity.WinUI/NavigationViewItem.cs
+++ b/src/Legerity.WinUI/NavigationViewItem.cs
@@ -4,8 +4,6 @@ namespace Legerity.Windows.Elements.WinUI
     using System.Collections.Generic;
     using System.Linq;
     using Legerity.Extensions;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -139,7 +137,7 @@ namespace Legerity.Windows.Elements.WinUI
                     element => new NavigationViewItem(this.ParentNavigationView, this, element as WindowsElement));
             }
 
-            return this.Driver.FindElement(ByExtensions.AutomationId("ChildrenFlyout"))
+            return this.Driver.FindElement(WindowsByExtras.AutomationId("ChildrenFlyout"))
                 .FindElements(this.navigationViewItemLocator).Select(
                     element => new NavigationViewItem(this.ParentNavigationView, this, element as WindowsElement));
         }

--- a/src/Legerity.WinUI/NumberBox.cs
+++ b/src/Legerity.WinUI/NumberBox.cs
@@ -3,8 +3,6 @@ namespace Legerity.Windows.Elements.WinUI
     using System;
 
     using Legerity.Windows.Elements.Core;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -53,17 +51,17 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the element associated with the inline up button.
         /// </summary>
-        public Button InlineUpButton => this.Element.FindElement(ByExtensions.AutomationId("UpSpinButton"));
+        public Button InlineUpButton => this.Element.FindElement(WindowsByExtras.AutomationId("UpSpinButton"));
 
         /// <summary>
         /// Gets the element associated with the inline down button.
         /// </summary>
-        public Button InlineDownButton => this.Element.FindElement(ByExtensions.AutomationId("DownSpinButton"));
+        public Button InlineDownButton => this.Element.FindElement(WindowsByExtras.AutomationId("DownSpinButton"));
 
         /// <summary>
         /// Gets the element associated with the input text box.
         /// </summary>
-        public TextBox InputBox => this.Element.FindElement(ByExtensions.AutomationId("InputBox"));
+        public TextBox InputBox => this.Element.FindElement(WindowsByExtras.AutomationId("InputBox"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="NumberBox"/> without direct casting.

--- a/src/Legerity.WinUI/TabView.cs
+++ b/src/Legerity.WinUI/TabView.cs
@@ -16,7 +16,7 @@ namespace Legerity.Windows.Elements.WinUI
     /// </summary>
     public class TabView : WindowsElementWrapper
     {
-        private readonly By tabListViewLocator = ByExtensions.AutomationId("TabListView");
+        private readonly By tabListViewLocator = WindowsByExtras.AutomationId("TabListView");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TabView"/> class.
@@ -32,7 +32,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the element associated with the add tab button.
         /// </summary>
-        public Button AddTabButton => this.Element.FindElement(ByExtensions.AutomationId("AddButton"));
+        public Button AddTabButton => this.Element.FindElement(WindowsByExtras.AutomationId("AddButton"));
 
         /// <summary>
         /// Gets the collection of items associated with the pivot.
@@ -104,7 +104,7 @@ namespace Legerity.Windows.Elements.WinUI
         {
             this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
-            Button closeButton = item.FindElement(ByExtensions.AutomationId("CloseButton"));
+            Button closeButton = item.FindElement(WindowsByExtras.AutomationId("CloseButton"));
             closeButton.Click();
         }
     }

--- a/src/Legerity.Windows/Elements/Core/AutoSuggestBox.cs
+++ b/src/Legerity.Windows/Elements/Core/AutoSuggestBox.cs
@@ -1,9 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
-
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -13,7 +10,7 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class AutoSuggestBox : WindowsElementWrapper
     {
-        private readonly By suggestionsPopupLocator = ByExtensions.AutomationId("SuggestionsPopup");
+        private readonly By suggestionsPopupLocator = WindowsByExtras.AutomationId("SuggestionsPopup");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoSuggestBox"/> class.
@@ -34,12 +31,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the suggestion list when the <see cref="SuggestionsPopup"/> is shown.
         /// </summary>
-        public ListView SuggestionList => this.SuggestionsPopup.FindElement(ByExtensions.AutomationId("SuggestionsList"));
+        public ListView SuggestionList => this.SuggestionsPopup.FindElement(WindowsByExtras.AutomationId("SuggestionsList"));
 
         /// <summary>
         /// Gets the element associated with the text box.
         /// </summary>
-        public TextBox TextBox => this.Element.FindElement(ByExtensions.AutomationId("TextBox"));
+        public TextBox TextBox => this.Element.FindElement(WindowsByExtras.AutomationId("TextBox"));
 
         /// <summary>
         /// Gets the value of the auto-suggest box.

--- a/src/Legerity.Windows/Elements/Core/CalendarDatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/CalendarDatePicker.cs
@@ -1,8 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -29,7 +27,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the element associated with the calendar flyout.
         /// </summary>
         public CalendarView CalendarViewFlyout =>
-            this.Driver.FindElement(this.calendarPopupLocator).FindElement(ByExtensions.AutomationId("CalendarView"));
+            this.Driver.FindElement(this.calendarPopupLocator).FindElement(WindowsByExtras.AutomationId("CalendarView"));
 
         /// <summary>
         /// Gets the value of the calendar date picker.

--- a/src/Legerity.Windows/Elements/Core/CalendarView.cs
+++ b/src/Legerity.Windows/Elements/Core/CalendarView.cs
@@ -6,8 +6,6 @@ namespace Legerity.Windows.Elements.Core
     using System.Linq;
     using System.Threading;
     using Legerity.Extensions;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -47,17 +45,17 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the header button (change month, year).
         /// </summary>
-        public Button HeaderButton => this.Element.FindElement(ByExtensions.AutomationId("HeaderButton"));
+        public Button HeaderButton => this.Element.FindElement(WindowsByExtras.AutomationId("HeaderButton"));
 
         /// <summary>
         /// Gets the element associated with the next month button.
         /// </summary>
-        public Button NextMonthButton => this.Element.FindElement(ByExtensions.AutomationId("NextButton"));
+        public Button NextMonthButton => this.Element.FindElement(WindowsByExtras.AutomationId("NextButton"));
 
         /// <summary>
         /// Gets the element associated with the previous month button.
         /// </summary>
-        public Button PreviousMonthButton => this.Element.FindElement(ByExtensions.AutomationId("PreviousButton"));
+        public Button PreviousMonthButton => this.Element.FindElement(WindowsByExtras.AutomationId("PreviousButton"));
 
         /// <summary>
         /// Gets the collection of days associated with the current month in the calendar view.

--- a/src/Legerity.Windows/Elements/Core/CommandBar.cs
+++ b/src/Legerity.Windows/Elements/Core/CommandBar.cs
@@ -15,9 +15,9 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class CommandBar : WindowsElementWrapper
     {
-        private readonly By moreButtonLocator = ByExtensions.AutomationId("MoreButton");
+        private readonly By moreButtonLocator = WindowsByExtras.AutomationId("MoreButton");
 
-        private readonly By overflowPopupLocator = ByExtensions.AutomationId("OverflowPopup");
+        private readonly By overflowPopupLocator = WindowsByExtras.AutomationId("OverflowPopup");
 
         private readonly By appBarButtonLocator = By.ClassName(nameof(AppBarButton));
 

--- a/src/Legerity.Windows/Elements/Core/DatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/DatePicker.cs
@@ -1,8 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
-
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -60,11 +58,11 @@ namespace Legerity.Windows.Elements.Core
             this.Element.Click();
 
             // Finds the popup and changes the time.
-            WindowsElement popup = this.Driver.FindElement(ByExtensions.AutomationId("DatePickerFlyoutPresenter"));
-            popup.FindElement(ByExtensions.AutomationId("DayLoopingSelector")).FindElementByName(date.ToString("%d")).Click();
-            popup.FindElement(ByExtensions.AutomationId("MonthLoopingSelector")).FindElementByName(date.ToString("MMMM")).Click();
-            popup.FindElement(ByExtensions.AutomationId("YearLoopingSelector")).FindElementByName(date.ToString("yyyy")).Click();
-            popup.FindElement(ByExtensions.AutomationId("AcceptButton")).Click();
+            WindowsElement popup = this.Driver.FindElement(WindowsByExtras.AutomationId("DatePickerFlyoutPresenter"));
+            popup.FindElement(WindowsByExtras.AutomationId("DayLoopingSelector")).FindElementByName(date.ToString("%d")).Click();
+            popup.FindElement(WindowsByExtras.AutomationId("MonthLoopingSelector")).FindElementByName(date.ToString("MMMM")).Click();
+            popup.FindElement(WindowsByExtras.AutomationId("YearLoopingSelector")).FindElementByName(date.ToString("yyyy")).Click();
+            popup.FindElement(WindowsByExtras.AutomationId("AcceptButton")).Click();
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/FlipView.cs
+++ b/src/Legerity.Windows/Elements/Core/FlipView.cs
@@ -5,8 +5,6 @@ namespace Legerity.Windows.Elements.Core
     using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -35,12 +33,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the next item button.
         /// </summary>
-        public Button NextButton => this.Element.FindElement(ByExtensions.AutomationId("NextButtonHorizontal"));
+        public Button NextButton => this.Element.FindElement(WindowsByExtras.AutomationId("NextButtonHorizontal"));
 
         /// <summary>
         /// Gets the element associated with the previous item button.
         /// </summary>
-        public Button PreviousButton => this.Element.FindElement(ByExtensions.AutomationId("PreviousButtonHorizontal"));
+        public Button PreviousButton => this.Element.FindElement(WindowsByExtras.AutomationId("PreviousButtonHorizontal"));
 
         /// <summary>
         /// Gets the currently selected item.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.ColorFlyoutBase.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.ColorFlyoutBase.cs
@@ -3,8 +3,6 @@ namespace Legerity.Windows.Elements.Core
     using System;
     using System.Linq;
     using Legerity.Extensions;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -19,7 +17,7 @@ namespace Legerity.Windows.Elements.Core
         /// </summary>
         private abstract class InkToolbarColorFlyoutBase : WindowsElementWrapper
         {
-            private readonly By penColorPaletteLocator = ByExtensions.AutomationId("PenColorPalette");
+            private readonly By penColorPaletteLocator = WindowsByExtras.AutomationId("PenColorPalette");
 
             /// <summary>
             /// Initializes a new instance of the <see cref="InkToolbarColorFlyoutBase"/> class.
@@ -40,7 +38,7 @@ namespace Legerity.Windows.Elements.Core
             /// <summary>
             /// Gets the element associated with the size of the ink.
             /// </summary>
-            public Slider SizeSlider => this.Driver.FindElement(ByExtensions.AutomationId("PenStrokeWidthSlider"));
+            public Slider SizeSlider => this.Driver.FindElement(WindowsByExtras.AutomationId("PenStrokeWidthSlider"));
 
             /// <summary>
             /// Gets the currently selected color.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.cs
@@ -1,8 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -33,7 +31,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the element associated with the ballpoint pen button.
         /// </summary>
         public RadioButton BallpointPenButton =>
-            this.Element.FindElement(ByExtensions.AutomationId("InkToolbarBallpointPenButton"));
+            this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarBallpointPenButton"));
 
         /// <summary>
         /// Gets the currently selected ballpoint pen color.
@@ -44,7 +42,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the element associated with the pencil button.
         /// </summary>
         public RadioButton PencilButton =>
-            this.Element.FindElement(ByExtensions.AutomationId("InkToolbarPencilButton"));
+            this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarPencilButton"));
 
         /// <summary>
         /// Gets the currently selected pencil color.
@@ -55,7 +53,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the element associated with the highlighter button.
         /// </summary>
         public RadioButton HighlighterButton =>
-            this.Element.FindElement(ByExtensions.AutomationId("InkToolbarHighlighterButton"));
+            this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarHighlighterButton"));
 
         /// <summary>
         /// Gets the currently selected highlighter color.
@@ -66,7 +64,7 @@ namespace Legerity.Windows.Elements.Core
         /// Gets the element associated with the ruler button.
         /// </summary>
         public ToggleButton RulerButton =>
-            this.Element.FindElement(ByExtensions.AutomationId("InkToolbarStencilButton"));
+            this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarStencilButton"));
 
         private InkToolbarBallpointPenFlyout BallpointPenFlyout =>
             this.Driver.FindElement(this.ballpointPenFlyoutLocator);

--- a/src/Legerity.Windows/Elements/Core/PasswordBox.cs
+++ b/src/Legerity.Windows/Elements/Core/PasswordBox.cs
@@ -1,7 +1,5 @@
 namespace Legerity.Windows.Elements.Core
 {
-    using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -24,7 +22,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the reveal password button.
         /// </summary>
-        public ToggleButton RevealButton => this.Element.FindElement(ByExtensions.AutomationId("RevealButton"));
+        public ToggleButton RevealButton => this.Element.FindElement(WindowsByExtras.AutomationId("RevealButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="PasswordBox"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/TimePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/TimePicker.cs
@@ -1,7 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
-    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -61,10 +60,10 @@ namespace Legerity.Windows.Elements.Core
             this.Element.Click();
 
             // Finds the popup and changes the time.
-            WindowsElement popup = this.Driver.FindElement(ByExtensions.AutomationId("TimePickerFlyoutPresenter"));
-            popup.FindElement(ByExtensions.AutomationId("HourLoopingSelector")).FindElementByName(time.ToString("%h")).Click();
-            popup.FindElement(ByExtensions.AutomationId("MinuteLoopingSelector")).FindElementByName(time.ToString("mm")).Click();
-            popup.FindElement(ByExtensions.AutomationId("AcceptButton")).Click();
+            WindowsElement popup = this.Driver.FindElement(WindowsByExtras.AutomationId("TimePickerFlyoutPresenter"));
+            popup.FindElement(WindowsByExtras.AutomationId("HourLoopingSelector")).FindElementByName(time.ToString("%h")).Click();
+            popup.FindElement(WindowsByExtras.AutomationId("MinuteLoopingSelector")).FindElementByName(time.ToString("mm")).Click();
+            popup.FindElement(WindowsByExtras.AutomationId("AcceptButton")).Click();
         }
     }
 }

--- a/src/Legerity.Windows/Extensions/ByExtensions.cs
+++ b/src/Legerity.Windows/Extensions/ByExtensions.cs
@@ -21,6 +21,7 @@ namespace Legerity.Windows.Extensions
         /// <exception cref="ArgumentNullException">
         /// Thrown if the <paramref name="automationId"/> is null.
         /// </exception>
+        [Obsolete("AutomationId(string) will be removed in a future major release. Please use the WindowsByExtras.AutomationId(string) instead.")]
         public static By AutomationId(string automationId)
         {
             if (automationId == null)

--- a/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
@@ -23,7 +23,7 @@ namespace Legerity.Windows.Extensions
         public static TElement FindElementByAutomationId<TElement>(this WindowsDriver<TElement> driver, string automationId)
             where TElement : IWebElement
         {
-            return driver.FindElement(ByExtensions.AutomationId(automationId));
+            return driver.FindElement(WindowsByExtras.AutomationId(automationId));
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Legerity.Windows.Extensions
         /// <returns>The located <see cref="AppiumWebElement"/>.</returns>
         public static AppiumWebElement FindElementByAutomationId(this WindowsElement element, string automationId)
         {
-            return element.FindElement(ByExtensions.AutomationId(automationId));
+            return element.FindElement(WindowsByExtras.AutomationId(automationId));
         }
 
         /// <summary>

--- a/src/Legerity.Windows/WindowsByExtras.cs
+++ b/src/Legerity.Windows/WindowsByExtras.cs
@@ -1,0 +1,31 @@
+namespace Legerity.Windows
+{
+    using System;
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines a collection of extra locator constraints for <see cref="By"/>.
+    /// </summary>
+    public static class WindowsByExtras
+    {
+        /// <summary>
+        /// Gets a mechanism to find elements by the Windows Automation ID.
+        /// </summary>
+        /// <param name="automationId">The automation ID to find.</param>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the <paramref name="automationId"/> is null.
+        /// </exception>
+        public static By AutomationId(string automationId)
+        {
+            if (automationId == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(automationId),
+                    "Cannot find elements with a null automation ID attribute");
+            }
+
+            return By.XPath($".//*[@AutomationId='{automationId}']");
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to introduce new `AndroidByExtras` that can be used to find elements by content description. 

Additional attribute extensions have been introduced to get the content description of an element. 

`WindowsByExtras` has been introduced to replace the `ByExtensions` class that contained the definition for retrieving elements by Automation ID. This change is to match the existing `ByExtras` and new `AndroidByExtras`

## PR checklist

- [x] Sample tests have been added/updated and pass
- [ ] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
