### PR TITLE
Partial name matching for element selection methods

### DIFF
--- a/samples/AndroidCoreSamples/AndroidCoreSamples.csproj
+++ b/samples/AndroidCoreSamples/AndroidCoreSamples.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/MADESampleApp/MADESampleApp.csproj
+++ b/samples/MADESampleApp/MADESampleApp.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/TelerikUwpSdkSample/TelerikUwpSdkSample.csproj
+++ b/samples/TelerikUwpSdkSample/TelerikUwpSdkSample.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/W3SchoolsWebTests/W3SchoolsWebTests.csproj
+++ b/samples/W3SchoolsWebTests/W3SchoolsWebTests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="100.0.4896.6000" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="99.0.1150.46" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="101.0.4951.4100" />
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="100.0.1185.50" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/WebTests/WebTests.csproj
+++ b/samples/WebTests/WebTests.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="99.0.1150.46" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="100.0.1185.50" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
+++ b/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/WindowsCommunityToolkitSampleApp/WindowsCommunityToolkitSampleApp.csproj
+++ b/samples/WindowsCommunityToolkitSampleApp/WindowsCommunityToolkitSampleApp.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/samples/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/samples/XamlControlsGallery/XamlControlsGallery.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 

--- a/src/Legerity.Android/Elements/AndroidElementWrapper.cs
+++ b/src/Legerity.Android/Elements/AndroidElementWrapper.cs
@@ -30,11 +30,6 @@ namespace Legerity.Android.Elements
         public AndroidDriver<AndroidElement> Driver => AppManager.AndroidApp;
 
         /// <summary>
-        /// Gets a value indicating whether the element is enabled.
-        /// </summary>
-        public bool IsEnabled => this.Element.Enabled;
-
-        /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
         /// <param name="locator">The locator to find a specific element.</param>

--- a/src/Legerity.Android/Elements/Core/Button.cs
+++ b/src/Legerity.Android/Elements/Core/Button.cs
@@ -47,13 +47,5 @@ namespace Legerity.Android.Elements.Core
         {
             return new Button(element as AndroidElement);
         }
-
-        /// <summary>
-        /// Clicks the button.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
     }
 }

--- a/src/Legerity.Android/Elements/Core/CheckBox.cs
+++ b/src/Legerity.Android/Elements/Core/CheckBox.cs
@@ -24,7 +24,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the check box is in the checked state.
         /// </summary>
-        public bool IsChecked => this.Element.GetAttribute("Checked") == CheckedValue;
+        public virtual bool IsChecked => this.GetAttribute("Checked") == CheckedValue;
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="CheckBox"/> without direct casting.
@@ -57,27 +57,27 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Checks the check box on.
         /// </summary>
-        public void CheckOn()
+        public virtual void CheckOn()
         {
             if (this.IsChecked)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
 
         /// <summary>
         /// Checks the check box off.
         /// </summary>
-        public void CheckOff()
+        public virtual void CheckOff()
         {
             if (!this.IsChecked)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.Android/Elements/Core/DatePicker.cs
+++ b/src/Legerity.Android/Elements/Core/DatePicker.cs
@@ -45,7 +45,7 @@ namespace Legerity.Android.Elements.Core
         /// This will be in the format, 'ddd, MMM d'.
         /// </para>
         /// </summary>
-        public TextView DateTextView => this.Element.FindElement(By.Id("android:id/date_picker_header_date"));
+        public virtual TextView DateTextView => this.Element.FindElement(By.Id("android:id/date_picker_header_date"));
 
         /// <summary>
         /// Gets the element associated with the year text.
@@ -53,27 +53,27 @@ namespace Legerity.Android.Elements.Core
         /// This will be in the format, 'YYYY'.
         /// </para>
         /// </summary>
-        public TextView YearTextView => this.Element.FindElement(By.Id("android:id/date_picker_header_year"));
+        public virtual TextView YearTextView => this.Element.FindElement(By.Id("android:id/date_picker_header_year"));
 
         /// <summary>
         /// Gets the element associated with the day picker.
         /// </summary>
-        public View DayPickerView => this.Element.FindElement(By.Id("android:id/day_picker_view_pager"));
+        public virtual View DayPickerView => this.Element.FindElement(By.Id("android:id/day_picker_view_pager"));
 
         /// <summary>
         /// Gets the element associated with the next month button.
         /// </summary>
-        public Button NextMonthButton => this.Element.FindElementByAndroidUIAutomator("UiSelector().description(\"Next month\")");
+        public virtual Button NextMonthButton => this.Element.FindElementByAndroidUIAutomator("UiSelector().description(\"Next month\")");
 
         /// <summary>
         /// Gets the element associated with the previous month button.
         /// </summary>
-        public Button PreviousMonthButton => this.Element.FindElementByAndroidUIAutomator("UiSelector().description(\"Previous month\")");
+        public virtual Button PreviousMonthButton => this.Element.FindElementByAndroidUIAutomator("UiSelector().description(\"Previous month\")");
 
         /// <summary>
         /// Gets the selected date/time value.
         /// </summary>
-        public DateTime SelectedDate => this.GetCurrentViewDate();
+        public virtual DateTime SelectedDate => this.GetCurrentViewDate();
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="DatePicker"/> without direct casting.
@@ -107,7 +107,7 @@ namespace Legerity.Android.Elements.Core
         /// Sets the selected date of the date picker.
         /// </summary>
         /// <param name="date">The date to set to.</param>
-        public void SetDate(DateTime date)
+        public virtual void SetDate(DateTime date)
         {
             DateTime currentViewDate = this.GetCurrentViewDate();
 

--- a/src/Legerity.Android/Elements/Core/EditText.cs
+++ b/src/Legerity.Android/Elements/Core/EditText.cs
@@ -20,7 +20,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets the text value of the text box.
         /// </summary>
-        public string Text => this.Element.Text;
+        public virtual string Text => this.Element.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="EditText"/> without direct casting.
@@ -54,7 +54,7 @@ namespace Legerity.Android.Elements.Core
         /// Sets the text of the text box to the specified text.
         /// </summary>
         /// <param name="text">The text to display.</param>
-        public void SetText(string text)
+        public virtual void SetText(string text)
         {
             this.ClearText();
             this.AppendText(text);
@@ -64,18 +64,18 @@ namespace Legerity.Android.Elements.Core
         /// Appends the specified text to the text box.
         /// </summary>
         /// <param name="text">The text to append.</param>
-        public void AppendText(string text)
+        public virtual void AppendText(string text)
         {
-            this.Element.Click();
+            this.Click();
             this.Element.SendKeys(text);
         }
 
         /// <summary>
         /// Clears the text from the text box.
         /// </summary>
-        public void ClearText()
+        public virtual void ClearText()
         {
-            this.Element.Click();
+            this.Click();
             this.Element.Clear();
         }
     }

--- a/src/Legerity.Android/Elements/Core/RadioButton.cs
+++ b/src/Legerity.Android/Elements/Core/RadioButton.cs
@@ -23,10 +23,8 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the radio button is selected.
         /// </summary>
-        public bool IsSelected =>
-            this.Element.GetAttribute("Checked").Equals(
-                "True",
-                StringComparison.CurrentCultureIgnoreCase);
+        public virtual bool IsSelected =>
+            this.GetAttribute("Checked").Equals("True", StringComparison.CurrentCultureIgnoreCase);
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="RadioButton"/> without direct casting.

--- a/src/Legerity.Android/Elements/Core/Spinner.cs
+++ b/src/Legerity.Android/Elements/Core/Spinner.cs
@@ -23,7 +23,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets the currently selected item.
         /// </summary>
-        public string SelectedItem => this.GetSelectedItem();
+        public virtual string SelectedItem => this.GetSelectedItem();
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="Spinner"/> without direct casting.
@@ -59,13 +59,29 @@ namespace Legerity.Android.Elements.Core
         /// <param name="name">
         /// The name of the item to select.
         /// </param>
-        public void SelectItem(string name)
+        public virtual void SelectItem(string name)
         {
-            this.Element.Click();
+            this.Click();
 
             var locator =
                 new ByAndroidUIAutomator(
                     $"new UiScrollable(new UiSelector()).scrollIntoView(new UiSelector().text(\"{name}\"));");
+            AndroidElement item = this.Driver.FindElement(locator);
+
+            item.Click();
+        }
+
+        /// <summary>
+        /// Selects an item in the combo-box with the specified partial item name.
+        /// </summary>
+        /// <param name="partialName">The partial name match for the item to select.</param>
+        public virtual void SelectItemByPartialName(string partialName)
+        {
+            this.Click();
+
+            var locator =
+                new ByAndroidUIAutomator(
+                    $"new UiScrollable(new UiSelector()).scrollIntoView(new UiSelector().textContains(\"{partialName}\"));");
             AndroidElement item = this.Driver.FindElement(locator);
 
             item.Click();

--- a/src/Legerity.Android/Elements/Core/Switch.cs
+++ b/src/Legerity.Android/Elements/Core/Switch.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Android.Elements.Core
 {
+    using System;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Android;
 
@@ -8,8 +9,6 @@ namespace Legerity.Android.Elements.Core
     /// </summary>
     public class Switch : AndroidElementWrapper
     {
-        private const string ToggleOnValue = "true";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Switch"/> class.
         /// </summary>
@@ -24,7 +23,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the toggle switch is in the on position.
         /// </summary>
-        public bool IsOn => this.Element.GetAttribute("Checked") == ToggleOnValue;
+        public virtual bool IsOn => this.GetAttribute("Checked").Equals("True", StringComparison.CurrentCultureIgnoreCase);
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="Switch"/> without direct casting.
@@ -57,27 +56,27 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Toggles the switch on.
         /// </summary>
-        public void ToggleOn()
+        public virtual void ToggleOn()
         {
             if (this.IsOn)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
 
         /// <summary>
         /// Toggles the switch off.
         /// </summary>
-        public void ToggleOff()
+        public virtual void ToggleOff()
         {
             if (!this.IsOn)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.Android/Elements/Core/TextView.cs
+++ b/src/Legerity.Android/Elements/Core/TextView.cs
@@ -22,7 +22,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets the text value of the text view.
         /// </summary>
-        public string Text => this.Element.Text;
+        public virtual string Text => this.Element.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="TextView"/> without direct casting.

--- a/src/Legerity.Android/Elements/Core/ToggleButton.cs
+++ b/src/Legerity.Android/Elements/Core/ToggleButton.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Android.Elements.Core
 {
+    using System;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Android;
 
@@ -8,8 +9,6 @@ namespace Legerity.Android.Elements.Core
     /// </summary>
     public class ToggleButton : Button
     {
-        private const string ToggleOnValue = "true";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ToggleButton"/> class.
         /// </summary>
@@ -24,7 +23,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the toggle button is in the on position.
         /// </summary>
-        public bool IsOn => this.Element.GetAttribute("Checked") == ToggleOnValue;
+        public virtual bool IsOn => this.GetAttribute("Checked").Equals("True", StringComparison.CurrentCultureIgnoreCase);
 
         /// <summary>
         /// Allows conversion of a <see cref="AndroidElement"/> to the <see cref="ToggleButton"/> without direct casting.
@@ -57,7 +56,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Toggles the button on.
         /// </summary>
-        public void ToggleOn()
+        public virtual void ToggleOn()
         {
             if (this.IsOn)
             {
@@ -70,7 +69,7 @@ namespace Legerity.Android.Elements.Core
         /// <summary>
         /// Toggles the button off.
         /// </summary>
-        public void ToggleOff()
+        public virtual void ToggleOff()
         {
             if (!this.IsOn)
             {

--- a/src/Legerity.Android/Elements/Core/View.cs
+++ b/src/Legerity.Android/Elements/Core/View.cs
@@ -47,13 +47,5 @@ namespace Legerity.Android.Elements.Core
         {
             return new View(element as AndroidElement);
         }
-
-        /// <summary>
-        /// Clicks the element.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
     }
 }

--- a/src/Legerity.Core/ElementWrapper`1.cs
+++ b/src/Legerity.Core/ElementWrapper`1.cs
@@ -39,7 +39,30 @@ namespace Legerity
         /// <summary>
         /// Gets a value indicating whether the element is visible.
         /// </summary>
-        public bool IsVisible => this.Element.Displayed;
+        public virtual bool IsVisible => this.Element.Displayed;
+
+        /// <summary>
+        /// Gets a value indicating whether the element is enabled.
+        /// </summary>
+        public virtual bool IsEnabled => this.Element.Enabled;
+
+        /// <summary>
+        /// Clicks the element.
+        /// </summary>
+        public virtual void Click()
+        {
+            this.Element.Click();
+        }
+
+        /// <summary>
+        /// Gets the value of the specified attribute for this element.
+        /// </summary>
+        /// <param name="attributeName">The name of the attribute.</param>
+        /// <returns>The attribute's current value if it exists; otherwise, null.</returns>
+        public string GetAttribute(string attributeName)
+        {
+            return this.Element.GetAttribute(attributeName);
+        }
 
         /// <summary>
         /// Finds a child element by the specified locator.

--- a/src/Legerity.Core/IElementWrapper.cs
+++ b/src/Legerity.Core/IElementWrapper.cs
@@ -21,6 +21,23 @@ namespace Legerity
         bool IsVisible { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the element is enabled.
+        /// </summary>
+        bool IsEnabled { get; }
+
+        /// <summary>
+        /// Clicks the element.
+        /// </summary>
+        void Click();
+
+        /// <summary>
+        /// Gets the value of the specified attribute for this element.
+        /// </summary>
+        /// <param name="attributeName">The name of the attribute.</param>
+        /// <returns>The attribute's current value if it exists; otherwise, null.</returns>
+        string GetAttribute(string attributeName);
+
+        /// <summary>
         /// Determines whether the given element is shown.
         /// </summary>
         /// <param name="locator">

--- a/src/Legerity.Core/Web/WebAppManagerOptions.cs
+++ b/src/Legerity.Core/Web/WebAppManagerOptions.cs
@@ -11,7 +11,6 @@ namespace Legerity.Web
         /// <summary>
         /// Initializes a new instance of the <see cref="WebAppManagerOptions"/> class.
         /// </summary>
-
         public WebAppManagerOptions()
         {
         }

--- a/src/Legerity.IOS/Elements/Core/Button.cs
+++ b/src/Legerity.IOS/Elements/Core/Button.cs
@@ -23,7 +23,7 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Gets the button's label content.
         /// </summary>
-        public string Label => this.Element.GetLabel();
+        public virtual string Label => this.Element.GetLabel();
 
         /// <summary>
         /// Allows conversion of a <see cref="IOSElement"/> to the <see cref="Button"/> without direct casting.
@@ -51,14 +51,6 @@ namespace Legerity.IOS.Elements.Core
         public static implicit operator Button(AppiumWebElement element)
         {
             return new Button(element as IOSElement);
-        }
-
-        /// <summary>
-        /// Clicks the button.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
         }
     }
 }

--- a/src/Legerity.IOS/Elements/Core/Label.cs
+++ b/src/Legerity.IOS/Elements/Core/Label.cs
@@ -23,7 +23,7 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Gets the text value of the label.
         /// </summary>
-        public string Text => this.Element.GetLabel();
+        public virtual string Text => this.Element.GetLabel();
 
         /// <summary>
         /// Allows conversion of a <see cref="IOSElement"/> to the <see cref="Label"/> without direct casting.

--- a/src/Legerity.IOS/Elements/Core/ProgressView.cs
+++ b/src/Legerity.IOS/Elements/Core/ProgressView.cs
@@ -23,8 +23,8 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Gets the value of the progress bar.
         /// </summary>
-        public double Percentage => double.Parse(this.Element.GetValue().TrimEnd('%'));
-        
+        public virtual double Percentage => double.Parse(this.Element.GetValue().TrimEnd('%'));
+
         /// <summary>
         /// Allows conversion of a <see cref="IOSElement"/> to the <see cref="ProgressView"/> without direct casting.
         /// </summary>

--- a/src/Legerity.IOS/Elements/Core/Slider.cs
+++ b/src/Legerity.IOS/Elements/Core/Slider.cs
@@ -25,12 +25,12 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Gets the value of the slider as a percentage between 0 and 100.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetValue().TrimEnd('%'));
+        public virtual double Value => double.Parse(this.Element.GetValue().TrimEnd('%'));
 
         /// <summary>
         /// Gets a value indicating whether the control is in a readonly state.
         /// </summary>
-        public bool IsReadonly => !this.IsEnabled;
+        public virtual bool IsReadonly => !this.IsEnabled;
 
         /// <summary>
         /// Allows conversion of a <see cref="IOSElement"/> to the <see cref="Slider"/> without direct casting.
@@ -66,9 +66,9 @@ namespace Legerity.IOS.Elements.Core
         /// <param name="value">
         /// The value.
         /// </param>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
-            this.Element.Click();
+            this.Click();
 
             double currentValue = this.Value;
             while (Math.Abs(currentValue - value) > double.Epsilon)

--- a/src/Legerity.IOS/Elements/Core/Switch.cs
+++ b/src/Legerity.IOS/Elements/Core/Switch.cs
@@ -25,7 +25,7 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the toggle switch is in the on position.
         /// </summary>
-        public bool IsOn => this.Element.GetValue() == ToggleOnValue;
+        public virtual bool IsOn => this.Element.GetValue() == ToggleOnValue;
 
         /// <summary>
         /// Allows conversion of a <see cref="IOSElement"/> to the <see cref="Switch"/> without direct casting.
@@ -58,27 +58,27 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Toggles the switch on.
         /// </summary>
-        public void ToggleOn()
+        public virtual void ToggleOn()
         {
             if (this.IsOn)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
 
         /// <summary>
         /// Toggles the switch off.
         /// </summary>
-        public void ToggleOff()
+        public virtual void ToggleOff()
         {
             if (!this.IsOn)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.IOS/Elements/Core/TextField.cs
+++ b/src/Legerity.IOS/Elements/Core/TextField.cs
@@ -22,12 +22,12 @@ namespace Legerity.IOS.Elements.Core
         /// <summary>
         /// Gets the text value of the text field.
         /// </summary>
-        public string Text => this.Element.GetValue();
+        public virtual string Text => this.Element.GetValue();
 
         /// <summary>
         /// Gets the element associated with the clear text button, if shown.
         /// </summary>
-        public Button ClearTextButton => this.Element.FindElement(IOSByExtras.Label("Clear text"));
+        public virtual Button ClearTextButton => this.Element.FindElement(IOSByExtras.Label("Clear text"));
 
         /// <summary>
         /// Allows conversion of a <see cref="IOSElement"/> to the <see cref="TextField"/> without direct casting.
@@ -61,7 +61,7 @@ namespace Legerity.IOS.Elements.Core
         /// Sets the text of the text field to the specified text.
         /// </summary>
         /// <param name="text">The text to display.</param>
-        public void SetText(string text)
+        public virtual void SetText(string text)
         {
             this.ClearText();
             this.AppendText(text);
@@ -71,18 +71,18 @@ namespace Legerity.IOS.Elements.Core
         /// Appends the specified text to the text field.
         /// </summary>
         /// <param name="text">The text to append.</param>
-        public void AppendText(string text)
+        public virtual void AppendText(string text)
         {
-            this.Element.Click();
+            this.Click();
             this.Element.SendKeys(text);
         }
 
         /// <summary>
         /// Clears the text from the text field.
         /// </summary>
-        public void ClearText()
+        public virtual void ClearText()
         {
-            this.Element.Click();
+            this.Click();
             this.Element.Clear();
         }
     }

--- a/src/Legerity.IOS/Elements/IOSElementWrapper.cs
+++ b/src/Legerity.IOS/Elements/IOSElementWrapper.cs
@@ -30,11 +30,6 @@ namespace Legerity.IOS.Elements
         public IOSDriver<IOSElement> Driver => AppManager.IOSApp;
 
         /// <summary>
-        /// Gets a value indicating whether the element is enabled.
-        /// </summary>
-        public bool IsEnabled => this.Element.Enabled;
-
-        /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
         /// <param name="locator">The locator to find a specific element.</param>

--- a/src/Legerity.MADE/DropDownList.cs
+++ b/src/Legerity.MADE/DropDownList.cs
@@ -25,7 +25,7 @@ namespace Legerity.Windows.Elements.MADE
         /// <summary>
         /// Gets the <see cref="ListView"/> element associated with the drop down content.
         /// </summary>
-        public ListView DropDown => this.Element.FindElement(WindowsByExtras.AutomationId("DropDownContent"));
+        public virtual ListView DropDown => this.Element.FindElement(WindowsByExtras.AutomationId("DropDownContent"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="DropDownList"/> without direct casting.
@@ -61,21 +61,38 @@ namespace Legerity.Windows.Elements.MADE
         /// <param name="name">
         /// The name of the item to select.
         /// </param>
-        public void SelectItem(string name)
+        public virtual void SelectItem(string name)
+        {
+            this.OpenDropDown();
+            this.DropDown.ClickItem(name);
+        }
+
+        /// <summary>
+        /// Selects an item in the combo-box with the specified partial item name.
+        /// </summary>
+        /// <param name="partialName">The partial name match for the item to select.</param>
+        public virtual void SelectItemByPartialName(string partialName)
+        {
+            this.OpenDropDown();
+            this.DropDown.ClickItemByPartialName(partialName);
+        }
+
+        /// <summary>
+        /// Opens the drop down if it is not already open.
+        /// </summary>
+        public virtual void OpenDropDown()
         {
             if (!this.IsDropDownOpen())
             {
-                this.Element.Click();
+                this.Click();
             }
-
-            this.DropDown.ClickItem(name);
         }
 
         /// <summary>
         /// Determines whether the drop down is open.
         /// </summary>
         /// <returns>True if the drop down is open; otherwise, false.</returns>
-        public bool IsDropDownOpen()
+        public virtual bool IsDropDownOpen()
         {
             bool isVisible;
 

--- a/src/Legerity.MADE/InputValidator.cs
+++ b/src/Legerity.MADE/InputValidator.cs
@@ -24,12 +24,12 @@ namespace Legerity.Windows.Elements.MADE
         /// <summary>
         /// Gets the <see cref="TextBlock"/> associated with the validation feedback message.
         /// </summary>
-        public TextBlock ValidationFeedback => this.Element.FindElement(WindowsByExtras.AutomationId("ValidatorFeedbackMessage"));
+        public virtual TextBlock ValidationFeedback => this.Element.FindElement(WindowsByExtras.AutomationId("ValidatorFeedbackMessage"));
 
         /// <summary>
         /// Gets the validation feedback message associated with the <see cref="ValidationFeedback"/> element.
         /// </summary>
-        public string Message => this.ValidationFeedback?.Text;
+        public virtual string Message => this.ValidationFeedback?.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InputValidator"/> without direct casting.
@@ -73,7 +73,7 @@ namespace Legerity.Windows.Elements.MADE
         /// Retrieves the feedback message text if the <see cref="ValidationFeedback"/> is shown.
         /// </summary>
         /// <returns>The feedback message text of the <see cref="ValidationFeedback"/> element.</returns>
-        public string FeedbackMessage()
+        public virtual string FeedbackMessage()
         {
             string message;
 

--- a/src/Legerity.Telerik.Uwp/RadAutoCompleteBox.cs
+++ b/src/Legerity.Telerik.Uwp/RadAutoCompleteBox.cs
@@ -27,12 +27,12 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Gets the element associated with the text box.
         /// </summary>
-        public TextBox TextBox => this.Element.FindElement(By.ClassName("TextBox"));
+        public virtual TextBox TextBox => this.Element.FindElement(By.ClassName("TextBox"));
 
         /// <summary>
         /// Gets the value of the auto-suggest box.
         /// </summary>
-        public string Text => this.TextBox.Text;
+        public virtual string Text => this.TextBox.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadAutoCompleteBox"/> without direct casting.
@@ -66,7 +66,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// Selects a suggestion from the auto-suggest box.
         /// </summary>
         /// <param name="suggestion">The suggestion to select.</param>
-        public void SelectSuggestion(string suggestion)
+        public virtual void SelectSuggestion(string suggestion)
         {
             this.SelectSuggestion(suggestion, suggestion);
         }
@@ -76,7 +76,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// </summary>
         /// <param name="value">The initial value to set.</param>
         /// <param name="suggestion">The suggestion to select.</param>
-        public void SelectSuggestion(string value, string suggestion)
+        public virtual void SelectSuggestion(string value, string suggestion)
         {
             this.SetText(value);
 
@@ -87,10 +87,25 @@ namespace Legerity.Windows.Elements.Telerik
         }
 
         /// <summary>
+        /// Selects a suggestion from the auto-suggest box.
+        /// </summary>
+        /// <param name="value">The initial value to set.</param>
+        /// <param name="partialSuggestion">The partial suggestion match to select.</param>
+        public virtual void SelectSuggestionByPartialSuggestion(string value, string partialSuggestion)
+        {
+            this.SetText(value);
+
+            this.VerifyElementShown(this.suggestionsControlLocator, TimeSpan.FromSeconds(2));
+
+            ListBox suggestionList = this.Element.FindElement(this.suggestionsControlLocator);
+            suggestionList.ClickItemByPartialName(partialSuggestion);
+        }
+
+        /// <summary>
         /// Sets the value of the auto-suggest box.
         /// </summary>
         /// <param name="value">The value to set.</param>
-        public void SetText(string value)
+        public virtual void SetText(string value)
         {
             this.TextBox.SetText(value);
         }

--- a/src/Legerity.Telerik.Uwp/RadBulletGraph.cs
+++ b/src/Legerity.Telerik.Uwp/RadBulletGraph.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Windows.Elements.Telerik
 {
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -22,17 +23,17 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Gets the minimum value of the bullet graph.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+        public virtual double Minimum => this.GetRangeMinimum();
 
         /// <summary>
         /// Gets the maximum value of the bullet graph.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+        public virtual double Maximum => this.GetRangeMaximum();
 
         /// <summary>
         /// Gets the value of the bullet graph.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Value => this.GetRangeValue();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadBulletGraph"/> without direct casting.

--- a/src/Legerity.Telerik.Uwp/RadBusyIndicator.cs
+++ b/src/Legerity.Telerik.Uwp/RadBusyIndicator.cs
@@ -24,7 +24,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Gets a value indicating whether the busy indicator is on.
         /// </summary>
-        public bool IsOn => this.Element.GetAttribute("ItemStatus") == OnValue;
+        public virtual bool IsOn => this.GetAttribute("ItemStatus") == OnValue;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadBusyIndicator"/> without direct casting.

--- a/src/Legerity.Telerik.Uwp/RadNumericBox.cs
+++ b/src/Legerity.Telerik.Uwp/RadNumericBox.cs
@@ -2,6 +2,7 @@ namespace Legerity.Windows.Elements.Telerik
 {
     using System;
     using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -25,42 +26,42 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Gets the minimum value of the RadNumericBox.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+        public virtual double Minimum => this.GetRangeMinimum();
 
         /// <summary>
         /// Gets the maximum value of the RadNumericBox.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+        public virtual double Maximum => this.GetRangeMaximum();
 
         /// <summary>
         /// Gets the small change (step) value of the RadNumericBox.
         /// </summary>
-        public double SmallChange => double.Parse(this.Element.GetAttribute("RangeValue.SmallChange"));
+        public virtual double SmallChange => this.GetRangeSmallChange();
 
         /// <summary>
         /// Gets the value of the RadNumericBox.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Value => this.GetRangeValue();
 
         /// <summary>
         /// Gets a value indicating whether the control is in a readonly state.
         /// </summary>
-        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+        public virtual bool IsReadonly => this.IsRangeReadonly();
 
         /// <summary>
         /// Gets the element associated with the increase button.
         /// </summary>
-        public Button Increase => this.Element.FindElement(WindowsByExtras.AutomationId("PART_IncreaseButton"));
+        public virtual Button Increase => this.Element.FindElement(WindowsByExtras.AutomationId("PART_IncreaseButton"));
 
         /// <summary>
         /// Gets the element associated with the decrease button.
         /// </summary>
-        public Button DecreaseButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_DecreaseButton"));
+        public virtual Button DecreaseButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_DecreaseButton"));
 
         /// <summary>
         /// Gets the element associated with the input text box.
         /// </summary>
-        public TextBox InputBox => this.Element.FindElement(WindowsByExtras.AutomationId("PART_TextBox"));
+        public virtual TextBox InputBox => this.Element.FindElement(WindowsByExtras.AutomationId("PART_TextBox"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadNumericBox"/> without direct casting.
@@ -99,7 +100,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the RadNumericBox.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
@@ -127,7 +128,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Increases the number box value by the <see cref="SmallChange"/> value.
         /// </summary>
-        public void Increment()
+        public virtual void Increment()
         {
             this.Increase.Click();
         }
@@ -135,7 +136,7 @@ namespace Legerity.Windows.Elements.Telerik
         /// <summary>
         /// Decreases the number box value by the <see cref="SmallChange"/> value.
         /// </summary>
-        public void Decrement()
+        public virtual void Decrement()
         {
             this.DecreaseButton.Click();
         }

--- a/src/Legerity.WCT/BladeView.cs
+++ b/src/Legerity.WCT/BladeView.cs
@@ -26,7 +26,7 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the UI components associated with the child blades.
         /// </summary>
-        public IEnumerable<BladeViewItem> Blades =>
+        public virtual IEnumerable<BladeViewItem> Blades =>
             this.Element.FindElements(By.ClassName("BladeItem"))
                 .Select(element => new BladeViewItem(this, element as WindowsElement));
 
@@ -63,18 +63,38 @@ namespace Legerity.Windows.Elements.WCT
         /// </summary>
         /// <param name="name">The name of the blade to retrieve.</param>
         /// <returns>A <see cref="BladeViewItem"/> instance if found; otherwise, null.</returns>
-        public BladeViewItem GetBlade(string name)
+        public virtual BladeViewItem GetBlade(string name)
         {
             return this.Blades.FirstOrDefault(element => element.Element.VerifyNameOrAutomationIdEquals(name));
         }
 
         /// <summary>
-        /// Closes an open blade.
+        /// Retrieves a <see cref="BladeViewItem"/> by the given partial name.
+        /// </summary>
+        /// <param name="partialName">The partial name of the blade to retrieve.</param>
+        /// <returns>A <see cref="BladeViewItem"/> instance if found; otherwise, null.</returns>
+        public virtual BladeViewItem GetBladeByPartialName(string partialName)
+        {
+            return this.Blades.FirstOrDefault(element => element.Element.VerifyNameOrAutomationIdContains(partialName));
+        }
+
+        /// <summary>
+        /// Closes an open blade by name.
         /// </summary>
         /// <param name="name">The name of the blade to close.</param>
-        public void CloseBlade(string name)
+        public virtual void CloseBlade(string name)
         {
             BladeViewItem blade = this.GetBlade(name);
+            blade.Close();
+        }
+
+        /// <summary>
+        /// Closes an open blade by partial name.
+        /// </summary>
+        /// <param name="partialName">The partial name of the blade to close.</param>
+        public virtual void CloseBladeByPartialName(string partialName)
+        {
+            BladeViewItem blade = this.GetBladeByPartialName(partialName);
             blade.Close();
         }
     }

--- a/src/Legerity.WCT/BladeViewItem.cs
+++ b/src/Legerity.WCT/BladeViewItem.cs
@@ -51,17 +51,17 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the <see cref="Button"/> element associated with the blade enlarge option.
         /// </summary>
-        public Button EnlargeButton => this.Element.FindElement(WindowsByExtras.AutomationId("EnlargeButton"));
+        public virtual Button EnlargeButton => this.Element.FindElement(WindowsByExtras.AutomationId("EnlargeButton"));
 
         /// <summary>
         /// Gets the <see cref="Button"/> element associated with the blade close option.
         /// </summary>
-        public Button CloseButton => this.Element.FindElement(WindowsByExtras.AutomationId("CloseButton"));
+        public virtual Button CloseButton => this.Element.FindElement(WindowsByExtras.AutomationId("CloseButton"));
 
         /// <summary>
         /// Closes the blade item.
         /// </summary>
-        public void Close()
+        public virtual void Close()
         {
             this.CloseButton.Click();
         }

--- a/src/Legerity.WCT/Carousel.cs
+++ b/src/Legerity.WCT/Carousel.cs
@@ -30,21 +30,17 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the collection of items associated with the carousel.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.carouselItemLocator);
+        public virtual ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.carouselItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem =>
-            this.Items.FirstOrDefault(
-                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                    "True",
-                    StringComparison.CurrentCultureIgnoreCase));
+        public virtual AppiumWebElement SelectedItem => this.Items.FirstOrDefault(i => i.IsSelected());
 
         /// <summary>
         /// Gets the index of the element associated with the currently selected item.
         /// </summary>
-        public int SelectedIndex => this.Items.IndexOf(this.SelectedItem);
+        public virtual int SelectedIndex => this.Items.IndexOf(this.SelectedItem);
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ListView"/> without direct casting.
@@ -80,11 +76,30 @@ namespace Legerity.Windows.Elements.WCT
         /// <param name="name">
         /// The name of the item to click.
         /// </param>
-        public void SelectItem(string name)
+        public virtual void SelectItem(string name)
         {
             this.VerifyElementsShown(this.carouselItemLocator, TimeSpan.FromSeconds(2));
 
             int index = this.Items.IndexOf(this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name)));
+            int selectedIndex = this.SelectedIndex;
+            while (Math.Abs(index - selectedIndex) > double.Epsilon)
+            {
+                this.Element.SendKeys(selectedIndex < index ? Keys.ArrowRight : Keys.ArrowLeft);
+                selectedIndex = this.SelectedIndex;
+            }
+        }
+
+        /// <summary>
+        /// Clicks on an item in the carousel with the specified partial item name.
+        /// </summary>
+        /// <param name="partialName">
+        /// The partial name of the item to click.
+        /// </param>
+        public virtual void SelectItemByPartialName(string partialName)
+        {
+            this.VerifyElementsShown(this.carouselItemLocator, TimeSpan.FromSeconds(2));
+
+            int index = this.Items.IndexOf(this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(partialName)));
             int selectedIndex = this.SelectedIndex;
             while (Math.Abs(index - selectedIndex) > double.Epsilon)
             {

--- a/src/Legerity.WCT/Expander.cs
+++ b/src/Legerity.WCT/Expander.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Elements.WCT
 {
     using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -9,8 +10,6 @@ namespace Legerity.Windows.Elements.WCT
     /// </summary>
     public class Expander : WindowsElementWrapper
     {
-        private const string ToggleOnValue = "1";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Expander"/> class.
         /// </summary>
@@ -25,9 +24,12 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets a value indicating whether the expander has the content expanded (visible).
         /// </summary>
-        public bool IsExpanded => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
+        public virtual bool IsExpanded => this.GetToggleState() == ToggleState.Checked;
 
-        private ToggleButton ToggleButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_ExpanderToggleButton"));
+        /// <summary>
+        /// Gets the <see cref="ToggleButton"/> associated with the expander.
+        /// </summary>
+        public virtual ToggleButton ToggleButton => this.Element.FindElement(WindowsByExtras.AutomationId("PART_ExpanderToggleButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Expander"/> without direct casting.
@@ -60,7 +62,7 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Expands the content of the expander.
         /// </summary>
-        public void Expand()
+        public virtual void Expand()
         {
             if (this.IsExpanded)
             {
@@ -73,7 +75,7 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Collapses the content of the expander.
         /// </summary>
-        public void Collapse()
+        public virtual void Collapse()
         {
             if (!this.IsExpanded)
             {

--- a/src/Legerity.WCT/InAppNotification.cs
+++ b/src/Legerity.WCT/InAppNotification.cs
@@ -32,7 +32,7 @@ namespace Legerity.Windows.Elements.WCT
         /// Note, this only works if the Content is based on a <see cref="string"/> or if the ContentTemplate includes a TextBlock element with the message.
         /// </para>
         /// </summary>
-        public string Message => this.Element.FindElementsByClassName("TextBlock").FirstOrDefault()?.Text;
+        public virtual string Message => this.Element.FindElementsByClassName("TextBlock").FirstOrDefault()?.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InAppNotification"/> without direct casting.

--- a/src/Legerity.WCT/RadialGauge.cs
+++ b/src/Legerity.WCT/RadialGauge.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Elements.WCT
 {
     using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -24,27 +25,27 @@ namespace Legerity.Windows.Elements.WCT
         /// <summary>
         /// Gets the minimum value of the gauge.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+        public virtual double Minimum => this.GetRangeMinimum();
 
         /// <summary>
         /// Gets the maximum value of the gauge.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+        public virtual double Maximum => this.GetRangeMaximum();
 
         /// <summary>
         /// Gets the small change (step) value of the gauge.
         /// </summary>
-        public double SmallChange => double.Parse(this.Element.GetAttribute("RangeValue.SmallChange"));
+        public virtual double SmallChange => this.GetRangeSmallChange();
 
         /// <summary>
         /// Gets the value of the gauge.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Value => this.GetRangeValue();
 
         /// <summary>
         /// Gets a value indicating whether the control is in a readonly state.
         /// </summary>
-        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+        public virtual bool IsReadonly => this.IsRangeReadonly();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadialGauge"/> without direct casting.
@@ -83,22 +84,28 @@ namespace Legerity.Windows.Elements.WCT
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the gauge.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
 
             if (value < this.Minimum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be greater than or equal to the minimum value {min}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"Value must be greater than or equal to the minimum value {min}");
             }
 
             if (value > this.Maximum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be less than or equal to the maximum value {max}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"Value must be less than or equal to the maximum value {max}");
             }
 
-            this.Element.Click();
+            this.Click();
 
             double currentValue = this.Value;
             while (Math.Abs(currentValue - value) > double.Epsilon)

--- a/src/Legerity.Web/Elements/Core/Button.cs
+++ b/src/Legerity.Web/Elements/Core/Button.cs
@@ -44,13 +44,5 @@ namespace Legerity.Web.Elements.Core
         {
             return new Button(element);
         }
-
-        /// <summary>
-        /// Clicks the button.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
     }
 }

--- a/src/Legerity.Web/Elements/Core/CheckBox.cs
+++ b/src/Legerity.Web/Elements/Core/CheckBox.cs
@@ -34,7 +34,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the check box is in the checked state.
         /// </summary>
-        public bool IsChecked => this.Element.Selected;
+        public virtual bool IsChecked => this.Element.Selected;
 
         /// <summary>
         /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="CheckBox"/> without direct casting.
@@ -53,27 +53,27 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Checks the check box on.
         /// </summary>
-        public void CheckOn()
+        public virtual void CheckOn()
         {
             if (this.IsChecked)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
 
         /// <summary>
         /// Checks the check box off.
         /// </summary>
-        public void CheckOff()
+        public virtual void CheckOff()
         {
             if (!this.IsChecked)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.Web/Elements/Core/FileInput.cs
+++ b/src/Legerity.Web/Elements/Core/FileInput.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Web.Elements.Core
 {
     using Legerity.Web.Elements;
+    using Legerity.Web.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
 
@@ -34,7 +35,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the file path for the selected file.
         /// </summary>
-        public string FilePath => this.Element.GetAttribute("value");
+        public virtual string FilePath => this.GetValue();
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="FileInput"/> without direct casting.
@@ -54,7 +55,7 @@ namespace Legerity.Web.Elements.Core
         /// Sets the selected file by an absolute file path.
         /// </summary>
         /// <param name="filePath">The file path.</param>
-        public void SetAbsoluteFilePath(string filePath)
+        public virtual void SetAbsoluteFilePath(string filePath)
         {
             this.ClearFile();
             this.Element.SendKeys(filePath);
@@ -63,7 +64,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Clears the selected file.
         /// </summary>
-        public void ClearFile()
+        public virtual void ClearFile()
         {
             this.Element.Clear();
         }

--- a/src/Legerity.Web/Elements/Core/Image.cs
+++ b/src/Legerity.Web/Elements/Core/Image.cs
@@ -34,22 +34,22 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the source URI of the image.
         /// </summary>
-        public string Source => this.Element.GetAttribute("src");
+        public virtual string Source => this.GetAttribute("src");
 
         /// <summary>
         /// Gets the alt text of the image.
         /// </summary>
-        public string AltText => this.Element.GetAttribute("alt");
+        public virtual string AltText => this.GetAttribute("alt");
 
         /// <summary>
         /// Gets the width of the image.
         /// </summary>
-        public double Width => double.Parse(this.Element.GetAttribute("width"));
+        public virtual double Width => double.Parse(this.GetAttribute("width"));
 
         /// <summary>
         /// Gets the height of the image.
         /// </summary>
-        public double Height => double.Parse(this.Element.GetAttribute("height"));
+        public virtual double Height => double.Parse(this.GetAttribute("height"));
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Image"/> without direct casting.

--- a/src/Legerity.Web/Elements/Core/List.cs
+++ b/src/Legerity.Web/Elements/Core/List.cs
@@ -35,7 +35,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the list.
         /// </summary>
-        public ReadOnlyCollection<IWebElement> Items => this.Element.FindElements(By.TagName("li"));
+        public virtual ReadOnlyCollection<IWebElement> Items => this.Element.FindElements(WebByExtras.ListItem());
 
         /// <summary>
         /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="List"/> without direct casting.

--- a/src/Legerity.Web/Elements/Core/NumberInput.cs
+++ b/src/Legerity.Web/Elements/Core/NumberInput.cs
@@ -34,17 +34,17 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the minimum value of the NumberBox.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("min"));
+        public virtual double Minimum => double.Parse(this.GetAttribute("min"));
 
         /// <summary>
         /// Gets the maximum value of the NumberBox.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("max"));
+        public virtual double Maximum => double.Parse(this.GetAttribute("max"));
 
         /// <summary>
         /// Gets the value of the NumberBox.
         /// </summary>
-        public double Value => double.TryParse(this.Text, out double val) ? val : 0;
+        public virtual double Value => double.TryParse(this.Text, out double val) ? val : 0;
 
         /// <summary>
         /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="NumberInput"/> without direct casting.
@@ -69,7 +69,7 @@ namespace Legerity.Web.Elements.Core
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the NumberBox.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
@@ -96,7 +96,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Increases the number box value.
         /// </summary>
-        public void Increment()
+        public virtual void Increment()
         {
             this.Element.SendKeys(Keys.ArrowUp);
         }
@@ -104,7 +104,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Decreases the number box value.
         /// </summary>
-        public void Decrement()
+        public virtual void Decrement()
         {
             this.Element.SendKeys(Keys.ArrowDown);
         }

--- a/src/Legerity.Web/Elements/Core/Option.cs
+++ b/src/Legerity.Web/Elements/Core/Option.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Web.Elements.Core
 {
     using Legerity.Web.Elements;
+    using Legerity.Web.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
 
@@ -34,17 +35,17 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the value of the option.
         /// </summary>
-        public string Value => this.Element.GetAttribute("value");
+        public virtual string Value => this.GetValue();
 
         /// <summary>
         /// Gets the display value of the option.
         /// </summary>
-        public string DisplayValue => this.Element.Text;
+        public virtual string DisplayValue => this.Element.Text;
 
         /// <summary>
         /// Gets a value indicating whether the option is selected.
         /// </summary>
-        public bool IsSelected => this.Element.Selected;
+        public virtual bool IsSelected => this.Element.Selected;
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Option"/> without direct casting.
@@ -63,9 +64,9 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Selects the option.
         /// </summary>
-        public void Select()
+        public virtual void Select()
         {
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.Web/Elements/Core/RadioButton.cs
+++ b/src/Legerity.Web/Elements/Core/RadioButton.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Web.Elements.Core
 {
+    using Legerity.Web.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
 
@@ -33,12 +34,12 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the radio button is selected.
         /// </summary>
-        public bool IsSelected => this.Element.Selected;
+        public virtual bool IsSelected => this.Element.Selected;
 
         /// <summary>
         /// Gets the name of the group for the radio button.
         /// </summary>
-        public string Group => this.Element.GetAttribute("name");
+        public virtual string Group => this.GetName();
 
         /// <summary>
         /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="RadioButton"/> without direct casting.

--- a/src/Legerity.Web/Elements/Core/RangeInput.cs
+++ b/src/Legerity.Web/Elements/Core/RangeInput.cs
@@ -34,17 +34,17 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the minimum value of the range input.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("min"));
+        public virtual double Minimum => double.Parse(this.GetAttribute("min"));
 
         /// <summary>
         /// Gets the maximum value of the range input.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("max"));
+        public virtual double Maximum => double.Parse(this.GetAttribute("max"));
 
         /// <summary>
         /// Gets the value of the range input.
         /// </summary>
-        public double Value => double.TryParse(this.Text, out double val) ? val : 0;
+        public virtual double Value => double.TryParse(this.Text, out double val) ? val : 0;
 
         /// <summary>
         /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="RangeInput"/> without direct casting.
@@ -69,7 +69,7 @@ namespace Legerity.Web.Elements.Core
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the range input.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
@@ -90,7 +90,7 @@ namespace Legerity.Web.Elements.Core
                     $"Value must be less than or equal to the maximum value {max}");
             }
 
-            this.Element.Click();
+            this.Click();
 
             double currentValue = this.Value;
             while (Math.Abs(currentValue - value) > double.Epsilon)
@@ -103,7 +103,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Increases the range input value.
         /// </summary>
-        public void Increment()
+        public virtual void Increment()
         {
             this.Element.SendKeys(Keys.ArrowUp);
         }
@@ -111,7 +111,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Decreases the range input value.
         /// </summary>
-        public void Decrement()
+        public virtual void Decrement()
         {
             this.Element.SendKeys(Keys.ArrowDown);
         }

--- a/src/Legerity.Web/Elements/Core/Select.cs
+++ b/src/Legerity.Web/Elements/Core/Select.cs
@@ -2,7 +2,9 @@ namespace Legerity.Web.Elements.Core
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
+    using Legerity.Extensions;
     using Legerity.Web.Elements;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
@@ -37,22 +39,23 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets a value indicating whether multiple items can be selected.
         /// </summary>
-        public bool IsMultiple => this.GetIsMultiple();
+        public virtual bool IsMultiple => this.GetIsMultiple();
 
         /// <summary>
         /// Gets the collection of items associated with the select.
         /// </summary>
-        public IEnumerable<Option> Options => this.Element.FindElements(By.TagName("option")).Select(e => new Option(e));
+        public virtual IEnumerable<Option> Options =>
+            this.Element.FindElements(WebByExtras.Option()).Select(e => new Option(e));
 
         /// <summary>
         /// Gets the selected item when in a single selection state.
         /// </summary>
-        public Option SelectedOption => this.Options.FirstOrDefault(e => e.IsSelected);
+        public virtual Option SelectedOption => this.Options.FirstOrDefault(e => e.IsSelected);
 
         /// <summary>
         /// Gets the selected items when in a multiple selection state.
         /// </summary>
-        public IEnumerable<Option> SelectedOptions => this.Options.Where(e => e.IsSelected);
+        public virtual IEnumerable<Option> SelectedOptions => this.Options.Where(e => e.IsSelected);
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Select"/> without direct casting.
@@ -74,11 +77,28 @@ namespace Legerity.Web.Elements.Core
         /// <param name="displayValue">
         /// The display value of the item to select.
         /// </param>
-        public void SelectOptionByDisplayValue(string displayValue)
+        public virtual void SelectOptionByDisplayValue(string displayValue)
         {
             Option item =
                 this.Options.FirstOrDefault(e =>
                     e.DisplayValue.Equals(displayValue, StringComparison.CurrentCultureIgnoreCase));
+            item.Select();
+        }
+
+        /// <summary>
+        /// Selects an item in the select element with the specified partial display value.
+        /// </summary>
+        /// <param name="partialDisplayValue">
+        /// The partial display value of the item to select.
+        /// </param>
+        public virtual void SelectOptionByPartialDisplayValue(string partialDisplayValue)
+        {
+            Option item =
+                this.Options.FirstOrDefault(e =>
+                    e.DisplayValue.Contains(
+                        partialDisplayValue,
+                        CultureInfo.CurrentCulture,
+                        CompareOptions.IgnoreCase));
             item.Select();
         }
 
@@ -88,7 +108,7 @@ namespace Legerity.Web.Elements.Core
         /// <param name="value">
         /// The value of the item to select.
         /// </param>
-        public void SelectOptionByValue(string value)
+        public virtual void SelectOptionByValue(string value)
         {
             Option item =
                 this.Options.FirstOrDefault(e =>
@@ -96,9 +116,26 @@ namespace Legerity.Web.Elements.Core
             item.Select();
         }
 
+        /// <summary>
+        /// Selects an item in the select element with the specified partial value.
+        /// </summary>
+        /// <param name="partialValue">
+        /// The partial value of the item to select.
+        /// </param>
+        public virtual void SelectOptionByPartialValue(string partialValue)
+        {
+            Option item =
+                this.Options.FirstOrDefault(e =>
+                    e.Value.Contains(
+                        partialValue,
+                        CultureInfo.CurrentCulture,
+                        CompareOptions.IgnoreCase));
+            item.Select();
+        }
+
         private bool GetIsMultiple()
         {
-            string multipleAttr = this.Element.GetAttribute("multiple");
+            string multipleAttr = this.GetAttribute("multiple");
             if (multipleAttr == null)
             {
                 return false;

--- a/src/Legerity.Web/Elements/Core/Table.cs
+++ b/src/Legerity.Web/Elements/Core/Table.cs
@@ -36,22 +36,22 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets or sets a value indicating whether the first row in the table is a header row.
         /// </summary>
-        public bool IsFirstRowHeaders { get; set; } = true;
+        public virtual bool IsFirstRowHeaders { get; set; } = true;
 
         /// <summary>
         /// Gets the header names for the table.
         /// </summary>
-        public IEnumerable<string> Headers => this.IsFirstRowHeaders ? this.Rows.FirstOrDefault().GetAllChildElements().Select(x => x.Text) : this.Element.FindElements(By.TagName("th")).Select(x => x.Text);
+        public virtual IEnumerable<string> Headers => this.IsFirstRowHeaders ? this.Rows.FirstOrDefault().GetAllChildElements().Select(x => x.Text) : this.Element.FindElements(WebByExtras.TableHeaderCell()).Select(x => x.Text);
 
         /// <summary>
         /// Gets the collection of rows associated with the table. If a header row exists, that will be included.
         /// </summary>
-        public IEnumerable<TableRow> Rows => this.Element.FindElements(By.TagName("tr")).Select(e => new TableRow(e));
+        public virtual IEnumerable<TableRow> Rows => this.Element.FindElements(WebByExtras.TableRow()).Select(e => new TableRow(e));
 
         /// <summary>
         /// Gets the collection of rows associated with the table only containing the data values (not headers).
         /// </summary>
-        public IEnumerable<TableRow> DataRows => this.Rows.Where(x => x.FindElements(By.TagName("th")).Count == 0);
+        public virtual IEnumerable<TableRow> DataRows => this.Rows.Where(x => x.FindElements(WebByExtras.TableHeaderCell()).Count == 0);
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Table"/> without direct casting.
@@ -72,7 +72,7 @@ namespace Legerity.Web.Elements.Core
         /// </summary>
         /// <param name="idx">The specified row data index to retrieve data for.</param>
         /// <returns>A dictionary of key-value pairs containing the column header and the column value for the row.</returns>
-        public IReadOnlyDictionary<string, string> GetRowDataByIndex(int idx)
+        public virtual IReadOnlyDictionary<string, string> GetRowDataByIndex(int idx)
         {
             void AddRowData(IDictionary<string, string> dictionary, string header, TableRow tableRow, int valueIdx)
             {
@@ -109,7 +109,7 @@ namespace Legerity.Web.Elements.Core
         /// </summary>
         /// <param name="header">The column header name.</param>
         /// <returns>A collection of values for each row in the column.</returns>
-        public IEnumerable<string> GetColumnDataByHeader(string header)
+        public virtual IEnumerable<string> GetColumnDataByHeader(string header)
         {
             var headers = this.Headers.ToList();
             int idx = headers.IndexOf(header);
@@ -121,7 +121,7 @@ namespace Legerity.Web.Elements.Core
         /// </summary>
         /// <param name="idx">The specified column index of data to retrieve.</param>
         /// <returns>A collection of values for each row in the column.</returns>
-        public IEnumerable<string> GetColumnDataByIndex(int idx)
+        public virtual IEnumerable<string> GetColumnDataByIndex(int idx)
         {
             if (idx == -1)
             {

--- a/src/Legerity.Web/Elements/Core/TableRow.cs
+++ b/src/Legerity.Web/Elements/Core/TableRow.cs
@@ -37,6 +37,6 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets all of the values for each column in the row.
         /// </summary>
-        public IEnumerable<string> Values => this.GetAllChildElements().Select(x => x.GetInnerHtml());
+        public virtual IEnumerable<string> Values => this.GetAllChildElements().Select(x => x.GetInnerHtml());
     }
 }

--- a/src/Legerity.Web/Elements/Core/TextArea.cs
+++ b/src/Legerity.Web/Elements/Core/TextArea.cs
@@ -33,12 +33,12 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the number of visible text lines.
         /// </summary>
-        public int Rows => int.Parse(this.Element.GetAttribute("rows"));
+        public virtual int Rows => int.Parse(this.GetAttribute("rows"));
 
         /// <summary>
         /// Gets the visible width.
         /// </summary>
-        public int Cols => int.Parse(this.Element.GetAttribute("cols"));
+        public virtual int Cols => int.Parse(this.GetAttribute("cols"));
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="TextArea"/> without direct casting.

--- a/src/Legerity.Web/Elements/Core/TextInput.cs
+++ b/src/Legerity.Web/Elements/Core/TextInput.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Web.Elements.Core
 {
     using Legerity.Web.Elements;
+    using Legerity.Web.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
 
@@ -34,7 +35,7 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the text value of the text input.
         /// </summary>
-        public string Text => this.Element.GetAttribute("value");
+        public virtual string Text => this.GetValue();
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="TextInput"/> without direct casting.
@@ -54,7 +55,7 @@ namespace Legerity.Web.Elements.Core
         /// Sets the text of the text box to the specified text.
         /// </summary>
         /// <param name="text">The text to display.</param>
-        public void SetText(string text)
+        public virtual void SetText(string text)
         {
             this.ClearText();
             this.AppendText(text);
@@ -64,18 +65,18 @@ namespace Legerity.Web.Elements.Core
         /// Appends the specified text to the text box.
         /// </summary>
         /// <param name="text">The text to append.</param>
-        public void AppendText(string text)
+        public virtual void AppendText(string text)
         {
-            this.Element.Click();
+            this.Click();
             this.Element.SendKeys(text);
         }
 
         /// <summary>
         /// Clears the text from the text box.
         /// </summary>
-        public void ClearText()
+        public virtual void ClearText()
         {
-            this.Element.Click();
+            this.Click();
             this.Element.Clear();
         }
     }

--- a/src/Legerity.Web/Elements/WebElementWrapper.cs
+++ b/src/Legerity.Web/Elements/WebElementWrapper.cs
@@ -51,12 +51,12 @@ namespace Legerity.Web.Elements
         /// <summary>
         /// Gets a value indicating whether the element is enabled.
         /// </summary>
-        public bool IsEnabled => this.Element.Enabled;
+        public virtual bool IsEnabled => this.Element.Enabled;
 
         /// <summary>
         /// Gets a value indicating whether the element is visible.
         /// </summary>
-        public bool IsVisible => this.Element.Displayed;
+        public virtual bool IsVisible => this.Element.Displayed;
 
         /// <summary>
         /// Finds a child element by the specified locator.
@@ -93,6 +93,24 @@ namespace Legerity.Web.Elements
             catch (ElementNotShownException)
             {
             }
+        }
+
+        /// <summary>
+        /// Clicks the element.
+        /// </summary>
+        public virtual void Click()
+        {
+            this.Element.Click();
+        }
+
+        /// <summary>
+        /// Gets the value of the specified attribute for this element.
+        /// </summary>
+        /// <param name="attributeName">The name of the attribute.</param>
+        /// <returns>The attribute's current value if it exists; otherwise, null.</returns>
+        public string GetAttribute(string attributeName)
+        {
+            return this.Element.GetAttribute(attributeName);
         }
 
         /// <summary>

--- a/src/Legerity.Web/Extensions/AttributeExtensions.cs
+++ b/src/Legerity.Web/Extensions/AttributeExtensions.cs
@@ -1,0 +1,83 @@
+namespace Legerity.Web.Extensions
+{
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a collection of extensions for retrieving element attributes.
+    /// </summary>
+    public static class AttributeExtensions
+    {
+        /// <summary>
+        /// Retrieves the name attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve a name from.</param>
+        /// <returns>The name of the element.</returns>
+        public static string GetName(this IWebElement element)
+        {
+            return element.GetAttribute("name");
+        }
+
+        /// <summary>
+        /// Retrieves the name attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a name from.</param>
+        /// <returns>The name of the element.</returns>
+        public static string GetName<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetName(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the value attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve a value from.</param>
+        /// <returns>The value of the element.</returns>
+        public static string GetValue(this IWebElement element)
+        {
+            return element.GetAttribute("value");
+        }
+
+        /// <summary>
+        /// Retrieves the value attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a value from.</param>
+        /// <returns>The value of the element.</returns>
+        public static string GetValue<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetValue(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the class attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve a class from.</param>
+        /// <returns>The class of the element.</returns>
+        public static string GetClass(this IWebElement element)
+        {
+            return element.GetAttribute("class");
+        }
+
+        /// <summary>
+        /// Retrieves the class attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a class from.</param>
+        /// <returns>The class of the element.</returns>
+        public static string GetClass<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetClass(element.Element);
+        }
+    }
+}

--- a/src/Legerity.Web/Extensions/IWebElementExtensions.cs
+++ b/src/Legerity.Web/Extensions/IWebElementExtensions.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Web.Extensions
 {
     using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
 
     /// <summary>
     /// Defines a collection of extensions for the <see cref="IWebElement"/> class.
@@ -18,6 +19,20 @@ namespace Legerity.Web.Extensions
         }
 
         /// <summary>
+        /// Retrieves the value attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the inner HTML from.</param>
+        /// <returns>The inner HTML of the element.</returns>
+        public static string GetInnerHtml<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetInnerHtml(element.Element);
+        }
+
+        /// <summary>
         /// Determines whether the specified <see cref="IWebElement"/> has the specified <paramref name="className">class</paramref>.
         /// </summary>
         /// <param name="element">The <see cref="IWebElement"/> to check.</param>
@@ -25,7 +40,22 @@ namespace Legerity.Web.Extensions
         /// <returns>True if the element has the class; otherwise, false.</returns>
         public static bool HasClass(this IWebElement element, string className)
         {
-            return element.GetAttribute("class").Contains(className);
+            return element.GetClass().Contains(className);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="IElementWrapper{TElement}"/> has the specified <paramref name="className">class</paramref>.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to check.</param>
+        /// <param name="className">The name of the class the element should have.</param>
+        /// <returns>True if the element has the class; otherwise, false.</returns>
+        public static bool HasClass<TElement>(this IElementWrapper<TElement> element, string className)
+            where TElement : IWebElement
+        {
+            return HasClass(element.Element, className);
         }
     }
 }

--- a/src/Legerity.Web/WebByExtras.cs
+++ b/src/Legerity.Web/WebByExtras.cs
@@ -1,0 +1,46 @@
+namespace Legerity.Web
+{
+    using OpenQA.Selenium;
+
+    /// <summary>
+    /// Defines a collection of extra locator constraints for <see cref="By"/>.
+    /// </summary>
+    public static class WebByExtras
+    {
+        /// <summary>
+        /// Gets a mechanism to find elements by the HTML li tag.
+        /// </summary>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By ListItem()
+        {
+            return By.TagName("li");
+        }
+
+        /// <summary>
+        /// Gets a mechanism to find elements by the HTML option tag.
+        /// </summary>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By Option()
+        {
+            return By.TagName("option");
+        }
+
+        /// <summary>
+        /// Gets a mechanism to find elements by the HTML th tag.
+        /// </summary>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By TableHeaderCell()
+        {
+            return By.TagName("th");
+        }
+
+        /// <summary>
+        /// Gets a mechanism to find elements by the HTML tr tag.
+        /// </summary>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By TableRow()
+        {
+            return By.TagName("tr");
+        }
+    }
+}

--- a/src/Legerity.WinUI/InfoBar.cs
+++ b/src/Legerity.WinUI/InfoBar.cs
@@ -23,32 +23,32 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the title of the info bar.
         /// </summary>
-        public string Title => this.TitleTextBlock.Text;
+        public virtual string Title => this.TitleTextBlock.Text;
 
         /// <summary>
         /// Gets the message of the info bar.
         /// </summary>
-        public string Message => this.MessageTextBlock.Text;
+        public virtual string Message => this.MessageTextBlock.Text;
 
         /// <summary>
         /// Gets a value indicating whether the info bar is open.
         /// </summary>
-        public bool IsOpen => !bool.Parse(this.Element.GetAttribute("IsOffscreen"));
+        public virtual bool IsOpen => !bool.Parse(this.GetAttribute("IsOffscreen"));
 
         /// <summary>
         /// Gets the element associated with the title <see cref="TextBlock"/>.
         /// </summary>
-        public TextBlock TitleTextBlock => this.FindElement(WindowsByExtras.AutomationId("Title"));
+        public virtual TextBlock TitleTextBlock => this.FindElement(WindowsByExtras.AutomationId("Title"));
 
         /// <summary>
         /// Gets the element associated with the message <see cref="TextBlock"/>.
         /// </summary>
-        public TextBlock MessageTextBlock => this.FindElement(WindowsByExtras.AutomationId("Message"));
+        public virtual TextBlock MessageTextBlock => this.FindElement(WindowsByExtras.AutomationId("Message"));
 
         /// <summary>
         /// Gets the element associated with the close <see cref="Button"/>.
         /// </summary>
-        public Button CloseButton => this.FindElement(WindowsByExtras.AutomationId("CloseButton"));
+        public virtual Button CloseButton => this.FindElement(WindowsByExtras.AutomationId("CloseButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InfoBar"/> without direct casting.
@@ -81,7 +81,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Closes the info bar.
         /// </summary>
-        public void Close()
+        public virtual void Close()
         {
             this.CloseButton.Click();
         }

--- a/src/Legerity.WinUI/MenuBar.cs
+++ b/src/Legerity.WinUI/MenuBar.cs
@@ -2,6 +2,7 @@ namespace Legerity.Windows.Elements.WinUI
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
     using OpenQA.Selenium;
@@ -27,7 +28,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI components associated with the menu items.
         /// </summary>
-        public IEnumerable<MenuBarItem> MenuItems =>
+        public virtual IEnumerable<MenuBarItem> MenuItems =>
             this.Element.FindElements(By.ClassName("Microsoft.UI.Xaml.Controls.MenuBarItem"))
                 .Select(element => new MenuBarItem(this, element as WindowsElement));
 
@@ -68,11 +69,29 @@ namespace Legerity.Windows.Elements.WinUI
         /// <returns>
         /// The clicked <see cref="MenuBarItem"/>.
         /// </returns>
-        public MenuBarItem ClickOption(string name)
+        public virtual MenuBarItem ClickOption(string name)
         {
             MenuBarItem item = this.MenuItems.FirstOrDefault(
                 element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
+        /// Clicks on a child menu option with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="MenuBarItem"/>.
+        /// </returns>
+        public virtual MenuBarItem ClickOptionByPartialName(string name)
+        {
+            MenuBarItem item = this.MenuItems.FirstOrDefault(
+                element => element.GetName()
+                    .Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
             item.Click();
             return item;
         }

--- a/src/Legerity.WinUI/MenuBarItem.cs
+++ b/src/Legerity.WinUI/MenuBarItem.cs
@@ -2,6 +2,7 @@ namespace Legerity.Windows.Elements.WinUI
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
@@ -47,7 +48,7 @@ namespace Legerity.Windows.Elements.WinUI
         }
 
         /// <summary>Gets the original parent <see cref="MenuBar"/> reference object.</summary>
-        public MenuBar ParentMenuBar =>
+        public virtual MenuBar ParentMenuBar =>
             this.parentMenuBarReference != null && this.parentMenuBarReference.IsAlive
                 ? this.parentMenuBarReference.Target as MenuBar
                 : null;
@@ -55,20 +56,12 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI components associated with the child menu items.
         /// </summary>
-        public IEnumerable<MenuFlyoutItem> ChildMenuItems => this.GetChildMenuItems();
+        public virtual IEnumerable<MenuFlyoutItem> ChildMenuItems => this.GetChildMenuItems();
 
         /// <summary>
         /// Gets the UI components associated with the child menu sub-items.
         /// </summary>
-        public IEnumerable<MenuFlyoutSubItem> ChildMenuSubItems => this.GetChildMenuSubItems();
-
-        /// <summary>
-        /// Clicks the item.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
+        public virtual IEnumerable<MenuFlyoutSubItem> ChildMenuSubItems => this.GetChildMenuSubItems();
 
         /// <summary>
         /// Clicks on a child menu option with the specified item name.
@@ -79,7 +72,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <returns>
         /// The clicked <see cref="MenuFlyoutItem"/>.
         /// </returns>
-        public MenuFlyoutItem ClickChildOption(string name)
+        public virtual MenuFlyoutItem ClickChildOption(string name)
         {
             MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
                 element => element.GetName()
@@ -89,15 +82,47 @@ namespace Legerity.Windows.Elements.WinUI
         }
 
         /// <summary>
+        /// Clicks on a child menu option with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="MenuFlyoutItem"/>.
+        /// </returns>
+        public virtual MenuFlyoutItem ClickChildOptionByPartialName(string name)
+        {
+            MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
+                element => element.GetName()
+                    .Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
         /// Clicks on a child menu sub option with the specified item name.
         /// </summary>
         /// <param name="name">The name of the sub-item to click.</param>
         /// <returns>The clicked <see cref="MenuFlyoutSubItem"/>.</returns>
-        public MenuFlyoutSubItem ClickChildSubOption(string name)
+        public virtual MenuFlyoutSubItem ClickChildSubOption(string name)
         {
             MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
                 element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
+        /// Clicks on a child menu sub option with the specified partial item name.
+        /// </summary>
+        /// <param name="name">The partial name of the sub-item to click.</param>
+        /// <returns>The clicked <see cref="MenuFlyoutSubItem"/>.</returns>
+        public virtual MenuFlyoutSubItem ClickChildSubOptionByPartialName(string name)
+        {
+            MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
+                element => element.GetName()
+                    .Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
             item.Click();
             return item;
         }

--- a/src/Legerity.WinUI/NavigationView.cs
+++ b/src/Legerity.WinUI/NavigationView.cs
@@ -2,6 +2,7 @@ namespace Legerity.Windows.Elements.WinUI
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
     using Legerity.Windows.Elements.Core;
@@ -28,39 +29,43 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI component associated with displaying the menu items.
         /// </summary>
-        public AppiumWebElement MenuItemsView => this.Element.FindElement(WindowsByExtras.AutomationId("MenuItemsHost"));
+        public virtual AppiumWebElement MenuItemsView =>
+            this.Element.FindElement(WindowsByExtras.AutomationId("MenuItemsHost"));
 
         /// <summary>
         /// Gets the UI components associated with the menu items.
         /// </summary>
-        public IEnumerable<NavigationViewItem> MenuItems =>
+        public virtual IEnumerable<NavigationViewItem> MenuItems =>
             this.MenuItemsView.FindElements(By.ClassName("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
                 .Select(element => new NavigationViewItem(this, element as WindowsElement));
 
         /// <summary>
         /// Gets the UI component associated with the settings menu item.
         /// </summary>
-        public AppiumWebElement SettingsMenuItem => this.Element.FindElement(WindowsByExtras.AutomationId("SettingsItem"));
+        public virtual AppiumWebElement SettingsMenuItem =>
+            this.Element.FindElement(WindowsByExtras.AutomationId("SettingsItem"));
 
         /// <summary>
         /// Gets the UI component associated with the navigation pane toggle button.
         /// </summary>
-        public Button ToggleNavigationPaneButton => this.Element.FindElement(WindowsByExtras.AutomationId("TogglePaneButton"));
+        public virtual Button ToggleNavigationPaneButton =>
+            this.Element.FindElement(WindowsByExtras.AutomationId("TogglePaneButton"));
 
         /// <summary>
         /// Gets the UI component associated with the navigation back button.
         /// </summary>
-        public Button BackButton => this.Element.FindElement(WindowsByExtras.AutomationId("NavigationViewBackButton"));
+        public virtual Button BackButton =>
+            this.Element.FindElement(WindowsByExtras.AutomationId("NavigationViewBackButton"));
 
         /// <summary>
         /// Gets a value indicating whether the pane is currently open.
         /// </summary>
-        public bool IsPaneOpen => this.VerifyPaneOpen(this.ExpectedCompactPaneWidth);
+        public virtual bool IsPaneOpen => this.VerifyPaneOpen(this.ExpectedCompactPaneWidth);
 
         /// <summary>
         /// Gets or sets the expected compact pane width used to determine the pane open state.
         /// </summary>
-        public int ExpectedCompactPaneWidth { get; set; } = 72;
+        public virtual int ExpectedCompactPaneWidth { get; set; } = 72;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="NavigationView"/> without direct casting.
@@ -93,7 +98,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Opens the navigation pane.
         /// </summary>
-        public void OpenNavigationPane()
+        public virtual void OpenNavigationPane()
         {
             if (this.IsPaneOpen)
             {
@@ -106,7 +111,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Collapses the navigation pane.
         /// </summary>
-        public void CloseNavigationPane()
+        public virtual void CloseNavigationPane()
         {
             if (!this.IsPaneOpen)
             {
@@ -119,7 +124,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Navigates the view back.
         /// </summary>
-        public void GoBack()
+        public virtual void GoBack()
         {
             if (this.BackButton.IsEnabled)
             {
@@ -136,7 +141,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <returns>
         /// The clicked <see cref="NavigationViewItem"/>.
         /// </returns>
-        public NavigationViewItem ClickMenuOption(string name)
+        public virtual NavigationViewItem ClickMenuOption(string name)
         {
             NavigationViewItem item = this.MenuItems.FirstOrDefault(
                 element => element.GetName().Equals(name, StringComparison.CurrentCultureIgnoreCase));
@@ -145,9 +150,26 @@ namespace Legerity.Windows.Elements.WinUI
         }
 
         /// <summary>
+        /// Clicks on a menu option in the navigation view with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="NavigationViewItem"/>.
+        /// </returns>
+        public virtual NavigationViewItem ClickMenuOptionByPartialName(string name)
+        {
+            NavigationViewItem item = this.MenuItems.FirstOrDefault(
+                element => element.GetName().Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
         /// Opens the settings option.
         /// </summary>
-        public void OpenSettings()
+        public virtual void OpenSettings()
         {
             this.SettingsMenuItem.Click();
         }
@@ -157,7 +179,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// </summary>
         /// <param name="expectedCompactPaneWidth">The expected compact pane width when closed.</param>
         /// <returns>True if the pane is open; otherwise, false.</returns>
-        public bool VerifyPaneOpen(int expectedCompactPaneWidth)
+        public virtual bool VerifyPaneOpen(int expectedCompactPaneWidth)
         {
             AppiumWebElement pane = this.Element.FindElement(WindowsByExtras.AutomationId("PaneRoot"));
             int paneWidth = pane.Rect.Width;

--- a/src/Legerity.WinUI/NavigationViewItem.cs
+++ b/src/Legerity.WinUI/NavigationViewItem.cs
@@ -2,6 +2,7 @@ namespace Legerity.Windows.Elements.WinUI
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
     using OpenQA.Selenium;
@@ -101,15 +102,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the UI components associated with the child menu items.
         /// </summary>
-        public IEnumerable<NavigationViewItem> ChildMenuItems => this.GetChildMenuItems();
-
-        /// <summary>
-        /// Clicks the item.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
+        public virtual IEnumerable<NavigationViewItem> ChildMenuItems => this.GetChildMenuItems();
 
         /// <summary>
         /// Clicks on a child menu option with the specified item name.
@@ -120,11 +113,29 @@ namespace Legerity.Windows.Elements.WinUI
         /// <returns>
         /// The clicked <see cref="NavigationViewItem"/>.
         /// </returns>
-        public NavigationViewItem ClickChildOption(string name)
+        public virtual NavigationViewItem ClickChildOption(string name)
         {
             NavigationViewItem item = this.ChildMenuItems.FirstOrDefault(
                 element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
+        /// Clicks on a child menu option with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="NavigationViewItem"/>.
+        /// </returns>
+        public virtual NavigationViewItem ClickChildOptionByPartialName(string name)
+        {
+            NavigationViewItem item = this.ChildMenuItems.FirstOrDefault(
+                element => element.GetName()
+                    .Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
             item.Click();
             return item;
         }

--- a/src/Legerity.WinUI/NumberBox.cs
+++ b/src/Legerity.WinUI/NumberBox.cs
@@ -1,8 +1,8 @@
 namespace Legerity.Windows.Elements.WinUI
 {
     using System;
-
     using Legerity.Windows.Elements.Core;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -26,42 +26,43 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the minimum value of the NumberBox.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+        public virtual double Minimum => this.GetRangeMinimum();
 
         /// <summary>
         /// Gets the maximum value of the NumberBox.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+        public virtual double Maximum => this.GetRangeMaximum();
 
         /// <summary>
         /// Gets the small change (step) value of the NumberBox.
         /// </summary>
-        public double SmallChange => double.Parse(this.Element.GetAttribute("RangeValue.SmallChange"));
+        public virtual double SmallChange => this.GetRangeSmallChange();
 
         /// <summary>
         /// Gets the value of the NumberBox.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Value => this.GetRangeValue();
 
         /// <summary>
         /// Gets a value indicating whether the control is in a readonly state.
         /// </summary>
-        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+        public virtual bool IsReadonly => this.IsRangeReadonly();
 
         /// <summary>
         /// Gets the element associated with the inline up button.
         /// </summary>
-        public Button InlineUpButton => this.Element.FindElement(WindowsByExtras.AutomationId("UpSpinButton"));
+        public virtual Button InlineUpButton => this.Element.FindElement(WindowsByExtras.AutomationId("UpSpinButton"));
 
         /// <summary>
         /// Gets the element associated with the inline down button.
         /// </summary>
-        public Button InlineDownButton => this.Element.FindElement(WindowsByExtras.AutomationId("DownSpinButton"));
+        public virtual Button InlineDownButton =>
+            this.Element.FindElement(WindowsByExtras.AutomationId("DownSpinButton"));
 
         /// <summary>
         /// Gets the element associated with the input text box.
         /// </summary>
-        public TextBox InputBox => this.Element.FindElement(WindowsByExtras.AutomationId("InputBox"));
+        public virtual TextBox InputBox => this.Element.FindElement(WindowsByExtras.AutomationId("InputBox"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="NumberBox"/> without direct casting.
@@ -100,7 +101,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the NumberBox.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
@@ -128,7 +129,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Increases the number box value by the <see cref="SmallChange"/> value.
         /// </summary>
-        public void Increment()
+        public virtual void Increment()
         {
             this.Element.SendKeys(Keys.ArrowUp);
         }
@@ -136,7 +137,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Decreases the number box value by the <see cref="SmallChange"/> value.
         /// </summary>
-        public void Decrement()
+        public virtual void Decrement()
         {
             this.Element.SendKeys(Keys.ArrowDown);
         }

--- a/src/Legerity.WinUI/RatingControl.cs
+++ b/src/Legerity.WinUI/RatingControl.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Elements.WinUI
 {
     using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -24,16 +25,22 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the value of the rating out of 5.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Value => this.GetRangeValue();
 
         /// <summary>
         /// Gets a value indicating whether the control is in a readonly state.
         /// </summary>
-        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+        public virtual bool IsReadonly => this.IsRangeReadonly();
 
-        private double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+        /// <summary>
+        /// Gets the minimum rating value.
+        /// </summary>
+        public virtual double Minimum => this.GetRangeMinimum();
 
-        private double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+        /// <summary>
+        /// Gets the maximum rating value.
+        /// </summary>
+        public virtual double Maximum => this.GetRangeMaximum();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RatingControl"/> without direct casting.
@@ -72,22 +79,28 @@ namespace Legerity.Windows.Elements.WinUI
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the slider.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
 
             if (value < this.Minimum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be greater than or equal to the minimum value {min}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"Value must be greater than or equal to the minimum value {min}");
             }
 
             if (value > this.Maximum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be less than or equal to the maximum value {max}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"Value must be less than or equal to the maximum value {max}");
             }
 
-            this.Element.Click();
+            this.Click();
 
             double currentValue = this.Value;
             while (Math.Abs(currentValue - value) > double.Epsilon)

--- a/src/Legerity.WinUI/TabView.cs
+++ b/src/Legerity.WinUI/TabView.cs
@@ -3,10 +3,8 @@ namespace Legerity.Windows.Elements.WinUI
     using System;
     using System.Collections.ObjectModel;
     using System.Linq;
-
     using Legerity.Windows.Elements.Core;
     using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -32,17 +30,17 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Gets the element associated with the add tab button.
         /// </summary>
-        public Button AddTabButton => this.Element.FindElement(WindowsByExtras.AutomationId("AddButton"));
+        public virtual Button AddTabButton => this.Element.FindElement(WindowsByExtras.AutomationId("AddButton"));
 
         /// <summary>
         /// Gets the collection of items associated with the pivot.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Tabs => this.TabsListView.Items;
+        public virtual ReadOnlyCollection<AppiumWebElement> Tabs => this.TabsListView.Items;
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem => this.TabsListView.SelectedItem;
+        public virtual AppiumWebElement SelectedItem => this.TabsListView.SelectedItem;
 
         private ListView TabsListView => this.Element.FindElement(this.tabListViewLocator);
 
@@ -77,7 +75,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <summary>
         /// Adds a new tab to the tab view.
         /// </summary>
-        public void CreateTab()
+        public virtual void CreateTab()
         {
             this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             this.AddTabButton.Click();
@@ -89,7 +87,7 @@ namespace Legerity.Windows.Elements.WinUI
         /// <param name="name">
         /// The name of the item to click.
         /// </param>
-        public void SelectTab(string name)
+        public virtual void SelectTab(string name)
         {
             this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
@@ -97,13 +95,38 @@ namespace Legerity.Windows.Elements.WinUI
         }
 
         /// <summary>
+        /// Clicks on a tab in the view with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        public virtual void SelectTabByPartialName(string name)
+        {
+            this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
+            AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(name));
+            item.Click();
+        }
+
+        /// <summary>
         /// Closes a tab in the view with the specified item name.
         /// </summary>
         /// <param name="name">The name of the item to close.</param>
-        public void CloseTab(string name)
+        public virtual void CloseTab(string name)
         {
             this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
+            Button closeButton = item.FindElement(WindowsByExtras.AutomationId("CloseButton"));
+            closeButton.Click();
+        }
+
+        /// <summary>
+        /// Closes a tab in the view with the specified partial item name.
+        /// </summary>
+        /// <param name="name">The partial name of the item to close.</param>
+        public virtual void CloseTabByPartialName(string name)
+        {
+            this.VerifyElementShown(this.tabListViewLocator, TimeSpan.FromSeconds(2));
+            AppiumWebElement item = this.Tabs.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(name));
             Button closeButton = item.FindElement(WindowsByExtras.AutomationId("CloseButton"));
             closeButton.Click();
         }

--- a/src/Legerity.Windows/Elements/Core/AppBarToggleButton.cs
+++ b/src/Legerity.Windows/Elements/Core/AppBarToggleButton.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -8,8 +9,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class AppBarToggleButton : AppBarButton
     {
-        private const string ToggleOnValue = "1";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AppBarToggleButton"/> class.
         /// </summary>
@@ -24,7 +23,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the toggle button is in the on position.
         /// </summary>
-        public bool IsOn => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
+        public virtual bool IsOn => this.GetToggleState() == ToggleState.Checked;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="AppBarToggleButton"/> without direct casting.
@@ -57,7 +56,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Toggles the button on.
         /// </summary>
-        public void ToggleOn()
+        public virtual void ToggleOn()
         {
             if (this.IsOn)
             {
@@ -70,7 +69,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Toggles the button off.
         /// </summary>
-        public void ToggleOff()
+        public virtual void ToggleOff()
         {
             if (!this.IsOn)
             {

--- a/src/Legerity.Windows/Elements/Core/AutoSuggestBox.cs
+++ b/src/Legerity.Windows/Elements/Core/AutoSuggestBox.cs
@@ -26,22 +26,22 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the suggestions popup.
         /// </summary>
-        public AppiumWebElement SuggestionsPopup => this.Element.FindElement(this.suggestionsPopupLocator);
+        public virtual AppiumWebElement SuggestionsPopup => this.Element.FindElement(this.suggestionsPopupLocator);
 
         /// <summary>
         /// Gets the element associated with the suggestion list when the <see cref="SuggestionsPopup"/> is shown.
         /// </summary>
-        public ListView SuggestionList => this.SuggestionsPopup.FindElement(WindowsByExtras.AutomationId("SuggestionsList"));
+        public virtual ListView SuggestionList => this.SuggestionsPopup.FindElement(WindowsByExtras.AutomationId("SuggestionsList"));
 
         /// <summary>
         /// Gets the element associated with the text box.
         /// </summary>
-        public TextBox TextBox => this.Element.FindElement(WindowsByExtras.AutomationId("TextBox"));
+        public virtual TextBox TextBox => this.Element.FindElement(WindowsByExtras.AutomationId("TextBox"));
 
         /// <summary>
         /// Gets the value of the auto-suggest box.
         /// </summary>
-        public string Text => this.TextBox.Text;
+        public virtual string Text => this.TextBox.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="AutoSuggestBox"/> without direct casting.
@@ -75,7 +75,7 @@ namespace Legerity.Windows.Elements.Core
         /// Selects a suggestion from the auto-suggest box.
         /// </summary>
         /// <param name="suggestion">The suggestion to select.</param>
-        public void SelectSuggestion(string suggestion)
+        public virtual void SelectSuggestion(string suggestion)
         {
             this.SelectSuggestion(suggestion, suggestion);
         }
@@ -85,7 +85,7 @@ namespace Legerity.Windows.Elements.Core
         /// </summary>
         /// <param name="value">The initial value to set.</param>
         /// <param name="suggestion">The suggestion to select.</param>
-        public void SelectSuggestion(string value, string suggestion)
+        public virtual void SelectSuggestion(string value, string suggestion)
         {
             this.SetText(value);
 
@@ -95,10 +95,24 @@ namespace Legerity.Windows.Elements.Core
         }
 
         /// <summary>
+        /// Selects a suggestion from the auto-suggest box.
+        /// </summary>
+        /// <param name="value">The initial value to set.</param>
+        /// <param name="partialSuggestion">The partial suggestion match to select.</param>
+        public virtual void SelectSuggestionByPartialSuggestion(string value, string partialSuggestion)
+        {
+            this.SetText(value);
+
+            this.VerifyElementShown(this.suggestionsPopupLocator, TimeSpan.FromSeconds(2));
+
+            this.SuggestionList.ClickItemByPartialName(partialSuggestion);
+        }
+
+        /// <summary>
         /// Sets the value of the auto-suggest box.
         /// </summary>
         /// <param name="value">The value to set.</param>
-        public void SetText(string value)
+        public virtual void SetText(string value)
         {
             this.TextBox.SetText(value);
         }

--- a/src/Legerity.Windows/Elements/Core/Button.cs
+++ b/src/Legerity.Windows/Elements/Core/Button.cs
@@ -46,13 +46,5 @@ namespace Legerity.Windows.Elements.Core
         {
             return new Button(element as WindowsElement);
         }
-
-        /// <summary>
-        /// Clicks the button.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/CalendarDatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/CalendarDatePicker.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -26,13 +27,13 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the calendar flyout.
         /// </summary>
-        public CalendarView CalendarViewFlyout =>
+        public virtual CalendarView CalendarViewFlyout =>
             this.Driver.FindElement(this.calendarPopupLocator).FindElement(WindowsByExtras.AutomationId("CalendarView"));
 
         /// <summary>
         /// Gets the value of the calendar date picker.
         /// </summary>
-        public string Value => this.Element.GetAttribute("Value.Value");
+        public virtual string Value => this.GetValue();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="CalendarDatePicker"/> without direct casting.
@@ -66,9 +67,9 @@ namespace Legerity.Windows.Elements.Core
         /// Sets the selected date of the calendar view.
         /// </summary>
         /// <param name="date">The date to set to.</param>
-        public void SetDate(DateTime date)
+        public virtual void SetDate(DateTime date)
         {
-            this.Element.Click();
+            this.Click();
 
             this.VerifyDriverElementShown(this.calendarPopupLocator, TimeSpan.FromSeconds(2));
 

--- a/src/Legerity.Windows/Elements/Core/CalendarView.cs
+++ b/src/Legerity.Windows/Elements/Core/CalendarView.cs
@@ -6,6 +6,7 @@ namespace Legerity.Windows.Elements.Core
     using System.Linq;
     using System.Threading;
     using Legerity.Extensions;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -45,27 +46,27 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the header button (change month, year).
         /// </summary>
-        public Button HeaderButton => this.Element.FindElement(WindowsByExtras.AutomationId("HeaderButton"));
+        public virtual Button HeaderButton => this.Element.FindElement(WindowsByExtras.AutomationId("HeaderButton"));
 
         /// <summary>
         /// Gets the element associated with the next month button.
         /// </summary>
-        public Button NextMonthButton => this.Element.FindElement(WindowsByExtras.AutomationId("NextButton"));
+        public virtual Button NextMonthButton => this.Element.FindElement(WindowsByExtras.AutomationId("NextButton"));
 
         /// <summary>
         /// Gets the element associated with the previous month button.
         /// </summary>
-        public Button PreviousMonthButton => this.Element.FindElement(WindowsByExtras.AutomationId("PreviousButton"));
+        public virtual Button PreviousMonthButton => this.Element.FindElement(WindowsByExtras.AutomationId("PreviousButton"));
 
         /// <summary>
         /// Gets the collection of days associated with the current month in the calendar view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Days => this.Element.FindElements(By.ClassName("CalendarViewDayItem"));
+        public virtual ReadOnlyCollection<AppiumWebElement> Days => this.Element.FindElements(By.ClassName("CalendarViewDayItem"));
 
         /// <summary>
         /// Gets the value of the calendar view.
         /// </summary>
-        public string Value => this.Element.GetAttribute("Value.Value");
+        public virtual string Value => this.GetValue();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="CalendarView"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/CheckBox.cs
+++ b/src/Legerity.Windows/Elements/Core/CheckBox.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -8,10 +9,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class CheckBox : WindowsElementWrapper
     {
-        private const string CheckedValue = "1";
-
-        private const string IndeterminateValue = "2";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CheckBox"/> class.
         /// </summary>
@@ -26,12 +23,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the check box is in the checked state.
         /// </summary>
-        public bool IsChecked => this.Element.GetAttribute("Toggle.ToggleState") == CheckedValue;
+        public virtual bool IsChecked => this.GetToggleState() == ToggleState.Checked;
 
         /// <summary>
         /// Gets a value indicating whether the check box is in the indeterminate state.
         /// </summary>
-        public bool IsIndeterminate => this.Element.GetAttribute("Toggle.ToggleState") == IndeterminateValue;
+        public virtual bool IsIndeterminate => this.GetToggleState() == ToggleState.Indeterminate;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="CheckBox"/> without direct casting.
@@ -64,27 +61,27 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Checks the check box on.
         /// </summary>
-        public void CheckOn()
+        public virtual void CheckOn()
         {
             if (this.IsChecked)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
 
         /// <summary>
         /// Checks the check box off.
         /// </summary>
-        public void CheckOff()
+        public virtual void CheckOff()
         {
             if (!this.IsChecked)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/ComboBox.cs
+++ b/src/Legerity.Windows/Elements/Core/ComboBox.cs
@@ -1,7 +1,9 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
     using OpenQA.Selenium;
@@ -29,7 +31,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the currently selected item.
         /// </summary>
-        public string SelectedItem => this.GetSelectedItem();
+        public virtual string SelectedItem => this.GetSelectedItem();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ComboBox"/> without direct casting.
@@ -65,16 +67,28 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the item to select.
         /// </param>
-        public void SelectItem(string name)
+        public virtual void SelectItem(string name)
         {
-            this.Element.Click();
-
-            this.VerifyElementsShown(this.comboBoxItemLocator, TimeSpan.FromSeconds(2));
-
-            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemLocator);
+            IEnumerable<AppiumWebElement> listElements = this.GetItemsToSelect();
 
             AppiumWebElement item = listElements.FirstOrDefault(
                 element => element.GetName().Equals(name, StringComparison.CurrentCultureIgnoreCase));
+
+            item.Click();
+        }
+
+        /// <summary>
+        /// Selects an item in the combo-box with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to select.
+        /// </param>
+        public virtual void SelectItemByPartialName(string name)
+        {
+            IEnumerable<AppiumWebElement> listElements = this.GetItemsToSelect();
+
+            AppiumWebElement item = listElements.FirstOrDefault(
+                element => element.GetName().Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
 
             item.Click();
         }
@@ -83,6 +97,14 @@ namespace Legerity.Windows.Elements.Core
         {
             ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemLocator);
             return listElements.Count == 1 ? listElements.FirstOrDefault().GetName() : null;
+        }
+
+        private IEnumerable<AppiumWebElement> GetItemsToSelect()
+        {
+            this.Click();
+            this.VerifyElementsShown(this.comboBoxItemLocator, TimeSpan.FromSeconds(2));
+            ReadOnlyCollection<AppiumWebElement> listElements = this.Element.FindElements(this.comboBoxItemLocator);
+            return listElements;
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/CommandBar.cs
+++ b/src/Legerity.Windows/Elements/Core/CommandBar.cs
@@ -3,9 +3,7 @@ namespace Legerity.Windows.Elements.Core
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
     using Legerity.Windows.Extensions;
-
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -35,9 +33,14 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of primary buttons.
         /// </summary>
-        public IEnumerable<AppBarButton> PrimaryButtons =>
+        public virtual IEnumerable<AppBarButton> PrimaryButtons =>
             this.Element.FindElements(this.appBarButtonLocator)
                 .Select<AppiumWebElement, AppBarButton>(element => element);
+
+        /// <summary>
+        /// Gets the <see cref="AppBarButton"/> for opening the secondary button menu.
+        /// </summary>
+        public virtual AppBarButton SecondaryMenuButton => this.Element.FindElement(this.moreButtonLocator);
 
         /// <summary>
         /// Gets the collection of secondary buttons.
@@ -45,7 +48,7 @@ namespace Legerity.Windows.Elements.Core
         /// Note, this property will only return a result when the secondary buttons are shown in the flyout.
         /// </para>
         /// </summary>
-        public IEnumerable<AppBarButton> SecondaryButtons =>
+        public virtual IEnumerable<AppBarButton> SecondaryButtons =>
             this.Driver.FindElement(this.overflowPopupLocator).FindElements(this.appBarButtonLocator)
                 .Select<AppiumWebElement, AppBarButton>(element => element);
 
@@ -78,15 +81,29 @@ namespace Legerity.Windows.Elements.Core
         }
 
         /// <summary>
-        /// Clicks a primary button in the command bar with the specified button name.
+        /// Clicks a primary button in the command bar with the specified button name or Automation ID.
         /// </summary>
         /// <param name="name">
         /// The name of the button to click.
         /// </param>
-        public void ClickPrimaryButton(string name)
+        public virtual void ClickPrimaryButton(string name)
         {
             AppBarButton item = this.PrimaryButtons.FirstOrDefault(
                 element => element.Element.VerifyNameOrAutomationIdEquals(name));
+
+            item.Click();
+        }
+
+        /// <summary>
+        /// Clicks a primary button in the command bar with the specified partial button name or Automation ID.
+        /// </summary>
+        /// <param name="partialName">
+        /// The partial name of the button to click.
+        /// </param>
+        public virtual void ClickPrimaryButtonByPartialName(string partialName)
+        {
+            AppBarButton item = this.PrimaryButtons.FirstOrDefault(
+                element => element.Element.VerifyNameOrAutomationIdContains(partialName));
 
             item.Click();
         }
@@ -97,19 +114,40 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the button to click.
         /// </param>
-        public void ClickSecondaryButton(string name)
+        public virtual void ClickSecondaryButton(string name)
         {
-            this.VerifyElementShown(this.moreButtonLocator, TimeSpan.FromSeconds(2));
-
-            AppBarButton secondaryOverflowButton = this.Element.FindElement(this.moreButtonLocator);
-            secondaryOverflowButton.Click();
-
-            this.VerifyDriverElementShown(this.overflowPopupLocator, TimeSpan.FromSeconds(2));
+            this.OpenSecondaryButtonMenu();
 
             AppBarButton secondaryButton = this.SecondaryButtons.FirstOrDefault(
                 button => button.Element.VerifyNameOrAutomationIdEquals(name));
 
             secondaryButton.Click();
+        }
+
+        /// <summary>
+        /// Clicks a secondary button in the command bar with the specified partial button name.
+        /// </summary>
+        /// <param name="partialName">
+        /// The partial name of the button to click.
+        /// </param>
+        public virtual void ClickSecondaryButtonByPartialName(string partialName)
+        {
+            this.OpenSecondaryButtonMenu();
+
+            AppBarButton secondaryButton = this.SecondaryButtons.FirstOrDefault(
+                button => button.Element.VerifyNameOrAutomationIdContains(partialName));
+
+            secondaryButton.Click();
+        }
+
+        /// <summary>
+        /// Opens the menu associated with the secondary button options.
+        /// </summary>
+        public virtual void OpenSecondaryButtonMenu()
+        {
+            this.VerifyElementShown(this.moreButtonLocator, TimeSpan.FromSeconds(2));
+            this.SecondaryMenuButton.Click();
+            this.VerifyDriverElementShown(this.overflowPopupLocator, TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/DatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/DatePicker.cs
@@ -52,10 +52,10 @@ namespace Legerity.Windows.Elements.Core
         /// Sets the date to the specified date.
         /// </summary>
         /// <param name="date">The date to set.</param>
-        public void SetDate(DateTime date)
+        public virtual void SetDate(DateTime date)
         {
             // Taps the time picker to show the popup.
-            this.Element.Click();
+            this.Click();
 
             // Finds the popup and changes the time.
             WindowsElement popup = this.Driver.FindElement(WindowsByExtras.AutomationId("DatePickerFlyoutPresenter"));

--- a/src/Legerity.Windows/Elements/Core/FlipView.cs
+++ b/src/Legerity.Windows/Elements/Core/FlipView.cs
@@ -5,6 +5,7 @@ namespace Legerity.Windows.Elements.Core
     using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -28,26 +29,22 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the flip view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(By.ClassName("FlipViewItem"));
+        public virtual ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(By.ClassName("FlipViewItem"));
 
         /// <summary>
         /// Gets the element associated with the next item button.
         /// </summary>
-        public Button NextButton => this.Element.FindElement(WindowsByExtras.AutomationId("NextButtonHorizontal"));
+        public virtual Button NextButton => this.Element.FindElement(WindowsByExtras.AutomationId("NextButtonHorizontal"));
 
         /// <summary>
         /// Gets the element associated with the previous item button.
         /// </summary>
-        public Button PreviousButton => this.Element.FindElement(WindowsByExtras.AutomationId("PreviousButtonHorizontal"));
+        public virtual Button PreviousButton => this.Element.FindElement(WindowsByExtras.AutomationId("PreviousButtonHorizontal"));
 
         /// <summary>
         /// Gets the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem =>
-            this.Items.FirstOrDefault(
-                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                    "True",
-                    StringComparison.CurrentCultureIgnoreCase));
+        public virtual AppiumWebElement SelectedItem => this.Items.FirstOrDefault(i => i.IsSelected());
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="FlipView"/> without direct casting.
@@ -83,7 +80,7 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the item.
         /// </param>
-        public void SelectItem(string name)
+        public virtual void SelectItem(string name)
         {
             int currentItemIdx = this.Items.IndexOf(this.SelectedItem);
             int expectedItemIdx = this.Items.IndexOf(
@@ -109,18 +106,18 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Selects the next item in the flip view.
         /// </summary>
-        public void SelectNext()
+        public virtual void SelectNext()
         {
-            this.Element.Click();
+            this.Click();
             this.Element.SendKeys(Keys.ArrowRight);
         }
 
         /// <summary>
         /// Selects the previous item in the flip view.
         /// </summary>
-        public void SelectPrevious()
+        public virtual void SelectPrevious()
         {
-            this.Element.Click();
+            this.Click();
             this.Element.SendKeys(Keys.ArrowLeft);
         }
     }

--- a/src/Legerity.Windows/Elements/Core/FlipViewItem.cs
+++ b/src/Legerity.Windows/Elements/Core/FlipViewItem.cs
@@ -1,6 +1,0 @@
-namespace Legerity.Windows.Elements.Core
-{
-    internal class FlipViewItem
-    {
-    }
-}

--- a/src/Legerity.Windows/Elements/Core/GridView.cs
+++ b/src/Legerity.Windows/Elements/Core/GridView.cs
@@ -30,16 +30,13 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the grid view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.gridViewItemLocator);
+        public virtual ReadOnlyCollection<AppiumWebElement> Items =>
+            this.Element.FindElements(this.gridViewItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem =>
-            this.Items.FirstOrDefault(
-                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                    "True",
-                    StringComparison.CurrentCultureIgnoreCase));
+        public virtual AppiumWebElement SelectedItem => this.Items.FirstOrDefault(i => i.IsSelected());
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="GridView"/> without direct casting.
@@ -75,11 +72,27 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the item to click.
         /// </param>
-        public void ClickItem(string name)
+        public virtual void ClickItem(string name)
         {
             this.VerifyElementsShown(this.gridViewItemLocator, TimeSpan.FromSeconds(2));
 
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
+
+            item.Click();
+        }
+
+        /// <summary>
+        /// Clicks on an item in the list view with the specified partial item name.
+        /// </summary>
+        /// <param name="partialName">
+        /// The partial name of the item to click.
+        /// </param>
+        public virtual void ClickItemByPartialName(string partialName)
+        {
+            this.VerifyElementsShown(this.gridViewItemLocator, TimeSpan.FromSeconds(2));
+
+            AppiumWebElement item =
+                this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(partialName));
 
             item.Click();
         }

--- a/src/Legerity.Windows/Elements/Core/Hub.cs
+++ b/src/Legerity.Windows/Elements/Core/Hub.cs
@@ -24,7 +24,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the hub.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(By.ClassName("HubSection"));
+        public virtual ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(By.ClassName("HubSection"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Hub"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.BallpointPenFlyout.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.BallpointPenFlyout.cs
@@ -11,7 +11,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Defines a color flyout for the ballpoint pen in the <see cref="InkToolbar"/>.
         /// </summary>
-        private class InkToolbarBallpointPenFlyout : InkToolbarColorFlyoutBase
+        public class InkToolbarBallpointPenFlyout : InkToolbarColorFlyoutBase
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="Legerity.Windows.Elements.Core.InkToolbar.InkToolbarBallpointPenFlyout"/> class.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.ColorFlyoutBase.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.ColorFlyoutBase.cs
@@ -3,6 +3,7 @@ namespace Legerity.Windows.Elements.Core
     using System;
     using System.Linq;
     using Legerity.Extensions;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -15,7 +16,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Defines a base for a color flyout in the <see cref="InkToolbar"/>.
         /// </summary>
-        private abstract class InkToolbarColorFlyoutBase : WindowsElementWrapper
+        public abstract class InkToolbarColorFlyoutBase : WindowsElementWrapper
         {
             private readonly By penColorPaletteLocator = WindowsByExtras.AutomationId("PenColorPalette");
 
@@ -33,40 +34,47 @@ namespace Legerity.Windows.Elements.Core
             /// <summary>
             /// Gets the element associated with the color grid.
             /// </summary>
-            public GridView ColorGridView => this.Driver.FindElement(this.penColorPaletteLocator);
+            public virtual GridView ColorGridView => this.Driver.FindElement(this.penColorPaletteLocator);
 
             /// <summary>
             /// Gets the element associated with the size of the ink.
             /// </summary>
-            public Slider SizeSlider => this.Driver.FindElement(WindowsByExtras.AutomationId("PenStrokeWidthSlider"));
+            public virtual Slider SizeSlider =>
+                this.Driver.FindElement(WindowsByExtras.AutomationId("PenStrokeWidthSlider"));
 
             /// <summary>
             /// Gets the currently selected color.
             /// </summary>
-            public string SelectedColor => this.GetSelectedColor().GetName();
+            public virtual string SelectedColor => this.GetSelectedColor().GetName();
 
             /// <summary>
             /// Gets the currently selected size.
             /// </summary>
-            public double SelectedSize => this.SizeSlider.Value;
+            public virtual double SelectedSize => this.SizeSlider.Value;
 
             /// <summary>
             /// Sets the color of the ink.
             /// </summary>
             /// <param name="color">The color to select.</param>
-            public void SetColor(string color)
+            public virtual void SetColor(string color)
             {
                 this.ColorGridView.ClickItem(color);
+            }
+
+            /// <summary>
+            /// Sets the color of the ink by partial color name match.
+            /// </summary>
+            /// <param name="partialColor">The partial color name to select.</param>
+            public virtual void SetColorByPartialName(string partialColor)
+            {
+                this.ColorGridView.ClickItemByPartialName(partialColor);
             }
 
             private AppiumWebElement GetSelectedColor()
             {
                 this.VerifyElementShown(this.penColorPaletteLocator, TimeSpan.FromSeconds(2));
 
-                return this.ColorGridView.Items.FirstOrDefault(
-                    i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                        "True",
-                        StringComparison.CurrentCultureIgnoreCase));
+                return this.ColorGridView.Items.FirstOrDefault(i => i.IsSelected());
             }
         }
     }

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.HighlighterFlyout.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.HighlighterFlyout.cs
@@ -11,7 +11,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Defines a color flyout for the highlighter in the <see cref="InkToolbar"/>.
         /// </summary>
-        private class InkToolbarHighlighterFlyout : InkToolbarColorFlyoutBase
+        public class InkToolbarHighlighterFlyout : InkToolbarColorFlyoutBase
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="Legerity.Windows.Elements.Core.InkToolbar.InkToolbarHighlighterFlyout"/> class.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.PencilFlyout.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.PencilFlyout.cs
@@ -11,7 +11,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Defines a color flyout for the pencil in the <see cref="InkToolbar"/>.
         /// </summary>
-        private class InkToolbarPencilFlyout : InkToolbarColorFlyoutBase
+        public class InkToolbarPencilFlyout : InkToolbarColorFlyoutBase
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="Legerity.Windows.Elements.Core.InkToolbar.InkToolbarPencilFlyout"/> class.

--- a/src/Legerity.Windows/Elements/Core/InkToolbar.cs
+++ b/src/Legerity.Windows/Elements/Core/InkToolbar.cs
@@ -30,48 +30,67 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the ballpoint pen button.
         /// </summary>
-        public RadioButton BallpointPenButton =>
+        public virtual RadioButton BallpointPenButton =>
             this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarBallpointPenButton"));
 
         /// <summary>
         /// Gets the currently selected ballpoint pen color.
         /// </summary>
-        public string SelectedBallpointPenColor => this.BallpointPenFlyout.SelectedColor;
+        public virtual string SelectedBallpointPenColor => this.BallpointPenFlyout.SelectedColor;
 
         /// <summary>
         /// Gets the element associated with the pencil button.
         /// </summary>
-        public RadioButton PencilButton =>
+        public virtual RadioButton PencilButton =>
             this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarPencilButton"));
 
         /// <summary>
         /// Gets the currently selected pencil color.
         /// </summary>
-        public string SelectedPencilColor => this.PencilFlyout.SelectedColor;
+        public virtual string SelectedPencilColor => this.PencilFlyout.SelectedColor;
 
         /// <summary>
         /// Gets the element associated with the highlighter button.
         /// </summary>
-        public RadioButton HighlighterButton =>
+        public virtual RadioButton HighlighterButton =>
             this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarHighlighterButton"));
 
         /// <summary>
         /// Gets the currently selected highlighter color.
         /// </summary>
-        public string SelectedHighlighterColor => this.HighlighterFlyout.SelectedColor;
+        public virtual string SelectedHighlighterColor => this.HighlighterFlyout.SelectedColor;
 
         /// <summary>
         /// Gets the element associated with the ruler button.
         /// </summary>
-        public ToggleButton RulerButton =>
+        public virtual ToggleButton RulerButton =>
             this.Element.FindElement(WindowsByExtras.AutomationId("InkToolbarStencilButton"));
 
-        private InkToolbarBallpointPenFlyout BallpointPenFlyout =>
+        /// <summary>
+        /// Gets the element associated with the ballpoint pen flyout.
+        /// </summary>
+        /// <remarks>
+        /// This is only available when the ballpoint pen button is selected.
+        /// </remarks>
+        public virtual InkToolbarBallpointPenFlyout BallpointPenFlyout =>
             this.Driver.FindElement(this.ballpointPenFlyoutLocator);
 
-        private InkToolbarPencilFlyout PencilFlyout => this.Driver.FindElement(this.pencilFlyoutLocator);
+        /// <summary>
+        /// Gets the element associated with the pencil flyout.
+        /// </summary>
+        /// <remarks>
+        /// This is only available when the pencil button is selected.
+        /// </remarks>
+        public virtual InkToolbarPencilFlyout PencilFlyout => this.Driver.FindElement(this.pencilFlyoutLocator);
 
-        private InkToolbarHighlighterFlyout HighlighterFlyout => this.Driver.FindElement(this.highlighterFlyoutLocator);
+        /// <summary>
+        /// Gets the element associated with the highlighter flyout.
+        /// </summary>
+        /// <remarks>
+        /// This is only available when the highlighter button is selected.
+        /// </remarks>
+        public virtual InkToolbarHighlighterFlyout HighlighterFlyout =>
+            this.Driver.FindElement(this.highlighterFlyoutLocator);
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="InkToolbar"/> without direct casting.
@@ -104,7 +123,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Selects the ballpoint pen option.
         /// </summary>
-        public void SelectBallpointPen()
+        public virtual void SelectBallpointPen()
         {
             if (!this.BallpointPenButton.IsSelected)
             {
@@ -115,7 +134,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Opens the ballpoint pen flyout.
         /// </summary>
-        public void OpenBallpointPenFlyout()
+        public virtual void OpenBallpointPenFlyout()
         {
             this.SelectBallpointPen();
 
@@ -129,16 +148,28 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="color">
         /// The color to set.
         /// </param>
-        public void SetBallpointPenColor(string color)
+        public virtual void SetBallpointPenColor(string color)
         {
             this.OpenBallpointPenFlyout();
             this.BallpointPenFlyout.SetColor(color);
         }
 
         /// <summary>
+        /// Sets the toolbar to the ballpoint pen with the given partial color name.
+        /// </summary>
+        /// <param name="color">
+        /// The partial color name to set.
+        /// </param>
+        public virtual void SetBallpointPenColorByPartialName(string color)
+        {
+            this.OpenBallpointPenFlyout();
+            this.BallpointPenFlyout.SetColorByPartialName(color);
+        }
+
+        /// <summary>
         /// Selects the pencil option.
         /// </summary>
-        public void SelectPencil()
+        public virtual void SelectPencil()
         {
             if (!this.PencilButton.IsSelected)
             {
@@ -149,7 +180,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Opens the pencil flyout.
         /// </summary>
-        public void OpenPencilFlyout()
+        public virtual void OpenPencilFlyout()
         {
             this.SelectPencil();
 
@@ -163,16 +194,28 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="color">
         /// The color to set.
         /// </param>
-        public void SetPencilColor(string color)
+        public virtual void SetPencilColor(string color)
         {
             this.OpenPencilFlyout();
             this.PencilFlyout.SetColor(color);
         }
 
         /// <summary>
+        /// Sets the toolbar to the pencil with the given partial color name.
+        /// </summary>
+        /// <param name="color">
+        /// The partial color name to set.
+        /// </param>
+        public virtual void SetPencilColorByPartialName(string color)
+        {
+            this.OpenPencilFlyout();
+            this.PencilFlyout.SetColorByPartialName(color);
+        }
+
+        /// <summary>
         /// Selects the highlighter option.
         /// </summary>
-        public void SelectHighlighter()
+        public virtual void SelectHighlighter()
         {
             if (!this.HighlighterButton.IsSelected)
             {
@@ -183,7 +226,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Opens the pencil flyout.
         /// </summary>
-        public void OpenHighlighterFlyout()
+        public virtual void OpenHighlighterFlyout()
         {
             this.SelectHighlighter();
 
@@ -192,15 +235,27 @@ namespace Legerity.Windows.Elements.Core
         }
 
         /// <summary>
-        /// Sets the toolbar to the pencil with the given color and size.
+        /// Sets the toolbar to the highlighter with the given color.
         /// </summary>
         /// <param name="color">
         /// The color to set.
         /// </param>
-        public void SetHighlighterColor(string color)
+        public virtual void SetHighlighterColor(string color)
         {
             this.OpenHighlighterFlyout();
             this.HighlighterFlyout.SetColor(color);
+        }
+
+        /// <summary>
+        /// Sets the toolbar to the highlighter with the given color.
+        /// </summary>
+        /// <param name="color">
+        /// The color to set.
+        /// </param>
+        public virtual void SetHighlighterColorByPartialName(string color)
+        {
+            this.OpenHighlighterFlyout();
+            this.HighlighterFlyout.SetColorByPartialName(color);
         }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/ListBox.cs
+++ b/src/Legerity.Windows/Elements/Core/ListBox.cs
@@ -30,16 +30,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the list box.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listBoxItemLocator);
+        public virtual ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listBoxItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem =>
-            this.Items.FirstOrDefault(
-                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                    "True",
-                    StringComparison.CurrentCultureIgnoreCase));
+        public virtual AppiumWebElement SelectedItem => this.Items.FirstOrDefault(i => i.IsSelected());
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ListBox"/> without direct casting.
@@ -75,12 +71,22 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the item to click.
         /// </param>
-        public void ClickItem(string name)
+        public virtual void ClickItem(string name)
         {
             this.VerifyElementsShown(this.listBoxItemLocator, TimeSpan.FromSeconds(2));
-
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
+            item.Click();
+        }
 
+        /// <summary>
+        /// Clicks on an item in the list box with the specified partial item name.
+        /// </summary>
+        /// <param name="partialName">The partial name match for the item to click.</param>
+        public virtual void ClickItemByPartialName(string partialName)
+        {
+            this.VerifyElementsShown(this.listBoxItemLocator, TimeSpan.FromSeconds(2));
+            AppiumWebElement item =
+                this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(partialName));
             item.Click();
         }
     }

--- a/src/Legerity.Windows/Elements/Core/ListView.cs
+++ b/src/Legerity.Windows/Elements/Core/ListView.cs
@@ -30,16 +30,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the list view.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listViewItemLocator);
+        public virtual ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.listViewItemLocator);
 
         /// <summary>
         /// Gets the element associated with the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem =>
-            this.Items.FirstOrDefault(
-                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                    "True",
-                    StringComparison.CurrentCultureIgnoreCase));
+        public virtual AppiumWebElement SelectedItem => this.Items.FirstOrDefault(i => i.IsSelected());
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ListView"/> without direct casting.
@@ -75,10 +71,22 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the item to click.
         /// </param>
-        public void ClickItem(string name)
+        public virtual void ClickItem(string name)
         {
             this.VerifyElementsShown(this.listViewItemLocator, TimeSpan.FromSeconds(2));
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
+            item.Click();
+        }
+
+        /// <summary>
+        /// Clicks on an item in the list view with the specified partial item name.
+        /// </summary>
+        /// <param name="partialName">The partial name match for the item to click.</param>
+        public virtual void ClickItemByPartialName(string partialName)
+        {
+            this.VerifyElementsShown(this.listViewItemLocator, TimeSpan.FromSeconds(2));
+            AppiumWebElement item =
+                this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(partialName));
             item.Click();
         }
     }

--- a/src/Legerity.Windows/Elements/Core/MenuFlyoutItem.cs
+++ b/src/Legerity.Windows/Elements/Core/MenuFlyoutItem.cs
@@ -17,13 +17,5 @@ namespace Legerity.Windows.Elements.Core
             : base(element)
         {
         }
-
-        /// <summary>
-        /// Clicks the item.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
     }
 }

--- a/src/Legerity.Windows/Elements/Core/MenuFlyoutSubItem.cs
+++ b/src/Legerity.Windows/Elements/Core/MenuFlyoutSubItem.cs
@@ -2,6 +2,7 @@ namespace Legerity.Windows.Elements.Core
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Legerity.Extensions;
     using OpenQA.Selenium;
@@ -26,20 +27,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the UI components associated with the child menu items.
         /// </summary>
-        public IEnumerable<MenuFlyoutItem> ChildMenuItems => this.GetChildMenuItems();
+        public virtual IEnumerable<MenuFlyoutItem> ChildMenuItems => this.GetChildMenuItems();
 
         /// <summary>
         /// Gets the UI components associated with the child menu sub-items.
         /// </summary>
-        public IEnumerable<MenuFlyoutSubItem> ChildMenuSubItems => this.GetChildMenuSubItems();
-
-        /// <summary>
-        /// Clicks the item.
-        /// </summary>
-        public void Click()
-        {
-            this.Element.Click();
-        }
+        public virtual IEnumerable<MenuFlyoutSubItem> ChildMenuSubItems => this.GetChildMenuSubItems();
 
         /// <summary>
         /// Clicks on a child menu option with the specified item name.
@@ -50,7 +43,7 @@ namespace Legerity.Windows.Elements.Core
         /// <returns>
         /// The clicked <see cref="MenuFlyoutItem"/>.
         /// </returns>
-        public MenuFlyoutItem ClickChildOption(string name)
+        public virtual MenuFlyoutItem ClickChildOption(string name)
         {
             MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
                 element => element.GetName()
@@ -61,15 +54,49 @@ namespace Legerity.Windows.Elements.Core
         }
 
         /// <summary>
+        /// Clicks on a child menu option with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        /// <returns>
+        /// The clicked <see cref="MenuFlyoutItem"/>.
+        /// </returns>
+        public virtual MenuFlyoutItem ClickChildOptionByPartialName(string name)
+        {
+            MenuFlyoutItem item = this.ChildMenuItems.FirstOrDefault(
+                element => element.GetName()
+                    .Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
+
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
         /// Clicks on a child menu sub option with the specified item name.
         /// </summary>
         /// <param name="name">The name of the sub-item to click.</param>
         /// <returns>The clicked <see cref="MenuFlyoutSubItem"/>.</returns>
-        public MenuFlyoutSubItem ClickChildSubOption(string name)
+        public virtual MenuFlyoutSubItem ClickChildSubOption(string name)
         {
             MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
                 element => element.GetName()
                     .Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            item.Click();
+            return item;
+        }
+
+        /// <summary>
+        /// Clicks on a child menu sub option with the specified partial item name.
+        /// </summary>
+        /// <param name="name">The name of the sub-item to click.</param>
+        /// <returns>The clicked <see cref="MenuFlyoutSubItem"/>.</returns>
+        public virtual MenuFlyoutSubItem ClickChildSubOptionByPartialName(string name)
+        {
+            MenuFlyoutSubItem item = this.ChildMenuSubItems.FirstOrDefault(
+                element => element.GetName()
+                    .Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase));
+
             item.Click();
             return item;
         }

--- a/src/Legerity.Windows/Elements/Core/PasswordBox.cs
+++ b/src/Legerity.Windows/Elements/Core/PasswordBox.cs
@@ -22,7 +22,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the element associated with the reveal password button.
         /// </summary>
-        public ToggleButton RevealButton => this.Element.FindElement(WindowsByExtras.AutomationId("RevealButton"));
+        public virtual ToggleButton RevealButton => this.Element.FindElement(WindowsByExtras.AutomationId("RevealButton"));
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="PasswordBox"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/Pivot.cs
+++ b/src/Legerity.Windows/Elements/Core/Pivot.cs
@@ -30,16 +30,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the collection of items associated with the pivot.
         /// </summary>
-        public ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.pivotItemLocator);
+        public virtual ReadOnlyCollection<AppiumWebElement> Items => this.Element.FindElements(this.pivotItemLocator);
 
         /// <summary>
         /// Gets the currently selected item.
         /// </summary>
-        public AppiumWebElement SelectedItem =>
-            this.Items.FirstOrDefault(
-                i => i.GetAttribute("SelectionItem.IsSelected").Equals(
-                    "True",
-                    StringComparison.CurrentCultureIgnoreCase));
+        public virtual AppiumWebElement SelectedItem => this.Items.FirstOrDefault(i => i.IsSelected());
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Pivot"/> without direct casting.
@@ -75,11 +71,26 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="name">
         /// The name of the item to click.
         /// </param>
-        public void ClickItem(string name)
+        public virtual void ClickItem(string name)
         {
             this.VerifyElementsShown(this.pivotItemLocator, TimeSpan.FromSeconds(2));
 
             AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdEquals(name));
+
+            item.Click();
+        }
+
+        /// <summary>
+        /// Clicks on an item in the pivot with the specified partial item name.
+        /// </summary>
+        /// <param name="name">
+        /// The partial name of the item to click.
+        /// </param>
+        public virtual void ClickItemByPartialName(string name)
+        {
+            this.VerifyElementsShown(this.pivotItemLocator, TimeSpan.FromSeconds(2));
+
+            AppiumWebElement item = this.Items.FirstOrDefault(element => element.VerifyNameOrAutomationIdContains(name));
 
             item.Click();
         }

--- a/src/Legerity.Windows/Elements/Core/ProgressBar.cs
+++ b/src/Legerity.Windows/Elements/Core/ProgressBar.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -23,13 +24,13 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the value of the progress bar.
         /// </summary>
-        public double Percentage => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Percentage => this.GetRangeValue();
 
         /// <summary>
         /// Gets a value indicating whether the control is in an indeterminate state.
         /// </summary>
         public bool IsIndeterminate =>
-            this.Element.GetAttribute("IsRangeValuePatternAvailable").Equals(
+            this.GetAttribute("IsRangeValuePatternAvailable").Equals(
                 "False",
                 StringComparison.CurrentCultureIgnoreCase);
 

--- a/src/Legerity.Windows/Elements/Core/RadioButton.cs
+++ b/src/Legerity.Windows/Elements/Core/RadioButton.cs
@@ -1,6 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
-    using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -23,10 +23,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the radio button is selected.
         /// </summary>
-        public bool IsSelected =>
-            this.Element.GetAttribute("SelectionItem.IsSelected").Equals(
-                "True",
-                StringComparison.CurrentCultureIgnoreCase);
+        public virtual bool IsSelected => this.IsSelected();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="RadioButton"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/Slider.cs
+++ b/src/Legerity.Windows/Elements/Core/Slider.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Elements.Core
 {
     using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
@@ -24,27 +25,27 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the minimum value of the slider.
         /// </summary>
-        public double Minimum => double.Parse(this.Element.GetAttribute("RangeValue.Minimum"));
+        public virtual double Minimum => this.GetRangeMinimum();
 
         /// <summary>
         /// Gets the maximum value of the slider.
         /// </summary>
-        public double Maximum => double.Parse(this.Element.GetAttribute("RangeValue.Maximum"));
+        public virtual double Maximum => this.GetRangeMaximum();
 
         /// <summary>
         /// Gets the small change (step) value of the slider.
         /// </summary>
-        public double SmallChange => double.Parse(this.Element.GetAttribute("RangeValue.SmallChange"));
+        public virtual double SmallChange => this.GetRangeSmallChange();
 
         /// <summary>
         /// Gets the value of the slider.
         /// </summary>
-        public double Value => double.Parse(this.Element.GetAttribute("RangeValue.Value"));
+        public virtual double Value => this.GetRangeValue();
 
         /// <summary>
         /// Gets a value indicating whether the control is in a readonly state.
         /// </summary>
-        public bool IsReadonly => bool.Parse(this.Element.GetAttribute("RangeValue.IsReadOnly"));
+        public virtual bool IsReadonly => this.IsRangeReadonly();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="Slider"/> without direct casting.
@@ -83,22 +84,28 @@ namespace Legerity.Windows.Elements.Core
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the value is out of the minimum and maximum range of the slider.
         /// </exception>
-        public void SetValue(double value)
+        public virtual void SetValue(double value)
         {
             double min = this.Minimum;
             double max = this.Maximum;
 
             if (value < this.Minimum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be greater than or equal to the minimum value {min}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"Value must be greater than or equal to the minimum value {min}");
             }
 
             if (value > this.Maximum)
             {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Value must be less than or equal to the maximum value {max}");
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    $"Value must be less than or equal to the maximum value {max}");
             }
 
-            this.Element.Click();
+            this.Click();
 
             double currentValue = this.Value;
             while (Math.Abs(currentValue - value) > double.Epsilon)

--- a/src/Legerity.Windows/Elements/Core/TextBlock.cs
+++ b/src/Legerity.Windows/Elements/Core/TextBlock.cs
@@ -22,7 +22,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the text value of the text block.
         /// </summary>
-        public string Text => this.Element.Text;
+        public virtual string Text => this.Element.Text;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="TextBlock"/> without direct casting.

--- a/src/Legerity.Windows/Elements/Core/TextBox.cs
+++ b/src/Legerity.Windows/Elements/Core/TextBox.cs
@@ -1,6 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
-    using System;
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -23,13 +23,12 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets the text value of the text box.
         /// </summary>
-        public string Text => this.Element.GetAttribute("Value.Value");
+        public virtual string Text => this.GetValue();
 
         /// <summary>
         /// Gets a value indicating whether the text box is in a readonly state.
         /// </summary>
-        public bool IsReadonly =>
-            this.Element.GetAttribute("Value.IsReadonly").Equals("True", StringComparison.CurrentCultureIgnoreCase);
+        public virtual bool IsReadonly => this.IsReadonly();
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="TextBox"/> without direct casting.
@@ -63,7 +62,7 @@ namespace Legerity.Windows.Elements.Core
         /// Sets the text of the text box to the specified text.
         /// </summary>
         /// <param name="text">The text to display.</param>
-        public void SetText(string text)
+        public virtual void SetText(string text)
         {
             this.ClearText();
             this.AppendText(text);
@@ -73,18 +72,18 @@ namespace Legerity.Windows.Elements.Core
         /// Appends the specified text to the text box.
         /// </summary>
         /// <param name="text">The text to append.</param>
-        public void AppendText(string text)
+        public virtual void AppendText(string text)
         {
-            this.Element.Click();
+            this.Click();
             this.Element.SendKeys(text);
         }
 
         /// <summary>
         /// Clears the text from the text box.
         /// </summary>
-        public void ClearText()
+        public virtual void ClearText()
         {
-            this.Element.Click();
+            this.Click();
             this.Element.Clear();
         }
     }

--- a/src/Legerity.Windows/Elements/Core/TimePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/TimePicker.cs
@@ -54,10 +54,10 @@ namespace Legerity.Windows.Elements.Core
         /// <param name="time">
         /// The time to set.
         /// </param>
-        public void SetTime(TimeSpan time)
+        public virtual void SetTime(TimeSpan time)
         {
             // Taps the time picker to show the popup.
-            this.Element.Click();
+            this.Click();
 
             // Finds the popup and changes the time.
             WindowsElement popup = this.Driver.FindElement(WindowsByExtras.AutomationId("TimePickerFlyoutPresenter"));

--- a/src/Legerity.Windows/Elements/Core/ToggleButton.cs
+++ b/src/Legerity.Windows/Elements/Core/ToggleButton.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -8,8 +9,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class ToggleButton : Button
     {
-        private const string ToggleOnValue = "1";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ToggleButton"/> class.
         /// </summary>
@@ -24,7 +23,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the toggle button is in the on position.
         /// </summary>
-        public bool IsOn => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
+        public virtual bool IsOn => this.GetToggleState() == ToggleState.Checked;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ToggleButton"/> without direct casting.
@@ -57,7 +56,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Toggles the button on.
         /// </summary>
-        public void ToggleOn()
+        public virtual void ToggleOn()
         {
             if (this.IsOn)
             {
@@ -70,7 +69,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Toggles the button off.
         /// </summary>
-        public void ToggleOff()
+        public virtual void ToggleOff()
         {
             if (!this.IsOn)
             {

--- a/src/Legerity.Windows/Elements/Core/ToggleState.cs
+++ b/src/Legerity.Windows/Elements/Core/ToggleState.cs
@@ -1,0 +1,23 @@
+namespace Legerity.Windows.Elements.Core
+{
+    /// <summary>
+    /// Defines the states of a toggle in a Windows element.
+    /// </summary>
+    public enum ToggleState
+    {
+        /// <summary>
+        /// The toggle is not checked.
+        /// </summary>
+        Unchecked = 0,
+
+        /// <summary>
+        /// The toggle is checked.
+        /// </summary>
+        Checked = 1,
+
+        /// <summary>
+        /// The toggle is indeterminate.
+        /// </summary>
+        Indeterminate = 2,
+    }
+}

--- a/src/Legerity.Windows/Elements/Core/ToggleSwitch.cs
+++ b/src/Legerity.Windows/Elements/Core/ToggleSwitch.cs
@@ -1,5 +1,6 @@
 namespace Legerity.Windows.Elements.Core
 {
+    using Legerity.Windows.Extensions;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Windows;
 
@@ -8,8 +9,6 @@ namespace Legerity.Windows.Elements.Core
     /// </summary>
     public class ToggleSwitch : WindowsElementWrapper
     {
-        private const string ToggleOnValue = "1";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ToggleSwitch"/> class.
         /// </summary>
@@ -24,7 +23,7 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Gets a value indicating whether the toggle switch is in the on position.
         /// </summary>
-        public bool IsOn => this.Element.GetAttribute("Toggle.ToggleState") == ToggleOnValue;
+        public virtual bool IsOn => this.GetToggleState() == ToggleState.Checked;
 
         /// <summary>
         /// Allows conversion of a <see cref="WindowsElement"/> to the <see cref="ToggleSwitch"/> without direct casting.
@@ -57,27 +56,27 @@ namespace Legerity.Windows.Elements.Core
         /// <summary>
         /// Toggles the switch on.
         /// </summary>
-        public void ToggleOn()
+        public virtual void ToggleOn()
         {
             if (this.IsOn)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
 
         /// <summary>
         /// Toggles the switch off.
         /// </summary>
-        public void ToggleOff()
+        public virtual void ToggleOff()
         {
             if (!this.IsOn)
             {
                 return;
             }
 
-            this.Element.Click();
+            this.Click();
         }
     }
 }

--- a/src/Legerity.Windows/Elements/WindowsElementWrapper.cs
+++ b/src/Legerity.Windows/Elements/WindowsElementWrapper.cs
@@ -29,11 +29,6 @@ namespace Legerity.Windows.Elements
         public WindowsDriver<WindowsElement> Driver => AppManager.WindowsApp;
 
         /// <summary>
-        /// Gets a value indicating whether the element is enabled.
-        /// </summary>
-        public bool IsEnabled => this.Element.Enabled;
-
-        /// <summary>
         /// Determines whether the specified element is shown with the specified timeout.
         /// </summary>
         /// <param name="locator">The locator to find a specific element.</param>

--- a/src/Legerity.Windows/Extensions/AttributeExtensions.cs
+++ b/src/Legerity.Windows/Extensions/AttributeExtensions.cs
@@ -1,5 +1,7 @@
 namespace Legerity.Windows.Extensions
 {
+    using System;
+    using Legerity.Windows.Elements.Core;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
 
@@ -30,6 +32,228 @@ namespace Legerity.Windows.Extensions
             where TElement : IWebElement
         {
             return GetAutomationId(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the Value.Value attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve a value from.</param>
+        /// <returns>The value of the element.</returns>
+        public static string GetValue(this IWebElement element)
+        {
+            return element.GetAttribute("Value.Value");
+        }
+
+        /// <summary>
+        /// Retrieves the Value.Value attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a value from.</param>
+        /// <returns>The value of the element.</returns>
+        public static string GetValue<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetValue(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the Value.IsReadonly attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the readonly state from.</param>
+        /// <returns>A value indicating whether the item is readonly.</returns>
+        public static bool IsReadonly(this IWebElement element)
+        {
+            return element.GetAttribute("Value.IsReadonly").Equals("True", StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Retrieves the Value.IsReadonly attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the readonly state from.</param>
+        /// <returns>A value indicating whether the item is readonly.</returns>
+        public static bool IsReadonly<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return IsReadonly(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the Toggle.ToggleState attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve a toggle state from.</param>
+        /// <returns>The <see cref="ToggleState"/> of the element.</returns>
+        public static ToggleState GetToggleState(this IWebElement element)
+        {
+            return element.GetAttribute("Toggle.ToggleState") switch
+            {
+                "1" => ToggleState.Checked,
+                "2" => ToggleState.Indeterminate,
+                _ => ToggleState.Unchecked
+            };
+        }
+
+        /// <summary>
+        /// Retrieves the Toggle.ToggleState attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve a toggle state from.</param>
+        /// <returns>The <see cref="ToggleState"/> of the element.</returns>
+        public static ToggleState GetToggleState<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetToggleState(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the SelectionItem.IsSelected attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the selected state from.</param>
+        /// <returns>A value indicating whether the item is selected.</returns>
+        public static bool IsSelected(this IWebElement element)
+        {
+            return element.GetAttribute("SelectionItem.IsSelected")
+                .Equals("True", StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Retrieves the SelectionItem.IsSelected attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the selected state from.</param>
+        /// <returns>A value indicating whether the item is selected.</returns>
+        public static bool IsSelected<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return IsSelected(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.Value attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the range value from.</param>
+        /// <returns>The range value of the element.</returns>
+        public static double GetRangeValue(this IWebElement element)
+        {
+            return double.Parse(element.GetAttribute("RangeValue.Value"));
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.Value attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the range value from.</param>
+        /// <returns>The range value of the element.</returns>
+        public static double GetRangeValue<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetRangeValue(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.Maximum attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the range max value from.</param>
+        /// <returns>The range max value of the element.</returns>
+        public static double GetRangeMaximum(this IWebElement element)
+        {
+            return double.Parse(element.GetAttribute("RangeValue.Maximum"));
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.Maximum attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the range max value from.</param>
+        /// <returns>The range max value of the element.</returns>
+        public static double GetRangeMaximum<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetRangeMaximum(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.Minimum attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the range min value from.</param>
+        /// <returns>The range min value of the element.</returns>
+        public static double GetRangeMinimum(this IWebElement element)
+        {
+            return double.Parse(element.GetAttribute("RangeValue.Minimum"));
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.Minimum attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the range min value from.</param>
+        /// <returns>The range min value of the element.</returns>
+        public static double GetRangeMinimum<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetRangeMinimum(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.SmallChange attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the range step value from.</param>
+        /// <returns>The range step value of the element.</returns>
+        public static double GetRangeSmallChange(this IWebElement element)
+        {
+            return double.Parse(element.GetAttribute("RangeValue.SmallChange"));
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.SmallChange attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the range step value from.</param>
+        /// <returns>The range step value of the element.</returns>
+        public static double GetRangeSmallChange<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return GetRangeSmallChange(element.Element);
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.IsReadOnly attribute from the specified element.
+        /// </summary>
+        /// <param name="element">The <see cref="IWebElement"/> to retrieve the readonly state from.</param>
+        /// <returns>A value indicating whether the item is readonly.</returns>
+        public static bool IsRangeReadonly(this IWebElement element)
+        {
+            return bool.Parse(element.GetAttribute("RangeValue.IsReadOnly"));
+        }
+
+        /// <summary>
+        /// Retrieves the RangeValue.IsReadOnly attribute from the specified element.
+        /// </summary>
+        /// <typeparam name="TElement">
+        /// The type of <see cref="RemoteWebElement"/>.
+        /// </typeparam>
+        /// <param name="element">The <see cref="IElementWrapper{TElement}"/> to retrieve the readonly state from.</param>
+        /// <returns>A value indicating whether the item is readonly.</returns>
+        public static bool IsRangeReadonly<TElement>(this IElementWrapper<TElement> element)
+            where TElement : IWebElement
+        {
+            return IsRangeReadonly(element.Element);
         }
     }
 }

--- a/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Extensions
 {
     using System;
+    using System.Globalization;
     using Legerity.Extensions;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
@@ -20,7 +21,9 @@ namespace Legerity.Windows.Extensions
         /// <param name="driver">The <see cref="WindowsDriver{TElement}"/> to search.</param>
         /// <param name="automationId">The automation ID associated with the element to locate.</param>
         /// <returns>The located <typeparamref name="TElement"/>.</returns>
-        public static TElement FindElementByAutomationId<TElement>(this WindowsDriver<TElement> driver, string automationId)
+        public static TElement FindElementByAutomationId<TElement>(
+            this WindowsDriver<TElement> driver,
+            string automationId)
             where TElement : IWebElement
         {
             return driver.FindElement(WindowsByExtras.AutomationId(automationId));
@@ -55,9 +58,9 @@ namespace Legerity.Windows.Extensions
             string automationId = element.GetAutomationId();
 
             return string.Equals(compare, name, StringComparison.CurrentCultureIgnoreCase) || string.Equals(
-                       compare,
-                       automationId,
-                       StringComparison.CurrentCultureIgnoreCase);
+                compare,
+                automationId,
+                StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>
@@ -78,9 +81,43 @@ namespace Legerity.Windows.Extensions
             string automationId = element.GetAutomationId();
 
             return string.Equals(compare, name, StringComparison.CurrentCultureIgnoreCase) || string.Equals(
-                       compare,
-                       automationId,
-                       StringComparison.CurrentCultureIgnoreCase);
+                compare,
+                automationId,
+                StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Verifies the elements name or AutomationId based on the given partial compare.
+        /// </summary>
+        /// <param name="element">
+        /// The element to verify.
+        /// </param>
+        /// <param name="partialCompare">The partial value to verify is the name or AutomationId.</param>
+        /// <returns>
+        /// True if the element's name or AutomationId matches; otherwise, false.
+        /// </returns>
+        public static bool VerifyNameOrAutomationIdContains(this AppiumWebElement element, string partialCompare)
+        {
+            string name = element.GetName();
+            string automationId = element.GetAutomationId();
+
+            return partialCompare.Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase) ||
+                   partialCompare.Contains(automationId, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+        }
+
+        /// <summary>
+        /// Verifies the elements name or AutomationId based on the given partial compare.
+        /// </summary>
+        /// <param name="element">The element to verify.</param>
+        /// <param name="partialCompare">The partial value to verify is the name or AutomationId.</param>
+        /// <returns>True if the element's name or AutomationId partially matches; otherwise, false.</returns>
+        public static bool VerifyNameOrAutomationIdContains(this WindowsElement element, string partialCompare)
+        {
+            string name = element.GetName();
+            string automationId = element.GetAutomationId();
+
+            return partialCompare.Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase) ||
+                   partialCompare.Contains(automationId, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to introduce partial name matching for element selection methods such as the `ComboBox.SelectItem(name)` method. 

Their equivalent, for example `ComboBox.SelectItemByPartialName(name)` methods will allow tests to search for elements by a part of the detail within the name for better filtering capability.

The change also includes moving core properties from the platform specific element wrappers into the base element wrapper. And changes to introduce new By locator extras, and custom attributes for retrieving data from platform specific elements.

## PR checklist

- [x] Sample tests have been added/updated and pass
- [x] [Documentation](/docs) has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
