### PR TITLE
Added new Web Authentication library with Azure AD page object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 [![Legerity docs](https://img.shields.io/badge/docs-Legerity-blue.svg)](https://made-apps.github.io/legerity/)
 [![Legerity discussions](https://img.shields.io/badge/discuss-Legerity-blue.svg)](https://github.com/MADE-Apps/legerity/discussions)
 
-Legerity is an automated UI testing framework for building maintainable tests quickly for Windows, Android, iOS, and Web applications with C#/.NET. 
+Legerity is an automated UI testing framework for building maintainable tests quickly for Windows, Android, iOS, and Web applications with C#/.NET.
 
 It simplifies the development by providing easy-to-use element wrappers for native app controls that allow developers to quickly get up and running with UI tests in no time.
 
@@ -59,7 +59,7 @@ Our documentation includes usages examples, as well as API documentation for you
 
 ## Installation 💾
 
-Legerity is publicly available via NuGet. Each available package is detailed below. 
+Legerity is publicly available via NuGet. Each available package is detailed below.
 
 For non-core platform controls, for example, WinUI or the Windows Community Toolkit, we're providing additional extension packages for you to take advantage of within your test projects.
 
@@ -71,6 +71,7 @@ For non-core platform controls, for example, WinUI or the Windows Community Tool
 | [![Nuget](https://img.shields.io/nuget/v/Legerity.Android.svg?label=Legerity.Android)](https://www.nuget.org/packages/Legerity.Android/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.Android.svg)](https://www.nuget.org/packages/Legerity.Android) |
 | [![Nuget](https://img.shields.io/nuget/v/Legerity.IOS.svg?label=Legerity.IOS)](https://www.nuget.org/packages/Legerity.IOS/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.IOS.svg)](https://www.nuget.org/packages/Legerity.IOS) |
 | [![Nuget](https://img.shields.io/nuget/v/Legerity.Web.svg?label=Legerity.Web)](https://www.nuget.org/packages/Legerity.Web/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.Web.svg)](https://www.nuget.org/packages/Legerity.Web) |
+| [![Nuget](https://img.shields.io/nuget/v/Legerity.Web.Authentication.svg?label=Legerity.Web.Authentication)](https://www.nuget.org/packages/Legerity.Web.Authentication/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.Web.Authentication.svg)](https://www.nuget.org/packages/Legerity.Web.Authentication) |
 | [![Nuget](https://img.shields.io/nuget/v/Legerity.MADE.svg?label=Legerity.MADE)](https://www.nuget.org/packages/Legerity.MADE/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.MADE.svg)](https://www.nuget.org/packages/Legerity.MADE) |
 | [![Nuget](https://img.shields.io/nuget/v/Legerity.Telerik.Uwp.svg?label=Legerity.Telerik.Uwp)](https://www.nuget.org/packages/Legerity.Telerik.Uwp/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.Telerik.Uwp.svg)](https://www.nuget.org/packages/Legerity.Telerik.Uwp) |
 | [![Nuget](https://img.shields.io/nuget/v/Legerity.WCT.svg?label=Legerity.WCT)](https://www.nuget.org/packages/Legerity.WCT/) | [![NuGet Downloads](https://img.shields.io/nuget/dt/Legerity.WCT.svg)](https://www.nuget.org/packages/Legerity.WCT) |
@@ -78,7 +79,7 @@ For non-core platform controls, for example, WinUI or the Windows Community Tool
 
 ## Support Legerity 💗
 
-As many developers know, projects like Legerity are built and maintained in spare time. If you find this project useful, please **Star** the repo and if possible, sponsor the project development on GitHub. 
+As many developers know, projects like Legerity are built and maintained in spare time. If you find this project useful, please **Star** the repo and if possible, sponsor the project development on GitHub.
 
 ## Contributing 🚀
 
@@ -110,7 +111,7 @@ Even better, why not help build out your custom control wrapper elements within 
 
 When contributing to new element wrappers, we recommended using the [Accessibility Insights tool](https://accessibilityinsights.io/en/). The tool is capable of inspecting and providing property values for Android, Web, and Windows applications.
 
-Alternatively, you can use the [Inspect.exe tool](https://docs.microsoft.com/en-us/windows/win32/winauto/inspect-objects) for Windows applications installed with the Windows SDKs. This is not recommended as the tool is considered legacy and can often cause oddities in UI when using. 
+Alternatively, you can use the [Inspect.exe tool](https://docs.microsoft.com/en-us/windows/win32/winauto/inspect-objects) for Windows applications installed with the Windows SDKs. This is not recommended as the tool is considered legacy and can often cause oddities in UI when using.
 
 ## License
 

--- a/docs/articles/available-packages.md
+++ b/docs/articles/available-packages.md
@@ -17,6 +17,7 @@ For non-core platform controls, for example, the Windows Community Toolkit, we p
 | Legerity.Android | [![Nuget](https://img.shields.io/nuget/v/Legerity.Android.svg)](https://www.nuget.org/packages/Legerity.Android/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.Android.svg)](https://www.nuget.org/packages/Legerity.Android/) |
 | Legerity.IOS | [![Nuget](https://img.shields.io/nuget/v/Legerity.IOS.svg)](https://www.nuget.org/packages/Legerity.IOS/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.IOS.svg)](https://www.nuget.org/packages/Legerity.IOS/) |
 | Legerity.Web | [![Nuget](https://img.shields.io/nuget/v/Legerity.Web.svg)](https://www.nuget.org/packages/Legerity.Web/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.Web.svg)](https://www.nuget.org/packages/Legerity.Web/) |
+| Legerity.Web.Authentication | [![Nuget](https://img.shields.io/nuget/v/Legerity.Web.Authentication.svg)](https://www.nuget.org/packages/Legerity.Web.Authentication/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.Web.Authentication.svg)](https://www.nuget.org/packages/Legerity.Web.Authentication/) |
 | Legerity.MADE | [![Nuget](https://img.shields.io/nuget/v/Legerity.MADE.svg)](https://www.nuget.org/packages/Legerity.MADE/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.MADE.svg)](https://www.nuget.org/packages/Legerity.MADE/) |
 | Legerity.Telerik.Uwp | [![Nuget](https://img.shields.io/nuget/v/Legerity.Telerik.Uwp.svg)](https://www.nuget.org/packages/Legerity.Telerik.Uwp/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.Telerik.Uwp.svg)](https://www.nuget.org/packages/Legerity.Telerik.Uwp/) |
 | Legerity.WCT | [![Nuget](https://img.shields.io/nuget/v/Legerity.WCT.svg)](https://www.nuget.org/packages/Legerity.WCT/) | [![Nuget](https://img.shields.io/nuget/vpre/Legerity.WCT.svg)](https://www.nuget.org/packages/Legerity.WCT/) |
@@ -238,5 +239,15 @@ It includes the base `WebElementWrapper` as well as the following element wrappe
 <span class="button">
 
 [Using the Web package](features/web.md)
+
+</span>
+
+### Web Authentication
+
+The Web Authentication extension package provides the capabilities for common page objects that cover standard web authentication provider flows, such as Azure Active Directory login.
+
+<span class="button">
+
+[Using the Web Authentication package](features/web-authentication.md)
 
 </span>

--- a/docs/articles/features/web-authentication.md
+++ b/docs/articles/features/web-authentication.md
@@ -1,0 +1,12 @@
+---
+uid: web-authentication
+title: Using the Web authentication helpers
+---
+
+# Using the Web authentication helpers
+
+The goal of the Web authentication library is to provide an easy set of standard page objects to interact with common authentication provider flows on the web.
+
+## Available web authentication helpers
+
+- [AzureAdLoginPage](https://github.com/MADE-Apps/legerity/blob/main/src/Legerity.Web.Authentication/Pages/AzureAdLoginPage.cs)

--- a/docs/articles/features/web.md
+++ b/docs/articles/features/web.md
@@ -23,3 +23,9 @@ These Web element wrappers are designed to be used with applications built for t
 - [Select](https://github.com/MADE-Apps/legerity/blob/main/src/Legerity.Web/Elements/Core/Select.cs)
 - [TextArea](https://github.com/MADE-Apps/legerity/blob/main/src/Legerity.Web/Elements/Core/TextArea.cs)
 - [TextInput](https://github.com/MADE-Apps/legerity/blob/main/src/Legerity.Web/Elements/Core/TextInput.cs)
+
+## Additional Web library packages
+
+As well as the core Web element wrappers for out-of-the-box SDK controls, Legerity provides the following additional packages which can be used with UI test projects for web applications.
+
+- [Web Authentication page objects](web-authentication.md)

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -36,3 +36,5 @@
       items:
         - name: Overview
           href: features/web.md
+        - name: Authentication Helpers
+          href: features/web-authentication.md

--- a/samples/AndroidCoreSamples/AndroidCoreSamples.csproj
+++ b/samples/AndroidCoreSamples/AndroidCoreSamples.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/samples/MADESampleApp/MADESampleApp.csproj
+++ b/samples/MADESampleApp/MADESampleApp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/samples/TelerikUwpSdkSample/TelerikUwpSdkSample.csproj
+++ b/samples/TelerikUwpSdkSample/TelerikUwpSdkSample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/samples/W3SchoolsWebTests/W3SchoolsWebTests.csproj
+++ b/samples/W3SchoolsWebTests/W3SchoolsWebTests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="104.0.5112.7900" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="104.0.1293.70" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.5200" />
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="105.0.1343.27" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 

--- a/samples/WebTests/WebTests.csproj
+++ b/samples/WebTests/WebTests.csproj
@@ -8,15 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="104.0.5112.7900" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="104.0.1293.70" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.5200" />
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="105.0.1343.27" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Legerity.Web.Authentication\Legerity.Web.Authentication.csproj" />
     <ProjectReference Include="..\..\src\Legerity\Legerity.csproj" />
   </ItemGroup>
 

--- a/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
+++ b/samples/WindowsAlarmsAndClock/WindowsAlarmsAndClock.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/samples/WindowsCommunityToolkitSampleApp/WindowsCommunityToolkitSampleApp.csproj
+++ b/samples/WindowsCommunityToolkitSampleApp/WindowsCommunityToolkitSampleApp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/samples/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/samples/XamlControlsGallery/XamlControlsGallery.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Shouldly" Version="4.1.0" />

--- a/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
+++ b/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
@@ -18,7 +18,8 @@ namespace Legerity.Android.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
-        public static void TryWaitUntil<TElementWrapper>(
+        /// <returns>Whether the wait was a success.</returns>
+        public static bool TryWaitUntil<TElementWrapper>(
             this TElementWrapper element,
             Func<TElementWrapper, bool> condition,
             TimeSpan? timeout = default,
@@ -32,7 +33,10 @@ namespace Legerity.Android.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return false;
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
+++ b/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
@@ -11,13 +11,41 @@ namespace Legerity.Android.Extensions
     public static class AndroidElementWrapperExtensions
     {
         /// <summary>
+        /// Attempts to wait until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
+        public static void TryWaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default,
+            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+            where TElementWrapper : AndroidElementWrapper
+        {
+            try
+            {
+                WaitUntil(element, condition, timeout);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
+        }
+
+        /// <summary>
         /// Waits until a specified element condition is met, with an optional timeout.
         /// </summary>
         /// <param name="element">The element to wait on.</param>
         /// <param name="condition">The condition of the element to wait on.</param>
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+        public static void WaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default)
             where TElementWrapper : AndroidElementWrapper
         {
             new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>

--- a/src/Legerity.Core/Extensions/DriverExtensions.cs
+++ b/src/Legerity.Core/Extensions/DriverExtensions.cs
@@ -73,7 +73,9 @@ namespace Legerity.Extensions
         /// <param name="driver">The remote web driver.</param>
         /// <param name="text">The partial text to find.</param>
         /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText(this RemoteWebDriver driver, string text)
+        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText(
+            this RemoteWebDriver driver,
+            string text)
         {
             return driver.FindElements(ByExtras.PartialText(text));
         }
@@ -99,6 +101,32 @@ namespace Legerity.Extensions
         }
 
         /// <summary>
+        /// Attempts to wait until a specified driver condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="appDriver">The driver to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+        public static void TryWaitUntil(
+            this IWebDriver appDriver,
+            Func<IWebDriver, bool> condition,
+            TimeSpan? timeout = default,
+            int retries = 0,
+            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+        {
+            try
+            {
+                WaitUntil(appDriver, condition, timeout, retries);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
+        }
+
+        /// <summary>
         /// Waits until a specified driver condition is met, with an optional timeout.
         /// </summary>
         /// <param name="appDriver">The driver to wait on.</param>
@@ -106,7 +134,11 @@ namespace Legerity.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
         /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
-        public static void WaitUntil(this IWebDriver appDriver, Func<IWebDriver, bool> condition, TimeSpan? timeout = default, int retries = 0)
+        public static void WaitUntil(
+            this IWebDriver appDriver,
+            Func<IWebDriver, bool> condition,
+            TimeSpan? timeout = default,
+            int retries = 0)
         {
             try
             {

--- a/src/Legerity.Core/Extensions/DriverExtensions.cs
+++ b/src/Legerity.Core/Extensions/DriverExtensions.cs
@@ -109,7 +109,8 @@ namespace Legerity.Extensions
         /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
-        public static void TryWaitUntil(
+        /// <returns>Whether the wait was a success.</returns>
+        public static bool TryWaitUntil(
             this IWebDriver appDriver,
             Func<IWebDriver, bool> condition,
             TimeSpan? timeout = default,
@@ -123,7 +124,10 @@ namespace Legerity.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return false;
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
@@ -50,7 +50,8 @@ namespace Legerity.Extensions
         /// <param name="element">The remote web element.</param>
         /// <param name="locator">The locator to find the elements.</param>
         /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public static ReadOnlyCollection<RemoteWebElement> FindWebElements<TElement>(this IElementWrapper<TElement> element, By locator)
+        public static ReadOnlyCollection<RemoteWebElement> FindWebElements<TElement>(
+            this IElementWrapper<TElement> element, By locator)
             where TElement : IWebElement
         {
             return element.Element.FindWebElements(locator);
@@ -80,7 +81,8 @@ namespace Legerity.Extensions
         /// <param name="element">The remote web element.</param>
         /// <param name="text">The text to find.</param>
         /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByText<TElement>(this IElementWrapper<TElement> element, string text)
+        public static ReadOnlyCollection<IWebElement> FindElementsByText<TElement>(
+            this IElementWrapper<TElement> element, string text)
             where TElement : IWebElement
         {
             return element.Element.FindElementsByText(text);
@@ -95,7 +97,9 @@ namespace Legerity.Extensions
         /// <param name="element">The remote web element.</param>
         /// <param name="text">The partial text to find.</param>
         /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByPartialText<TElement>(this IElementWrapper<TElement> element, string text)
+        public static IWebElement FindElementByPartialText<TElement>(
+            this IElementWrapper<TElement> element,
+            string text)
             where TElement : IWebElement
         {
             return element.Element.FindElementByPartialText(text);
@@ -110,7 +114,8 @@ namespace Legerity.Extensions
         /// <param name="element">The remote web element.</param>
         /// <param name="text">The partial text to find.</param>
         /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText<TElement>(this IElementWrapper<TElement> element, string text)
+        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText<TElement>(
+            this IElementWrapper<TElement> element, string text)
             where TElement : IWebElement
         {
             return element.Element.FindElementsByPartialText(text);
@@ -124,10 +129,36 @@ namespace Legerity.Extensions
         /// </typeparam>
         /// <param name="element">The remote web driver.</param>
         /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> GetAllChildElements<TElement>(this IElementWrapper<TElement> element)
+        public static ReadOnlyCollection<IWebElement> GetAllChildElements<TElement>(
+            this IElementWrapper<TElement> element)
             where TElement : IWebElement
         {
             return element.Element.GetAllChildElements();
+        }
+
+        /// <summary>
+        /// Attempts to wait until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+        public static void TryWaitUntil<TElement>(
+            this IElementWrapper<TElement> element,
+            Func<IElementWrapper<TElement>, bool> condition,
+            TimeSpan? timeout = default,
+            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+            where TElement : IWebElement
+        {
+            try
+            {
+                WaitUntil(element, condition, timeout);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
         }
 
         /// <summary>
@@ -137,7 +168,10 @@ namespace Legerity.Extensions
         /// <param name="condition">The condition of the element to wait on.</param>
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        public static void WaitUntil<TElement>(this IElementWrapper<TElement> element, Func<IElementWrapper<TElement>, bool> condition, TimeSpan? timeout = default)
+        public static void WaitUntil<TElement>(
+            this IElementWrapper<TElement> element,
+            Func<IElementWrapper<TElement>, bool> condition,
+            TimeSpan? timeout = default)
             where TElement : IWebElement
         {
             new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>

--- a/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
@@ -144,7 +144,8 @@ namespace Legerity.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        public static void TryWaitUntil<TElement>(
+        /// <returns>Whether the wait was a success.</returns>
+        public static bool TryWaitUntil<TElement>(
             this IElementWrapper<TElement> element,
             Func<IElementWrapper<TElement>, bool> condition,
             TimeSpan? timeout = default,
@@ -158,7 +159,10 @@ namespace Legerity.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return false;
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Legerity.Core/Extensions/PageExtensions.cs
+++ b/src/Legerity.Core/Extensions/PageExtensions.cs
@@ -1,10 +1,8 @@
 namespace Legerity.Extensions
 {
     using System;
-    using System.Collections.ObjectModel;
     using Legerity.Pages;
     using OpenQA.Selenium;
-    using OpenQA.Selenium.Remote;
     using OpenQA.Selenium.Support.UI;
 
     /// <summary>
@@ -12,6 +10,34 @@ namespace Legerity.Extensions
     /// </summary>
     public static class PageExtensions
     {
+        /// <summary>
+        /// Attempts to wait until a specified page condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="page">The page to wait on.</param>
+        /// <param name="condition">The condition of the page to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+        /// <returns>The instance of the page.</returns>
+        public static TPage TryWaitUntil<TPage>(
+            this TPage page,
+            Func<TPage, bool> condition,
+            TimeSpan? timeout = default,
+            Action<Exception> timeoutExceptionHandler = null)
+            where TPage : BasePage
+        {
+            try
+            {
+                WaitUntil(page, condition, timeout);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
+
+            return page;
+        }
+
         /// <summary>
         /// Waits until a specified page condition is met, with an optional timeout.
         /// </summary>

--- a/src/Legerity.Core/Extensions/PageExtensions.cs
+++ b/src/Legerity.Core/Extensions/PageExtensions.cs
@@ -18,8 +18,8 @@ namespace Legerity.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
-        /// <returns>The instance of the page.</returns>
-        public static TPage TryWaitUntil<TPage>(
+        /// <returns>Whether the wait was a success and the instance of the page.</returns>
+        public static (bool success, TPage page) TryWaitUntil<TPage>(
             this TPage page,
             Func<TPage, bool> condition,
             TimeSpan? timeout = default,
@@ -33,9 +33,10 @@ namespace Legerity.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return (false, page);
             }
 
-            return page;
+            return (true, page);
         }
 
         /// <summary>

--- a/src/Legerity.IOS/Extensions/IOSElementWrapperExtensions.cs
+++ b/src/Legerity.IOS/Extensions/IOSElementWrapperExtensions.cs
@@ -18,7 +18,8 @@ namespace Legerity.IOS.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="IOSElementWrapper"/>.</typeparam>
-        public static void TryWaitUntil<TElementWrapper>(
+        /// <returns>Whether the wait was a success.</returns>
+        public static bool TryWaitUntil<TElementWrapper>(
             this TElementWrapper element,
             Func<TElementWrapper, bool> condition,
             TimeSpan? timeout = default,
@@ -32,7 +33,10 @@ namespace Legerity.IOS.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return false;
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Legerity.IOS/Extensions/IOSElementWrapperExtensions.cs
+++ b/src/Legerity.IOS/Extensions/IOSElementWrapperExtensions.cs
@@ -11,13 +11,41 @@ namespace Legerity.IOS.Extensions
     public static class IOSElementWrapperExtensions
     {
         /// <summary>
+        /// Attempts to wait until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="IOSElementWrapper"/>.</typeparam>
+        public static void TryWaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default,
+            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+            where TElementWrapper : IOSElementWrapper
+        {
+            try
+            {
+                WaitUntil(element, condition, timeout);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
+        }
+
+        /// <summary>
         /// Waits until a specified element condition is met, with an optional timeout.
         /// </summary>
         /// <param name="element">The element to wait on.</param>
         /// <param name="condition">The condition of the element to wait on.</param>
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="IOSElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+        public static void WaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default)
             where TElementWrapper : IOSElementWrapper
         {
             new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>

--- a/src/Legerity.Web.Authentication/Legerity.Web.Authentication.csproj
+++ b/src/Legerity.Web.Authentication/Legerity.Web.Authentication.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Product>Legerity for Web Authentication - Framework for UI testing with Selenium/Appium</Product>
+    <Description>
+      An extension to the Legerity UI testing framework to support authenticating with common web identity providers.
+    </Description>
+    <PackageTags>AzureAD Appium Selenium ChromeDriver FirefoxDriver OperaDriver SafariDriver EdgeDriver InternetExplorerDriver RemoteWebDriver Web</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Legerity.Web\Legerity.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Legerity.Web.Authentication/Pages/AzureAdLoginPage.cs
+++ b/src/Legerity.Web.Authentication/Pages/AzureAdLoginPage.cs
@@ -1,0 +1,130 @@
+namespace Legerity.Web.Authentication.Pages
+{
+    using System;
+    using Legerity.Extensions;
+    using Legerity.Pages;
+    using Legerity.Web.Elements.Core;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// Defines a page object for the Azure Active Directory login page.
+    /// </summary>
+    public class AzureAdLoginPage : BasePage
+    {
+        /// <summary>
+        /// The expected title of the Azure AD login page.
+        /// </summary>
+        public const string Title = "Sign in to your account";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAdLoginPage"/> class using the <see cref="AppManager.App"/> instance that verifies the page has loaded within 2 seconds.
+        /// </summary>
+        public AzureAdLoginPage()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAdLoginPage"/> class using a <see cref="RemoteWebDriver"/> instance that verifies the page has loaded within 2 seconds.
+        /// </summary>
+        /// <param name="app">
+        /// The instance of the started application driver that will be used to drive the page interaction.
+        /// </param>
+        /// <exception cref="T:Legerity.Exceptions.DriverNotInitializedException">Thrown if AppManager.StartApp() has not been called.</exception>
+        /// <exception cref="T:Legerity.Exceptions.PageNotShownException">Thrown if the page is not shown in 2 seconds.</exception>
+        public AzureAdLoginPage(RemoteWebDriver app)
+            : base(app)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAdLoginPage"/> class using the <see cref="AppManager.App"/> instance that verifies the page has loaded within the given timeout.
+        /// </summary>
+        /// <param name="traitTimeout">
+        /// The amount of time the driver should wait when searching for the <see cref="Trait"/> if it is not immediately present.
+        /// </param>
+        /// <exception cref="T:Legerity.Exceptions.DriverNotInitializedException">Thrown if AppManager.StartApp() has not been called.</exception>
+        /// <exception cref="T:Legerity.Exceptions.PageNotShownException">Thrown if the page is not shown in the given timeout.</exception>
+        public AzureAdLoginPage(TimeSpan? traitTimeout)
+            : base(traitTimeout)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAdLoginPage"/> class using a <see cref="RemoteWebDriver"/> instance that verifies the page has loaded within the given timeout.
+        /// </summary>
+        /// <param name="app">
+        /// The instance of the started application driver that will be used to drive the page interaction.
+        /// </param>
+        /// <param name="traitTimeout">
+        /// The amount of time the driver should wait when searching for the <see cref="Trait"/> if it is not immediately present.
+        /// </param>
+        /// <exception cref="T:Legerity.Exceptions.DriverNotInitializedException">Thrown if AppManager.StartApp() has not been called.</exception>
+        /// <exception cref="T:Legerity.Exceptions.PageNotShownException">Thrown if the page is not shown in the given timeout.</exception>
+        public AzureAdLoginPage(RemoteWebDriver app, TimeSpan? traitTimeout)
+            : base(app, traitTimeout)
+        {
+        }
+
+        /// <summary>
+        /// Gets the input element for providing an email address.
+        /// </summary>
+        public virtual TextInput EmailInput => this.App.FindWebElement(WebByExtras.InputType("email"));
+
+        /// <summary>
+        /// Gets the input element for providing a password.
+        /// </summary>
+        public virtual TextInput PasswordInput => this.App.FindWebElement(WebByExtras.InputType("password"));
+
+        /// <summary>
+        /// Gets the button element for continuing the sign-in flow through the Azure AD login UI.
+        /// </summary>
+        public virtual Button SignInButton => this.App.FindWebElement(By.Id("idSIButton9"));
+
+        /// <summary>
+        /// Gets the optional "Use Password" button that appears when password-less authentication is enabled.
+        /// </summary>
+        public virtual Button UsePasswordButton => this.App.FindWebElement(By.Id("idA_PWD_SwitchToPassword"));
+
+        /// <summary>
+        /// Gets a given trait of the page to verify that the page is in view.
+        /// </summary>
+        protected override By Trait => By.ClassName("login-paginated-page");
+
+        /// <summary>
+        /// Login an Azure Active Directory user by email and password.
+        /// </summary>
+        /// <param name="email">The email address to authenticate with.</param>
+        /// <param name="password">The password associated with the email address to authenticate with.</param>
+        /// <returns>The <see cref="AzureAdLoginPage"/> instance.</returns>
+        public AzureAdLoginPage Login(string email, string password)
+        {
+            (bool hasEmailInput, AzureAdLoginPage _) =
+                this.TryWaitUntil(page => page.EmailInput.IsVisible, this.WaitTimeout);
+            if (!hasEmailInput)
+            {
+                // Cannot login as email address input not shown (possibly logged in already?)
+                return this;
+            }
+
+            this.EmailInput.SetText(email);
+
+            // Azure AD login uses a 2-step process for email and password.
+            this.SignInButton.Click();
+
+            // Check to ensure that the user is not authenticating with password-less authentication.
+            (bool isNotPasswordLogin, AzureAdLoginPage _) =
+                this.TryWaitUntil(page => page.UsePasswordButton.IsVisible, this.WaitTimeout);
+            if (isNotPasswordLogin)
+            {
+                this.UsePasswordButton.Click();
+                this.TryWaitUntil(page => page.PasswordInput.IsVisible, this.WaitTimeout);
+            }
+
+            this.PasswordInput.SetText(password);
+            this.SignInButton.Click();
+
+            return this;
+        }
+    }
+}

--- a/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
+++ b/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
@@ -18,7 +18,8 @@ namespace Legerity.Web.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
-        public static void TryWaitUntil<TElementWrapper>(
+        /// <returns>Whether the wait was a success.</returns>
+        public static bool TryWaitUntil<TElementWrapper>(
             this TElementWrapper element,
             Func<TElementWrapper, bool> condition,
             TimeSpan? timeout = default,
@@ -32,7 +33,10 @@ namespace Legerity.Web.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return false;
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
+++ b/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
@@ -11,13 +11,41 @@ namespace Legerity.Web.Extensions
     public static class WebElementWrapperExtensions
     {
         /// <summary>
+        /// Attempts to wait until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
+        public static void TryWaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default,
+            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+            where TElementWrapper : WebElementWrapper
+        {
+            try
+            {
+                WaitUntil(element, condition, timeout);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
+        }
+
+        /// <summary>
         /// Waits until a specified element condition is met, with an optional timeout.
         /// </summary>
         /// <param name="element">The element to wait on.</param>
         /// <param name="condition">The condition of the element to wait on.</param>
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+        public static void WaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default)
             where TElementWrapper : WebElementWrapper
         {
             new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>

--- a/src/Legerity.Web/WebByExtras.cs
+++ b/src/Legerity.Web/WebByExtras.cs
@@ -8,6 +8,16 @@ namespace Legerity.Web
     public static class WebByExtras
     {
         /// <summary>
+        /// Gets a mechanism to find elements by the HTML input tag with a specified type.
+        /// </summary>
+        /// <param name="inputType">The input type to find.</param>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By InputType(string inputType)
+        {
+            return By.XPath($"//input[@type='{inputType}']");
+        }
+
+        /// <summary>
         /// Gets a mechanism to find elements by the HTML li tag.
         /// </summary>
         /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>

--- a/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
@@ -18,7 +18,8 @@ namespace Legerity.Windows.Extensions
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
-        public static void TryWaitUntil<TElementWrapper>(
+        /// <returns>Whether the wait was a success.</returns>
+        public static bool TryWaitUntil<TElementWrapper>(
             this TElementWrapper element,
             Func<TElementWrapper, bool> condition,
             TimeSpan? timeout = default,
@@ -32,7 +33,10 @@ namespace Legerity.Windows.Extensions
             catch (WebDriverTimeoutException ex)
             {
                 timeoutExceptionHandler?.Invoke(ex);
+                return false;
             }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
@@ -11,13 +11,41 @@ namespace Legerity.Windows.Extensions
     public static class WindowsElementWrapperExtensions
     {
         /// <summary>
+        /// Attempts to wait until a specified element condition is met, with an optional timeout.
+        /// </summary>
+        /// <param name="element">The element to wait on.</param>
+        /// <param name="condition">The condition of the element to wait on.</param>
+        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+        /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
+        public static void TryWaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default,
+            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+            where TElementWrapper : WindowsElementWrapper
+        {
+            try
+            {
+                WaitUntil(element, condition, timeout);
+            }
+            catch (WebDriverTimeoutException ex)
+            {
+                timeoutExceptionHandler?.Invoke(ex);
+            }
+        }
+
+        /// <summary>
         /// Waits until a specified element condition is met, with an optional timeout.
         /// </summary>
         /// <param name="element">The element to wait on.</param>
         /// <param name="condition">The condition of the element to wait on.</param>
         /// <param name="timeout">The optional timeout wait on the condition being true.</param>
         /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(this TElementWrapper element, Func<TElementWrapper, bool> condition, TimeSpan? timeout = default)
+        public static void WaitUntil<TElementWrapper>(
+            this TElementWrapper element,
+            Func<TElementWrapper, bool> condition,
+            TimeSpan? timeout = default)
             where TElementWrapper : WindowsElementWrapper
         {
             new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>

--- a/src/Legerity.sln
+++ b/src/Legerity.sln
@@ -65,6 +65,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{9064E354
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Legerity.PageObjectGenerator", "..\tools\Legerity.PageObjectGenerator\Legerity.PageObjectGenerator.csproj", "{063E6264-F623-4469-BADF-95C8E93E3ACF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Legerity.Web.Authentication", "Legerity.Web.Authentication\Legerity.Web.Authentication.csproj", "{F6CCE4EA-9C7D-4DD0-BD6B-0B5C70EE9175}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,10 @@ Global
 		{063E6264-F623-4469-BADF-95C8E93E3ACF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{063E6264-F623-4469-BADF-95C8E93E3ACF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{063E6264-F623-4469-BADF-95C8E93E3ACF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6CCE4EA-9C7D-4DD0-BD6B-0B5C70EE9175}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6CCE4EA-9C7D-4DD0-BD6B-0B5C70EE9175}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6CCE4EA-9C7D-4DD0-BD6B-0B5C70EE9175}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6CCE4EA-9C7D-4DD0-BD6B-0B5C70EE9175}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/Legerity.PageObjectGenerator/Legerity.PageObjectGenerator.csproj
+++ b/tools/Legerity.PageObjectGenerator/Legerity.PageObjectGenerator.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
     <PackageReference Include="Scriban" Version="5.5.0" />
     <PackageReference Include="Serilog" Version="2.11.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Resolves #
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Added a new Web Authentication library to provide page object support for common web authentication providers.

Includes an initial page object for authenticating with Azure Active Directory.

This change also includes new `TryWaitUntil` extension methods to allow a wait to be attempted where the timeout exception is handled.

## PR checklist

- [ ] Have Legerity sample tests been added or updated, run locally, and all pass
- [ ] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [x] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->