### PR TITLE
🐛 Fix for issue where app driver is not quit when exception thrown in startup

### DIFF
--- a/src/Legerity.Core/Exceptions/DriverLoadFailedException.cs
+++ b/src/Legerity.Core/Exceptions/DriverLoadFailedException.cs
@@ -1,5 +1,7 @@
 namespace Legerity.Exceptions
 {
+    using System;
+
     /// <summary>
     /// Defines an exception thrown if the Appium driver fails to load the requested application.
     /// </summary>
@@ -13,6 +15,19 @@ namespace Legerity.Exceptions
         /// </param>
         internal DriverLoadFailedException(AppManagerOptions opts)
             : base($"The application driver could not be initialized with the specified app manager options. {opts}")
+        {
+            this.AppManagerOptions = opts;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DriverLoadFailedException"/> class.
+        /// </summary>
+        /// <param name="opts">
+        /// The app manager options used to initialize the driver.
+        /// </param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        internal DriverLoadFailedException(AppManagerOptions opts, Exception innerException)
+            : base($"The application driver could not be initialized with the specified app manager options. {opts}", innerException)
         {
             this.AppManagerOptions = opts;
         }


### PR DESCRIPTION
## Resolves #191
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

A change has been made to ensure that if an exception is thrown when the `StartApp` method is called on the `AppManager` that the app, if started, is quit to ensure that test execution can continue.

This change also ensures that the exception is bubbled up, wrapped in a `DriverLoadFailedException`.

## PR checklist

- [x] Have Legerity sample tests been added or updated, run locally, and all pass
- [ ] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [ ] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->