### PR TITLE
Added speed improvement to retrieving web `Table` data rows

### DIFF
--- a/src/Legerity.Web/Elements/Core/Table.cs
+++ b/src/Legerity.Web/Elements/Core/Table.cs
@@ -51,7 +51,8 @@ namespace Legerity.Web.Elements.Core
         /// <summary>
         /// Gets the collection of rows associated with the table only containing the data values (not headers).
         /// </summary>
-        public virtual IEnumerable<TableRow> DataRows => this.Rows.Where(x => x.FindElements(WebByExtras.TableHeaderCell()).Count == 0);
+        public virtual IEnumerable<TableRow> DataRows =>
+            this.Element.FindElements(WebByExtras.TableDataRow()).Select(e => new TableRow(e));
 
         /// <summary>
         /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Table"/> without direct casting.

--- a/src/Legerity.Web/WebByExtras.cs
+++ b/src/Legerity.Web/WebByExtras.cs
@@ -52,5 +52,14 @@ namespace Legerity.Web
         {
             return By.TagName("tr");
         }
+
+        /// <summary>
+        /// Gets a mechanism to find table row elements where a HTML tr tag has HTML td elements within it.
+        /// </summary>
+        /// <returns>A <see cref="By"/> object the driver can use to find elements.</returns>
+        public static By TableDataRow()
+        {
+            return By.XPath("//tr[td]");
+        }
     }
 }


### PR DESCRIPTION
## Resolves #194 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to introduce a new By locator for retrieving table data rows based on whether a `tr` element is located which contains `td` elements.

## PR checklist

- [ ] Have Legerity sample tests been added or updated, run locally, and all pass
- [ ] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [ ] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->