### PR TITLE
Fix for validating name or automation ID of Windows elements contains a value

### DIFF
--- a/src/Legerity.Core/Extensions/StringExtensions.cs
+++ b/src/Legerity.Core/Extensions/StringExtensions.cs
@@ -31,6 +31,11 @@ namespace Legerity.Extensions
             CultureInfo culture,
             CompareOptions compareOption)
         {
+            if (value == null || contains == null)
+            {
+                return false;
+            }
+
             return culture.CompareInfo.IndexOf(value, contains, compareOption) >= 0;
         }
     }

--- a/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementExtensions.cs
@@ -101,8 +101,8 @@ namespace Legerity.Windows.Extensions
             string name = element.GetName();
             string automationId = element.GetAutomationId();
 
-            return partialCompare.Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase) ||
-                   partialCompare.Contains(automationId, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+            return name.Contains(partialCompare, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase) ||
+                   automationId.Contains(partialCompare, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
         }
 
         /// <summary>
@@ -116,8 +116,8 @@ namespace Legerity.Windows.Extensions
             string name = element.GetName();
             string automationId = element.GetAutomationId();
 
-            return partialCompare.Contains(name, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase) ||
-                   partialCompare.Contains(automationId, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
+            return name.Contains(partialCompare, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase) ||
+                   automationId.Contains(partialCompare, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase);
         }
     }
 }


### PR DESCRIPTION
## Resolves #201 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to the `VerifyNameOrAutomationIdContains` method to ensure that the comparison for partial match on an element's name or Automation ID is validated correctly.

## PR checklist

- [ ] Have Legerity sample tests been added or updated, run locally, and all pass
- [ ] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [ ] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->