### PR TITLE
Add DateInput web element wrapper

### DIFF
--- a/src/Legerity.Web/Elements/Core/DateInput.cs
+++ b/src/Legerity.Web/Elements/Core/DateInput.cs
@@ -1,0 +1,78 @@
+namespace Legerity.Web.Elements.Core;
+
+using System;
+using Extensions;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.Extensions;
+
+/// <summary>
+/// Defines a <see cref="IWebElement"/> wrapper for the core web Input date control.
+/// </summary>
+public class DateInput : TextInput
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateInput"/> class.
+    /// </summary>
+    /// <param name="element">
+    /// The <see cref="IWebElement"/> reference.
+    /// </param>
+    public DateInput(IWebElement element)
+        : this(element as RemoteWebElement)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateInput"/> class.
+    /// </summary>
+    /// <param name="element">
+    /// The <see cref="RemoteWebElement"/> reference.
+    /// </param>
+    public DateInput(RemoteWebElement element)
+        : base(element)
+    {
+    }
+
+    /// <summary>
+    /// Gets the value of the date picker.
+    /// </summary>
+    public virtual string Value => this.GetValue();
+
+    /// <summary>
+    /// Gets the value of the date picker as a <see cref="DateTime"/>.
+    /// </summary>
+    public virtual DateTime? SelectedDate => this.GetSelectedDate();
+
+    /// <summary>
+    /// Allows conversion of a <see cref="RemoteWebElement"/> to the <see cref="DateInput"/> without direct casting.
+    /// </summary>
+    /// <param name="element">
+    /// The <see cref="RemoteWebElement"/>.
+    /// </param>
+    /// <returns>
+    /// The <see cref="DateInput"/>.
+    /// </returns>
+    public static implicit operator DateInput(RemoteWebElement element)
+    {
+        return new DateInput(element);
+    }
+
+    /// <summary>
+    /// Sets the date to the specified date.
+    /// </summary>
+    /// <param name="date">The date to set.</param>
+    public virtual void SetDate(DateTime date)
+    {
+        this.ElementDriver.ExecuteJavaScript(
+            "arguments[0].setAttribute('value', arguments[1])",
+            this.Element,
+            date.ToString("yyyy-MM-dd"));
+    }
+
+    private DateTime? GetSelectedDate()
+    {
+        string value = this.Value;
+        return string.IsNullOrEmpty(value) ? default :
+            DateTime.TryParse(value, out DateTime date) ? date : default(DateTime?);
+    }
+}

--- a/tests/Legerity.Web.Tests/Pages/DateInputPage.cs
+++ b/tests/Legerity.Web.Tests/Pages/DateInputPage.cs
@@ -1,0 +1,21 @@
+namespace Legerity.Web.Tests.Pages;
+
+using System;
+using Elements.Core;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+
+internal class DateInputPage : W3SchoolsBasePage
+{
+    public DateInputPage(RemoteWebDriver app) : base(app)
+    {
+    }
+
+    public DateInput DateInput => this.FindElement(By.Id("birthday"));
+
+    public DateInputPage SetBirthdayDate(DateTime date)
+    {
+        this.DateInput.SetDate(date);
+        return this;
+    }
+}

--- a/tests/Legerity.Web.Tests/Tests/DateInputTests.cs
+++ b/tests/Legerity.Web.Tests/Tests/DateInputTests.cs
@@ -1,0 +1,52 @@
+namespace Legerity.Web.Tests.Tests;
+
+using System.Collections.Generic;
+using System.IO;
+using System;
+using Legerity.Web.Tests.Pages;
+using OpenQA.Selenium.Remote;
+using Shouldly;
+
+[TestFixtureSource(nameof(PlatformOptions))]
+[Parallelizable(ParallelScope.Children)]
+internal class DateInputTests : W3SchoolsBaseTestClass
+{
+    private const string WebApplication = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_date";
+
+    public DateInputTests(AppManagerOptions options)
+        : base(options)
+    {
+    }
+
+    /// <summary>
+    /// Gets the platform options to run tests on.
+    /// </summary>
+    protected static IEnumerable<AppManagerOptions> PlatformOptions => new List<AppManagerOptions>
+    {
+        new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Maximize = true, Url = WebApplication, ImplicitWait = ImplicitWait, DriverOptions = ConfigureChromeOptions()
+        }
+    };
+
+    [Test]
+    public void ShouldSetDate()
+    {
+        // Arrange
+        DateTime expected = DateTime.Now.Date;
+
+        RemoteWebDriver app = this.StartApp();
+
+        DateInputPage dateInputPage = new DateInputPage(app)
+            .AcceptCookies<DateInputPage>()
+            .SwitchToContentFrame<DateInputPage>();
+
+        // Act
+        dateInputPage.SetBirthdayDate(expected);
+
+        // Assert
+        dateInputPage.DateInput.SelectedDate.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
## Resolves #208 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to incorporate a new `DateInput` element wrapper for the web date input type. 

## PR checklist

- [x] Have Legerity sample tests been added or updated, run locally, and all pass
- [x] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [x] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->