### PR TITLE
Add new By locator extras and wait conditions

### DIFF
--- a/docs/articles/using-legerity/by-locators.md
+++ b/docs/articles/using-legerity/by-locators.md
@@ -35,6 +35,9 @@ The `ByNested` locator allows you to find elements that are nested by a sequence
 RemoteWebElement element = app.FindElement(new ByNested(By.Id("PersonContainer"), By.TagName("form"), By.TagName("button")));
 ```
 
+> [!NOTE]
+> The complete nesting does not need to be known, you can provide a subset of the nesting and the locator will find the element if it is nested within the provided locators. For example, you can also find the same button in the above example by providing the `new ByNested(By.Id("PersonContainer"), By.TagName("button"))` locator too.
+
 ## Finding elements by text
 
 The Core package provides `ByExtras.Text` and `ByExtras.PartialText` locators that can be used to find elements on the page by their text content. These can be used across any app platform!

--- a/docs/articles/using-legerity/by-locators.md
+++ b/docs/articles/using-legerity/by-locators.md
@@ -16,6 +16,15 @@ You can find more information about the available locators in the following API 
 - [iOS By locators](xref:Legerity.IOS.IOSByExtras)
 - [Android By locators](xref:Legerity.Android.AndroidByExtras)
 - [Web By locators](xref:Legerity.Web.WebByExtras)
+- [By All locator](xref:Legerity.ByAll)
+
+## Finding elements that match all locators
+
+The `ByAll` locator allows you to find elements that match all of the provided locators. This is useful when you want to find an element that matches multiple criteria, such as a button that has a specific text.
+
+```csharp
+RemoteWebElement element = app.FindElement(new ByAll(By.TagName("button"), ByExtras.Text("Send Message")));
+```
 
 ## Finding elements by text
 

--- a/docs/articles/using-legerity/by-locators.md
+++ b/docs/articles/using-legerity/by-locators.md
@@ -17,6 +17,7 @@ You can find more information about the available locators in the following API 
 - [Android By locators](xref:Legerity.Android.AndroidByExtras)
 - [Web By locators](xref:Legerity.Web.WebByExtras)
 - [By All locator](xref:Legerity.ByAll)
+- [By Nested locator](xref:Legerity.ByNested)
 
 ## Finding elements that match all locators
 
@@ -24,6 +25,14 @@ The `ByAll` locator allows you to find elements that match all of the provided l
 
 ```csharp
 RemoteWebElement element = app.FindElement(new ByAll(By.TagName("button"), ByExtras.Text("Send Message")));
+```
+
+## Finding elements that are nested by sequenced locators
+
+The `ByNested` locator allows you to find elements that are nested by a sequence of locators. This is useful when you want to find an element that is nested within other elements, such as a button that is inside a form, inside an ID'd element.
+
+```csharp
+RemoteWebElement element = app.FindElement(new ByNested(By.Id("PersonContainer"), By.TagName("form"), By.TagName("button")));
 ```
 
 ## Finding elements by text

--- a/docs/articles/using-legerity/wait-conditions.md
+++ b/docs/articles/using-legerity/wait-conditions.md
@@ -134,7 +134,37 @@ You can use the `WaitUntilConditions.ElementExistsInPage` condition to wait for 
 public void ShouldWaitForElementToExistInPage()
 {
     new HomePage(this.App).WaitUntil(
-        WaitUntilConditions.ElementExistsInPage(By.Id("input")),
+        WaitUntilConditions.ElementExistsInPage<HomePage>(By.Id("input")),
+        TimeSpan.FromSeconds(5),
+        3);
+}
+```
+
+### Checking is an element is visible with a specific locator for a driver
+
+You can use the `WaitUntilConditions.ElementIsVisible` condition to wait for an element to be visible with a specific locator.
+
+```csharp
+[Test]
+public void ShouldWaitForElementToBeVisible()
+{
+    this.App.WaitUntil(
+        WaitUntilConditions.ElementIsVisible(By.Id("input")),
+        TimeSpan.FromSeconds(5),
+        3);
+}
+```
+
+### Checking is an element is visible with a specific locator for a page object
+
+You can use the `WaitUntilConditions.ElementIsVisibleInPage` condition to wait for an element to be visible with a specific locator.
+
+```csharp
+[Test]
+public void ShouldWaitForElementToBeVisibleInPage()
+{
+    new HomePage(this.App).WaitUntil(
+        WaitUntilConditions.ElementIsVisibleInPage<HomePage>(By.Id("input")),
         TimeSpan.FromSeconds(5),
         3);
 }

--- a/docs/articles/using-legerity/wait-conditions.md
+++ b/docs/articles/using-legerity/wait-conditions.md
@@ -169,3 +169,55 @@ public void ShouldWaitForElementToBeVisibleInPage()
         3);
 }
 ```
+
+### Checking is an element is not visible with a specific locator for a driver
+
+You can use the `WaitUntilConditions.ElementIsNotVisible` condition to wait for an element to be hidden (not visible) with a specific locator.
+
+```csharp
+[Test]
+public void ShouldWaitForElementToNotBeVisible()
+{
+    this.App.WaitUntil(
+        WaitUntilConditions.ElementIsNotVisible(By.Id("input")),
+        TimeSpan.FromSeconds(5),
+        3);
+}
+```
+
+### Checking is an element is not visible with a specific locator for a page object
+
+You can use the `WaitUntilConditions.ElementIsNotVisibleInPage` condition to wait for an element to be hidden (not visible) with a specific locator.
+
+```csharp
+[Test]
+public void ShouldWaitForElementToNotBeVisibleInPage()
+{
+    new HomePage(this.App).WaitUntil(
+        WaitUntilConditions.ElementIsNotVisibleInPage<HomePage>(By.Id("input")),
+        TimeSpan.FromSeconds(5),
+        3);
+}
+```
+
+### Checking a frame is available and switching to it
+
+You can use the `WaitUntilConditions.FrameAvailableToSwitchTo` condition to wait for a frame in the driver to be available and switch to it.
+
+```csharp
+[Test]
+public void ShouldWaitForFrameToBeAvailable()
+{
+    // By frame name
+    this.App.WaitUntil(
+        WaitUntilConditions.FrameAvailableToSwitchTo("frame"),
+        TimeSpan.FromSeconds(5),
+        3);
+
+    // By frame locator
+    this.App.WaitUntil(
+        WaitUntilConditions.FrameAvailableToSwitchTo(By.Id("frame")),
+        TimeSpan.FromSeconds(5),
+        3);
+}
+```

--- a/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
+++ b/src/Legerity.Android/Extensions/AndroidElementWrapperExtensions.cs
@@ -1,58 +1,68 @@
-namespace Legerity.Android.Extensions
+namespace Legerity.Android.Extensions;
+
+using System;
+using Legerity.Android.Elements;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for <see cref="AndroidElementWrapper"/> objects.
+/// </summary>
+public static class AndroidElementWrapperExtensions
 {
-    using System;
-    using Legerity.Android.Elements;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Support.UI;
-
     /// <summary>
-    /// Defines a collection of extensions for <see cref="AndroidElementWrapper"/> objects.
+    /// Attempts to wait until a specified element condition is met, with an optional timeout.
     /// </summary>
-    public static class AndroidElementWrapperExtensions
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <param name="exceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>Whether the wait was a success.</returns>
+    public static bool TryWaitUntil<TElementWrapper, TResult>(
+        this TElementWrapper element,
+        Func<TElementWrapper, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0,
+        Action<Exception> exceptionHandler = null)
+        where TElementWrapper : AndroidElementWrapper
     {
-        /// <summary>
-        /// Attempts to wait until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
-        /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
-        /// <returns>Whether the wait was a success.</returns>
-        public static bool TryWaitUntil<TElementWrapper>(
-            this TElementWrapper element,
-            Func<TElementWrapper, bool> condition,
-            TimeSpan? timeout = default,
-            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
-            where TElementWrapper : AndroidElementWrapper
+        try
         {
-            try
-            {
-                WaitUntil(element, condition, timeout);
-            }
-            catch (WebDriverTimeoutException ex)
-            {
-                timeoutExceptionHandler?.Invoke(ex);
-                return false;
-            }
-
-            return true;
+            WaitUntil(element, condition, timeout, retries);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            return false;
         }
 
-        /// <summary>
-        /// Waits until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(
-            this TElementWrapper element,
-            Func<TElementWrapper, bool> condition,
-            TimeSpan? timeout = default)
-            where TElementWrapper : AndroidElementWrapper
+        return true;
+    }
+
+    /// <summary>
+    /// Waits until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <typeparam name="TElementWrapper">The type of <see cref="AndroidElementWrapper"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>The <typeparamref name="TResult"/> of the wait until operation.</returns>
+    /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+    public static TResult WaitUntil<TElementWrapper, TResult>(
+        this TElementWrapper element,
+        Func<TElementWrapper, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0)
+        where TElementWrapper : AndroidElementWrapper
+    {
+        try
         {
-            new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>
+            return new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(_ =>
             {
                 try
                 {
@@ -60,9 +70,18 @@ namespace Legerity.Android.Extensions
                 }
                 catch (StaleElementReferenceException)
                 {
-                    return false;
+                    return default;
                 }
             });
+        }
+        catch (WebDriverException)
+        {
+            if (retries <= 0)
+            {
+                throw;
+            }
+
+            return WaitUntil(element, condition, timeout, retries - 1);
         }
     }
 }

--- a/src/Legerity.Core/ByAll.cs
+++ b/src/Legerity.Core/ByAll.cs
@@ -1,0 +1,73 @@
+namespace Legerity;
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenQA.Selenium;
+
+/// <summary>
+/// Defines a <see cref="By"/> locator that can be used to find all elements that match all locators in sequence.
+/// </summary>
+/// <remarks>
+/// The order of the locators is run in sequence which means that results of <see cref="FindElements"/> may not be in order of their location on screen.
+/// </remarks>
+/// <example>
+/// The following example shows how to find all elements that match the class name and then the text. All locators must match for the element to be returned.
+/// <code>
+/// driver.FindElement(new ByAll(By.ClassName("my-class"), By.Text("My Text")));
+/// </code>
+/// </example>
+public class ByAll : By
+{
+    private readonly By[] locators;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ByAll"/> class.
+    /// </summary>
+    /// <param name="locators">The locators to find all references of.</param>
+    public ByAll(params By[] locators)
+    {
+        this.locators = locators;
+    }
+
+    /// <summary>Finds the first element matching the criteria.</summary>
+    /// <param name="context">An <see cref="T:OpenQA.Selenium.ISearchContext" /> object to use to search for the elements.</param>
+    /// <returns>The first matching <see cref="T:OpenQA.Selenium.IWebElement" /> on the current context.</returns>
+    /// <exception cref="NoSuchElementException">Unable to find element using the by locators.</exception>
+    public override IWebElement FindElement(ISearchContext context)
+    {
+        ReadOnlyCollection<IWebElement> elements = this.FindElements(context);
+        if (elements.Count == 0)
+        {
+            throw new NoSuchElementException($"Unable to find element using {this}");
+        }
+
+        return elements[0];
+    }
+
+    /// <summary>Finds all elements matching the criteria.</summary>
+    /// <param name="context">An <see cref="T:OpenQA.Selenium.ISearchContext" /> object to use to search for the elements.</param>
+    /// <returns>A <see cref="T:System.Collections.ObjectModel.ReadOnlyCollection`1" /> of all <see cref="T:OpenQA.Selenium.IWebElement">WebElements</see>
+    /// matching the current criteria, or an empty list if nothing matches.</returns>
+    public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
+    {
+        if (this.locators.Length == 0)
+        {
+            return new List<IWebElement>().AsReadOnly();
+        }
+
+        IEnumerable<IWebElement> elements = null;
+        foreach (By locator in this.locators)
+        {
+            ReadOnlyCollection<IWebElement> foundElements = locator.FindElements(context);
+            if (foundElements.Count == 0)
+            {
+                return new List<IWebElement>().AsReadOnly();
+            }
+
+            elements = elements == null ? foundElements : elements.Intersect(locator.FindElements(context));
+        }
+
+        return (elements ?? new List<IWebElement>()).ToList().AsReadOnly();
+    }
+}

--- a/src/Legerity.Core/ByNested.cs
+++ b/src/Legerity.Core/ByNested.cs
@@ -1,0 +1,78 @@
+namespace Legerity;
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenQA.Selenium;
+
+/// <summary>
+/// Defines a <see cref="By"/> locator that can be used to find elements using a sequence of locators that are continuously nested until the final locator is run.
+/// </summary>
+/// <example>
+/// The following example shows how to find all elements that match inputs that appear under divs, followed by forms.
+/// <code>
+/// driver.FindElements(new ByNested(By.TagName("div"), By.TagName("form"), By.TagName("input")));
+/// </code>
+/// </example>
+public class ByNested : By
+{
+    private readonly By[] locators;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ByNested"/> class.
+    /// </summary>
+    /// <param name="locators">The locators in nesting sequence to find references of.</param>
+    public ByNested(params By[] locators)
+    {
+        this.locators = locators;
+    }
+
+    /// <summary>Finds the first element matching the criteria.</summary>
+    /// <param name="context">An <see cref="T:OpenQA.Selenium.ISearchContext" /> object to use to search for the elements.</param>
+    /// <returns>The first matching <see cref="T:OpenQA.Selenium.IWebElement" /> on the current context.</returns>
+    /// <exception cref="NoSuchElementException">Unable to find element using the by locators.</exception>
+    public override IWebElement FindElement(ISearchContext context)
+    {
+        ReadOnlyCollection<IWebElement> elements = this.FindElements(context);
+        if (elements.Count == 0)
+        {
+            throw new NoSuchElementException($"Unable to find element using {this}");
+        }
+
+        return elements[0];
+    }
+
+    /// <summary>Finds all elements matching the criteria.</summary>
+    /// <param name="context">An <see cref="T:OpenQA.Selenium.ISearchContext" /> object to use to search for the elements.</param>
+    /// <returns>A <see cref="T:System.Collections.ObjectModel.ReadOnlyCollection`1" /> of all <see cref="T:OpenQA.Selenium.IWebElement">WebElements</see>
+    /// matching the current criteria, or an empty list if nothing matches.</returns>
+    public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
+    {
+        if (this.locators.Length == 0)
+        {
+            return new List<IWebElement>().AsReadOnly();
+        }
+
+        IEnumerable<IWebElement> elements = null;
+        foreach (By locator in this.locators)
+        {
+            var nestedElements = new List<IWebElement>();
+
+            if (elements == null)
+            {
+                nestedElements.AddRange(locator.FindElements(context));
+            }
+            else
+            {
+                foreach (IWebElement element in elements)
+                {
+                    nestedElements.AddRange(element.FindElements(locator));
+                }
+            }
+
+            elements = nestedElements;
+        }
+
+        return (elements ?? new List<IWebElement>()).ToList().AsReadOnly();
+    }
+}

--- a/src/Legerity.Core/Extensions/DriverExtensions.cs
+++ b/src/Legerity.Core/Extensions/DriverExtensions.cs
@@ -1,162 +1,162 @@
-namespace Legerity.Extensions
+namespace Legerity.Extensions;
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for a driver.
+/// </summary>
+public static class DriverExtensions
 {
-    using System;
-    using System.Collections.ObjectModel;
-    using System.Linq;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Remote;
-    using OpenQA.Selenium.Support.UI;
+    /// <summary>
+    /// Finds the first element in the page that matches the <see cref="By" /> locator.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>A <see cref="RemoteWebElement"/>.</returns>
+    public static RemoteWebElement FindWebElement(this RemoteWebDriver driver, By locator)
+    {
+        return driver.FindElement(locator) as RemoteWebElement;
+    }
 
     /// <summary>
-    /// Defines a collection of extensions for a driver.
+    /// Finds all the elements in the page that matches the <see cref="By" /> locator.
     /// </summary>
-    public static class DriverExtensions
+    /// <param name="driver">The remote web driver.</param>
+    /// <param name="locator">The locator to find the elements.</param>
+    /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
+    public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this RemoteWebDriver driver, By locator)
     {
-        /// <summary>
-        /// Finds the first element in the page that matches the <see cref="By" /> locator.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>A <see cref="RemoteWebElement"/>.</returns>
-        public static RemoteWebElement FindWebElement(this RemoteWebDriver driver, By locator)
+        return driver.FindElements(locator).Cast<RemoteWebElement>().ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Finds the first element in the page that matches the specified text.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <param name="text">The text to find.</param>
+    /// <returns>A <see cref="IWebElement"/>.</returns>
+    public static IWebElement FindElementByText(this RemoteWebDriver driver, string text)
+    {
+        return driver.FindElement(ByExtras.Text(text));
+    }
+
+    /// <summary>
+    /// Finds all the elements in the page that matches the specified text.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <param name="text">The text to find.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> FindElementsByText(this RemoteWebDriver driver, string text)
+    {
+        return driver.FindElements(ByExtras.Text(text));
+    }
+
+    /// <summary>
+    /// Finds the first element in the page that matches the specified text partially.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <param name="text">The partial text to find.</param>
+    /// <returns>A <see cref="IWebElement"/>.</returns>
+    public static IWebElement FindElementByPartialText(this RemoteWebDriver driver, string text)
+    {
+        return driver.FindElement(ByExtras.PartialText(text));
+    }
+
+    /// <summary>
+    /// Finds all the elements in the page that matches the specified text partially.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <param name="text">The partial text to find.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> FindElementsByPartialText(
+        this RemoteWebDriver driver,
+        string text)
+    {
+        return driver.FindElements(ByExtras.PartialText(text));
+    }
+
+    /// <summary>
+    /// Retrieves all elements that can be located by the driver in the page.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> GetAllElements(this RemoteWebDriver driver)
+    {
+        return driver.FindElements(By.XPath("//*"));
+    }
+
+    /// <summary>
+    /// Retrieves all child elements that can be located by the driver in the page.
+    /// </summary>
+    /// <param name="driver">The remote web driver.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> GetAllChildElements(this RemoteWebDriver driver)
+    {
+        return driver.FindElements(By.XPath(".//*"));
+    }
+
+    /// <summary>
+    /// Attempts to wait until a specified driver condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="appDriver">The driver to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <param name="exceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <returns>Whether the wait was a success.</returns>
+    public static bool TryWaitUntil(
+        this IWebDriver appDriver,
+        Func<IWebDriver, bool> condition,
+        TimeSpan? timeout = default,
+        int retries = 0,
+        Action<Exception> exceptionHandler = null)
+    {
+        try
         {
-            return driver.FindElement(locator) as RemoteWebElement;
+            WaitUntil(appDriver, condition, timeout, retries);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            return false;
         }
 
-        /// <summary>
-        /// Finds all the elements in the page that matches the <see cref="By" /> locator.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <param name="locator">The locator to find the elements.</param>
-        /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this RemoteWebDriver driver, By locator)
-        {
-            return driver.FindElements(locator).Cast<RemoteWebElement>().ToList().AsReadOnly();
-        }
+        return true;
+    }
 
-        /// <summary>
-        /// Finds the first element in the page that matches the specified text.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <param name="text">The text to find.</param>
-        /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByText(this RemoteWebDriver driver, string text)
+    /// <summary>
+    /// Waits until a specified driver condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="appDriver">The driver to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>The <typeparamref name="TResult"/> of the wait until operation.</returns>
+    /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+    public static TResult WaitUntil<TResult>(
+        this IWebDriver appDriver,
+        Func<IWebDriver, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0)
+    {
+        try
         {
-            return driver.FindElement(ByExtras.Text(text));
+            return new WebDriverWait(appDriver, timeout ?? TimeSpan.Zero).Until(condition);
         }
-
-        /// <summary>
-        /// Finds all the elements in the page that matches the specified text.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <param name="text">The text to find.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByText(this RemoteWebDriver driver, string text)
+        catch (WebDriverException)
         {
-            return driver.FindElements(ByExtras.Text(text));
-        }
-
-        /// <summary>
-        /// Finds the first element in the page that matches the specified text partially.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <param name="text">The partial text to find.</param>
-        /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByPartialText(this RemoteWebDriver driver, string text)
-        {
-            return driver.FindElement(ByExtras.PartialText(text));
-        }
-
-        /// <summary>
-        /// Finds all the elements in the page that matches the specified text partially.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <param name="text">The partial text to find.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText(
-            this RemoteWebDriver driver,
-            string text)
-        {
-            return driver.FindElements(ByExtras.PartialText(text));
-        }
-
-        /// <summary>
-        /// Retrieves all elements that can be located by the driver in the page.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> GetAllElements(this RemoteWebDriver driver)
-        {
-            return driver.FindElements(By.XPath("//*"));
-        }
-
-        /// <summary>
-        /// Retrieves all child elements that can be located by the driver in the page.
-        /// </summary>
-        /// <param name="driver">The remote web driver.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> GetAllChildElements(this RemoteWebDriver driver)
-        {
-            return driver.FindElements(By.XPath(".//*"));
-        }
-
-        /// <summary>
-        /// Attempts to wait until a specified driver condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="appDriver">The driver to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
-        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
-        /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
-        /// <returns>Whether the wait was a success.</returns>
-        public static bool TryWaitUntil(
-            this IWebDriver appDriver,
-            Func<IWebDriver, bool> condition,
-            TimeSpan? timeout = default,
-            int retries = 0,
-            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
-        {
-            try
+            if (retries <= 0)
             {
-                WaitUntil(appDriver, condition, timeout, retries);
-            }
-            catch (WebDriverTimeoutException ex)
-            {
-                timeoutExceptionHandler?.Invoke(ex);
-                return false;
+                throw;
             }
 
-            return true;
-        }
-
-        /// <summary>
-        /// Waits until a specified driver condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="appDriver">The driver to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
-        /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
-        public static void WaitUntil(
-            this IWebDriver appDriver,
-            Func<IWebDriver, bool> condition,
-            TimeSpan? timeout = default,
-            int retries = 0)
-        {
-            try
-            {
-                new WebDriverWait(appDriver, timeout ?? TimeSpan.Zero).Until(condition);
-            }
-            catch (WebDriverException)
-            {
-                if (retries <= 0)
-                {
-                    throw;
-                }
-
-                WaitUntil(appDriver, condition, timeout, retries - 1);
-            }
+            return WaitUntil(appDriver, condition, timeout, retries - 1);
         }
     }
 }

--- a/src/Legerity.Core/Extensions/ElementExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementExtensions.cs
@@ -1,135 +1,154 @@
-namespace Legerity.Extensions
+namespace Legerity.Extensions;
+
+using System;
+using System.Collections.ObjectModel;
+using System.Drawing;
+using System.Linq;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for elements.
+/// </summary>
+public static class ElementExtensions
 {
-    using System;
-    using System.Collections.ObjectModel;
-    using System.Drawing;
-    using System.Linq;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Remote;
-    using OpenQA.Selenium.Support.UI;
+    /// <summary>
+    /// Determines the bounding rectangle for the specified element.
+    /// </summary>
+    /// <param name="element">The element to determine the rect for.</param>
+    /// <returns>The elements bounding rectangle.</returns>
+    public static Rectangle GetBoundingRect(this IWebElement element)
+    {
+        Point location = element.Location;
+        Size size = element.Size;
+        return new Rectangle(location.X, location.Y, size.Width, size.Height);
+    }
 
     /// <summary>
-    /// Defines a collection of extensions for elements.
+    /// Finds the first element in the given element that matches the <see cref="By" /> locator.
     /// </summary>
-    public static class ElementExtensions
+    /// <param name="element">The remote web element.</param>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>A <see cref="RemoteWebElement"/>.</returns>
+    public static RemoteWebElement FindWebElement(this IWebElement element, By locator)
     {
-        /// <summary>
-        /// Determines the bounding rectangle for the specified element.
-        /// </summary>
-        /// <param name="element">The element to determine the rect for.</param>
-        /// <returns>The elements bounding rectangle.</returns>
-        public static Rectangle GetBoundingRect(this IWebElement element)
+        return element.FindElement(locator) as RemoteWebElement;
+    }
+
+    /// <summary>
+    /// Finds all the elements in the given element that matches the <see cref="By" /> locator.
+    /// </summary>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="locator">The locator to find the elements.</param>
+    /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
+    public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this IWebElement element, By locator)
+    {
+        return element.FindElements(locator).Cast<RemoteWebElement>().ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Finds the first element in the given element that matches the specified text.
+    /// </summary>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The text to find.</param>
+    /// <returns>A <see cref="IWebElement"/>.</returns>
+    public static IWebElement FindElementByText(this IWebElement element, string text)
+    {
+        return element.FindElement(ByExtras.Text(text));
+    }
+
+    /// <summary>
+    /// Finds all the elements in the given element that matches the specified text.
+    /// </summary>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The text to find.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> FindElementsByText(this IWebElement element, string text)
+    {
+        return element.FindElements(ByExtras.Text(text));
+    }
+
+    /// <summary>
+    /// Finds the first element in the given element that matches the specified text partially.
+    /// </summary>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The partial text to find.</param>
+    /// <returns>A <see cref="IWebElement"/>.</returns>
+    public static IWebElement FindElementByPartialText(this IWebElement element, string text)
+    {
+        return element.FindElement(ByExtras.PartialText(text));
+    }
+
+    /// <summary>
+    /// Finds all the elements in the given element that matches the specified text partially.
+    /// </summary>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The partial text to find.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> FindElementsByPartialText(this IWebElement element, string text)
+    {
+        return element.FindElements(ByExtras.PartialText(text));
+    }
+
+    /// <summary>
+    /// Retrieves all child elements that can be located by the driver for the given element.
+    /// </summary>
+    /// <param name="element">The remote web driver.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> GetAllChildElements(this IWebElement element)
+    {
+        return element.FindElements(By.XPath(".//*"));
+    }
+
+    /// <summary>
+    /// Attempts to wait until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <returns>Whether the wait was a success.</returns>
+    public static bool TryWaitUntil(
+        this RemoteWebElement element,
+        Func<RemoteWebElement, bool> condition,
+        TimeSpan? timeout = default,
+        Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
+    {
+        try
         {
-            Point location = element.Location;
-            Size size = element.Size;
-            return new Rectangle(location.X, location.Y, size.Width, size.Height);
+            WaitUntil(element, condition, timeout);
+        }
+        catch (WebDriverTimeoutException ex)
+        {
+            timeoutExceptionHandler?.Invoke(ex);
+            return false;
         }
 
-        /// <summary>
-        /// Finds the first element in the given element that matches the <see cref="By" /> locator.
-        /// </summary>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>A <see cref="RemoteWebElement"/>.</returns>
-        public static RemoteWebElement FindWebElement(this IWebElement element, By locator)
-        {
-            return element.FindElement(locator) as RemoteWebElement;
-        }
+        return true;
+    }
 
-        /// <summary>
-        /// Finds all the elements in the given element that matches the <see cref="By" /> locator.
-        /// </summary>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="locator">The locator to find the elements.</param>
-        /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public static ReadOnlyCollection<RemoteWebElement> FindWebElements(this IWebElement element, By locator)
+    /// <summary>
+    /// Waits until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    public static void WaitUntil(
+        this RemoteWebElement element,
+        Func<RemoteWebElement, bool> condition,
+        TimeSpan? timeout = default)
+    {
+        new WebDriverWait(element.WrappedDriver, timeout ?? TimeSpan.Zero).Until(_ =>
         {
-            return element.FindElements(locator).Cast<RemoteWebElement>().ToList().AsReadOnly();
-        }
-
-        /// <summary>
-        /// Finds the first element in the given element that matches the specified text.
-        /// </summary>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The text to find.</param>
-        /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByText(this IWebElement element, string text)
-        {
-            return element.FindElement(ByExtras.Text(text));
-        }
-
-        /// <summary>
-        /// Finds all the elements in the given element that matches the specified text.
-        /// </summary>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The text to find.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByText(this IWebElement element, string text)
-        {
-            return element.FindElements(ByExtras.Text(text));
-        }
-
-        /// <summary>
-        /// Finds the first element in the given element that matches the specified text partially.
-        /// </summary>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The partial text to find.</param>
-        /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByPartialText(this IWebElement element, string text)
-        {
-            return element.FindElement(ByExtras.PartialText(text));
-        }
-
-        /// <summary>
-        /// Finds all the elements in the given element that matches the specified text partially.
-        /// </summary>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The partial text to find.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText(this IWebElement element, string text)
-        {
-            return element.FindElements(ByExtras.PartialText(text));
-        }
-
-        /// <summary>
-        /// Retrieves all child elements that can be located by the driver for the given element.
-        /// </summary>
-        /// <param name="element">The remote web driver.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> GetAllChildElements(this IWebElement element)
-        {
-            return element.FindElements(By.XPath(".//*"));
-        }
-
-        /// <summary>
-        /// Waits until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <remarks>
-        /// This uses the AppManager.App instance to perform a wait.
-        /// </remarks>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        [Obsolete(
-            "WaitUntil for IWebElement instances will be removed in a future major release as it has a dependency on the static AppManager driver instance.")]
-        public static void WaitUntil<TElement>(
-            this TElement element,
-            Func<TElement, bool> condition,
-            TimeSpan? timeout = default)
-            where TElement : IWebElement
-        {
-            new WebDriverWait(AppManager.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            try
             {
-                try
-                {
-                    return condition(element);
-                }
-                catch (StaleElementReferenceException)
-                {
-                    return false;
-                }
-            });
-        }
+                return condition(element);
+            }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
+        });
     }
 }

--- a/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
+++ b/src/Legerity.Core/Extensions/ElementWrapperExtensions.cs
@@ -1,184 +1,194 @@
-namespace Legerity.Extensions
+namespace Legerity.Extensions;
+
+using System;
+using System.Collections.ObjectModel;
+using System.Drawing;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for <see cref="IElementWrapper{TElement}"/> objects.
+/// </summary>
+public static class ElementWrapperExtensions
 {
-    using System;
-    using System.Collections.ObjectModel;
-    using System.Drawing;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Remote;
-    using OpenQA.Selenium.Support.UI;
+    /// <summary>
+    /// Determines the bounding rectangle for the specified element.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The element to determine the rect for.</param>
+    /// <returns>The elements bounding rectangle.</returns>
+    public static Rectangle GetBoundingRect<TElement>(this IElementWrapper<TElement> element)
+        where TElement : IWebElement
+    {
+        return element.Element.GetBoundingRect();
+    }
 
     /// <summary>
-    /// Defines a collection of extensions for <see cref="IElementWrapper{TElement}"/> objects.
+    /// Finds the first element in the given element that matches the <see cref="By" /> locator.
     /// </summary>
-    public static class ElementWrapperExtensions
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>A <see cref="RemoteWebElement"/>.</returns>
+    public static RemoteWebElement FindWebElement<TElement>(this IElementWrapper<TElement> element, By locator)
+        where TElement : IWebElement
     {
-        /// <summary>
-        /// Determines the bounding rectangle for the specified element.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The element to determine the rect for.</param>
-        /// <returns>The elements bounding rectangle.</returns>
-        public static Rectangle GetBoundingRect<TElement>(this IElementWrapper<TElement> element)
-            where TElement : IWebElement
+        return element.Element.FindWebElement(locator);
+    }
+
+    /// <summary>
+    /// Finds all the elements in the given element that matches the <see cref="By" /> locator.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="locator">The locator to find the elements.</param>
+    /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
+    public static ReadOnlyCollection<RemoteWebElement> FindWebElements<TElement>(
+        this IElementWrapper<TElement> element, By locator)
+        where TElement : IWebElement
+    {
+        return element.Element.FindWebElements(locator);
+    }
+
+    /// <summary>
+    /// Finds the first element in the given element that matches the specified text.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The text to find.</param>
+    /// <returns>A <see cref="IWebElement"/>.</returns>
+    public static IWebElement FindElementByText<TElement>(this IElementWrapper<TElement> element, string text)
+        where TElement : IWebElement
+    {
+        return element.Element.FindElementByText(text);
+    }
+
+    /// <summary>
+    /// Finds all the elements in the given element that matches the specified text.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The text to find.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> FindElementsByText<TElement>(
+        this IElementWrapper<TElement> element, string text)
+        where TElement : IWebElement
+    {
+        return element.Element.FindElementsByText(text);
+    }
+
+    /// <summary>
+    /// Finds the first element in the given element that matches the specified text partially.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The partial text to find.</param>
+    /// <returns>A <see cref="IWebElement"/>.</returns>
+    public static IWebElement FindElementByPartialText<TElement>(
+        this IElementWrapper<TElement> element,
+        string text)
+        where TElement : IWebElement
+    {
+        return element.Element.FindElementByPartialText(text);
+    }
+
+    /// <summary>
+    /// Finds all the elements in the given element that matches the specified text partially.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web element.</param>
+    /// <param name="text">The partial text to find.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> FindElementsByPartialText<TElement>(
+        this IElementWrapper<TElement> element, string text)
+        where TElement : IWebElement
+    {
+        return element.Element.FindElementsByPartialText(text);
+    }
+
+    /// <summary>
+    /// Retrieves all child elements that can be located by the driver for the given element.
+    /// </summary>
+    /// <typeparam name="TElement">
+    /// The type of <see cref="IWebElement"/>.
+    /// </typeparam>
+    /// <param name="element">The remote web driver.</param>
+    /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
+    public static ReadOnlyCollection<IWebElement> GetAllChildElements<TElement>(
+        this IElementWrapper<TElement> element)
+        where TElement : IWebElement
+    {
+        return element.Element.GetAllChildElements();
+    }
+
+    /// <summary>
+    /// Attempts to wait until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <param name="exceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>Whether the wait was a success.</returns>
+    public static bool TryWaitUntil<TElement, TResult>(
+        this IElementWrapper<TElement> element,
+        Func<IElementWrapper<TElement>, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0,
+        Action<Exception> exceptionHandler = null)
+        where TElement : IWebElement
+    {
+        try
         {
-            return element.Element.GetBoundingRect();
+            WaitUntil(element, condition, timeout, retries);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            return false;
         }
 
-        /// <summary>
-        /// Finds the first element in the given element that matches the <see cref="By" /> locator.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>A <see cref="RemoteWebElement"/>.</returns>
-        public static RemoteWebElement FindWebElement<TElement>(this IElementWrapper<TElement> element, By locator)
-            where TElement : IWebElement
-        {
-            return element.Element.FindWebElement(locator);
-        }
+        return true;
+    }
 
-        /// <summary>
-        /// Finds all the elements in the given element that matches the <see cref="By" /> locator.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="locator">The locator to find the elements.</param>
-        /// <returns>A readonly collection of <see cref="RemoteWebElement"/>.</returns>
-        public static ReadOnlyCollection<RemoteWebElement> FindWebElements<TElement>(
-            this IElementWrapper<TElement> element, By locator)
-            where TElement : IWebElement
+    /// <summary>
+    /// Waits until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>The <typeparamref name="TResult"/> of the wait until operation.</returns>
+    /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+    public static TResult WaitUntil<TElement, TResult>(
+        this IElementWrapper<TElement> element,
+        Func<IElementWrapper<TElement>, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0)
+        where TElement : IWebElement
+    {
+        try
         {
-            return element.Element.FindWebElements(locator);
-        }
-
-        /// <summary>
-        /// Finds the first element in the given element that matches the specified text.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The text to find.</param>
-        /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByText<TElement>(this IElementWrapper<TElement> element, string text)
-            where TElement : IWebElement
-        {
-            return element.Element.FindElementByText(text);
-        }
-
-        /// <summary>
-        /// Finds all the elements in the given element that matches the specified text.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The text to find.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByText<TElement>(
-            this IElementWrapper<TElement> element, string text)
-            where TElement : IWebElement
-        {
-            return element.Element.FindElementsByText(text);
-        }
-
-        /// <summary>
-        /// Finds the first element in the given element that matches the specified text partially.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The partial text to find.</param>
-        /// <returns>A <see cref="IWebElement"/>.</returns>
-        public static IWebElement FindElementByPartialText<TElement>(
-            this IElementWrapper<TElement> element,
-            string text)
-            where TElement : IWebElement
-        {
-            return element.Element.FindElementByPartialText(text);
-        }
-
-        /// <summary>
-        /// Finds all the elements in the given element that matches the specified text partially.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web element.</param>
-        /// <param name="text">The partial text to find.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> FindElementsByPartialText<TElement>(
-            this IElementWrapper<TElement> element, string text)
-            where TElement : IWebElement
-        {
-            return element.Element.FindElementsByPartialText(text);
-        }
-
-        /// <summary>
-        /// Retrieves all child elements that can be located by the driver for the given element.
-        /// </summary>
-        /// <typeparam name="TElement">
-        /// The type of <see cref="IWebElement"/>.
-        /// </typeparam>
-        /// <param name="element">The remote web driver.</param>
-        /// <returns>A readonly collection of <see cref="IWebElement"/>.</returns>
-        public static ReadOnlyCollection<IWebElement> GetAllChildElements<TElement>(
-            this IElementWrapper<TElement> element)
-            where TElement : IWebElement
-        {
-            return element.Element.GetAllChildElements();
-        }
-
-        /// <summary>
-        /// Attempts to wait until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
-        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        /// <returns>Whether the wait was a success.</returns>
-        public static bool TryWaitUntil<TElement>(
-            this IElementWrapper<TElement> element,
-            Func<IElementWrapper<TElement>, bool> condition,
-            TimeSpan? timeout = default,
-            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
-            where TElement : IWebElement
-        {
-            try
-            {
-                WaitUntil(element, condition, timeout);
-            }
-            catch (WebDriverTimeoutException ex)
-            {
-                timeoutExceptionHandler?.Invoke(ex);
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Waits until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        public static void WaitUntil<TElement>(
-            this IElementWrapper<TElement> element,
-            Func<IElementWrapper<TElement>, bool> condition,
-            TimeSpan? timeout = default)
-            where TElement : IWebElement
-        {
-            new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>
+            return new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(_ =>
             {
                 try
                 {
@@ -186,9 +196,18 @@ namespace Legerity.Extensions
                 }
                 catch (StaleElementReferenceException)
                 {
-                    return false;
+                    return default;
                 }
             });
+        }
+        catch (WebDriverException)
+        {
+            if (retries <= 0)
+            {
+                throw;
+            }
+
+            return WaitUntil(element, condition, timeout, retries - 1);
         }
     }
 }

--- a/src/Legerity.Core/Extensions/PageExtensions.cs
+++ b/src/Legerity.Core/Extensions/PageExtensions.cs
@@ -1,56 +1,67 @@
-namespace Legerity.Extensions
+namespace Legerity.Extensions;
+
+using System;
+using Legerity.Pages;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for page objects.
+/// </summary>
+public static class PageExtensions
 {
-    using System;
-    using Legerity.Pages;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Support.UI;
-
     /// <summary>
-    /// Defines a collection of extensions for page objects.
+    /// Attempts to wait until a specified page condition is met, with an optional timeout.
     /// </summary>
-    public static class PageExtensions
+    /// <param name="page">The page to wait on.</param>
+    /// <param name="condition">The condition of the page to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <param name="exceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+    /// <returns>Whether the wait was a success and the instance of the page.</returns>
+    public static (bool success, TPage page) TryWaitUntil<TPage>(
+        this TPage page,
+        Func<TPage, bool> condition,
+        TimeSpan? timeout = default,
+        int retries = 0,
+        Action<Exception> exceptionHandler = null)
+        where TPage : BasePage
     {
-        /// <summary>
-        /// Attempts to wait until a specified page condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="page">The page to wait on.</param>
-        /// <param name="condition">The condition of the page to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
-        /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
-        /// <returns>Whether the wait was a success and the instance of the page.</returns>
-        public static (bool success, TPage page) TryWaitUntil<TPage>(
-            this TPage page,
-            Func<TPage, bool> condition,
-            TimeSpan? timeout = default,
-            Action<Exception> timeoutExceptionHandler = null)
-            where TPage : BasePage
+        try
         {
-            try
-            {
-                WaitUntil(page, condition, timeout);
-            }
-            catch (WebDriverTimeoutException ex)
-            {
-                timeoutExceptionHandler?.Invoke(ex);
-                return (false, page);
-            }
-
-            return (true, page);
+            WaitUntil(page, condition, timeout, retries);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            return (false, page);
         }
 
-        /// <summary>
-        /// Waits until a specified page condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="page">The page to wait on.</param>
-        /// <param name="condition">The condition of the page to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
-        /// <returns>The instance of the page.</returns>
-        public static TPage WaitUntil<TPage>(this TPage page, Func<TPage, bool> condition, TimeSpan? timeout = default)
-            where TPage : BasePage
+        return (true, page);
+    }
+
+    /// <summary>
+    /// Waits until a specified page condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="page">The page to wait on.</param>
+    /// <param name="condition">The condition of the page to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>The instance of the page.</returns>
+    /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+    public static TPage WaitUntil<TPage, TResult>(
+        this TPage page,
+        Func<TPage, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0)
+        where TPage : BasePage
+    {
+        try
         {
-            new WebDriverWait(page.App, timeout ?? TimeSpan.Zero).Until(driver =>
+            new WebDriverWait(page.App, timeout ?? TimeSpan.Zero).Until(_ =>
             {
                 try
                 {
@@ -58,11 +69,20 @@ namespace Legerity.Extensions
                 }
                 catch (StaleElementReferenceException)
                 {
-                    return false;
+                    return default;
                 }
             });
-
-            return page;
         }
+        catch (WebDriverException)
+        {
+            if (retries <= 0)
+            {
+                throw;
+            }
+
+            return WaitUntil(page, condition, timeout, retries - 1);
+        }
+
+        return page;
     }
 }

--- a/src/Legerity.Core/Helpers/WaitUntilConditions.cs
+++ b/src/Legerity.Core/Helpers/WaitUntilConditions.cs
@@ -200,6 +200,116 @@ public static class WaitUntilConditions
     }
 
     /// <summary>
+    /// A condition for validating whether a specified element found by a locator is hidden (not visible) within the context of the page.
+    /// </summary>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is hidden (not visible); otherwise, false.</returns>
+    public static Func<IWebDriver, bool> ElementIsNotVisible(By locator)
+    {
+        return driver =>
+        {
+            try
+            {
+                return !driver.FindElement(locator).Displayed;
+            }
+            catch (NoSuchElementException)
+            {
+                // Returns true because the element is not present.
+                return true;
+            }
+            catch (StaleElementReferenceException)
+            {
+                // Returns true because a stale element implies it is not present.
+                return true;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is hidden (not visible) within the context of an element.
+    /// </summary>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is hidden (not visible); otherwise, false.</returns>
+    public static Func<TElement, bool> ElementIsNotVisibleInElement<TElement>(By locator)
+        where TElement : IWebElement
+    {
+        return element =>
+        {
+            try
+            {
+                return !element.FindElement(locator).Displayed;
+            }
+            catch (NoSuchElementException)
+            {
+                // Returns true because the element is not present.
+                return true;
+            }
+            catch (StaleElementReferenceException)
+            {
+                // Returns true because a stale element implies it is not present.
+                return true;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is hidden (not visible) within the context of an element wrapper.
+    /// </summary>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is hidden (not visible); otherwise, false.</returns>
+    public static Func<IElementWrapper<TElement>, bool> ElementIsNotVisibleInElementWrapper<TElement>(By locator)
+        where TElement : IWebElement
+    {
+        return wrapper =>
+        {
+            try
+            {
+                return !wrapper.Element.FindElement(locator).Displayed;
+            }
+            catch (NoSuchElementException)
+            {
+                // Returns true because the element is not present.
+                return true;
+            }
+            catch (StaleElementReferenceException)
+            {
+                // Returns true because a stale element implies it is not present.
+                return true;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is hidden (not visible) within the context of a page object.
+    /// </summary>
+    /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is hidden (not visible); otherwise, false.</returns>
+    public static Func<TPage, bool> ElementIsNotVisibleInPage<TPage>(By locator)
+        where TPage : BasePage
+    {
+        return page =>
+        {
+            try
+            {
+                return !page.App.FindElement(locator).Displayed;
+            }
+            catch (NoSuchElementException)
+            {
+                // Returns true because the element is not present.
+                return true;
+            }
+            catch (StaleElementReferenceException)
+            {
+                // Returns true because a stale element implies it is not present.
+                return true;
+            }
+        };
+    }
+
+    /// <summary>
     /// A condition for switching to a frame by its name when it is available.
     /// </summary>
     /// <param name="frameName">The name of the frame to switch to.</param>

--- a/src/Legerity.Core/Helpers/WaitUntilConditions.cs
+++ b/src/Legerity.Core/Helpers/WaitUntilConditions.cs
@@ -1,112 +1,199 @@
-namespace Legerity.Helpers
+namespace Legerity.Helpers;
+
+using System;
+using Legerity.Pages;
+using OpenQA.Selenium;
+
+/// <summary>
+/// Defines a set of conditions that can be used with the WaitUntil methods of elements and pages.
+/// </summary>
+public static class WaitUntilConditions
 {
-    using System;
-    using Legerity.Pages;
-    using OpenQA.Selenium;
+    /// <summary>
+    /// A condition for validating whether the title of the current Window matches the specified title.
+    /// </summary>
+    /// <param name="title">The expected title, which must be an exact match.</param>
+    /// <param name="comparison">The comparison for validating equality.</param>
+    /// <returns>True if the title matches; otherwise, false.</returns>
+    public static Func<IWebDriver, bool> TitleIs(string title,
+        StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+    {
+        return driver => driver.Title.Equals(title, comparison);
+    }
 
     /// <summary>
-    /// Defines a set of conditions that can be used with the WaitUntil methods of elements and pages.
+    /// A condition for validating whether the title of the current Window contains a case-sensitive substring.
     /// </summary>
-    public static class WaitUntilConditions
+    /// <param name="title">The fragment of title expected.</param>
+    /// <returns>True if the title contains the text; otherwise, false.</returns>
+    public static Func<IWebDriver, bool> TitleContains(string title)
     {
-        /// <summary>
-        /// A condition for validating whether the title of the current Window matches the specified title.
-        /// </summary>
-        /// <param name="title">The expected title, which must be an exact match.</param>
-        /// <param name="comparison">The comparison for validating equality.</param>
-        /// <returns>True if the title matches; otherwise, false.</returns>
-        public static Func<IWebDriver, bool> TitleIs(string title, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
-        {
-            return driver => driver.Title.Equals(title, comparison);
-        }
+        return driver => driver.Title.Contains(title);
+    }
 
-        /// <summary>
-        /// A condition for validating whether the title of the current Window contains a case-sensitive substring.
-        /// </summary>
-        /// <param name="title">The fragment of title expected.</param>
-        /// <returns>True if the title contains the text; otherwise, false.</returns>
-        public static Func<IWebDriver, bool> TitleContains(string title)
-        {
-            return driver => driver.Title.Contains(title);
-        }
+    /// <summary>
+    /// A condition for validating whether the URL of the current Window matches the specified URL.
+    /// </summary>
+    /// <param name="url">The URL that the page should be on.</param>
+    /// <param name="comparison">The comparison for validating equality.</param>
+    /// <returns>True if the URL matches; otherwise, false.</returns>
+    public static Func<IWebDriver, bool> UrlIs(string url,
+        StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+    {
+        return driver => driver.Url.Equals(url, comparison);
+    }
 
-        /// <summary>
-        /// A condition for validating whether the URL of the current Window matches the specified URL.
-        /// </summary>
-        /// <param name="url">The URL that the page should be on.</param>
-        /// <param name="comparison">The comparison for validating equality.</param>
-        /// <returns>True if the URL matches; otherwise, false.</returns>
-        public static Func<IWebDriver, bool> UrlIs(string url, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
-        {
-            return driver => driver.Url.Equals(url, comparison);
-        }
+    /// <summary>
+    /// A condition for validating whether the URL of the current Window contains a case-sensitive substring.
+    /// </summary>
+    /// <param name="url">The fragment of URL expected.</param>
+    /// <returns>True if the URL contains the text; otherwise, false.</returns>
+    public static Func<IWebDriver, bool> UrlContains(string url)
+    {
+        return driver => driver.Url.Contains(url);
+    }
 
-        /// <summary>
-        /// A condition for validating whether the URL of the current Window contains a case-sensitive substring.
-        /// </summary>
-        /// <param name="url">The fragment of URL expected.</param>
-        /// <returns>True if the URL contains the text; otherwise, false.</returns>
-        public static Func<IWebDriver, bool> UrlContains(string url)
-        {
-            return driver => driver.Url.Contains(url);
-        }
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator exists within the context of the page.
+    /// <para>
+    /// Note, the element may exist but may not be visible.
+    /// </para>
+    /// </summary>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element exists; otherwise, false.</returns>
+    public static Func<IWebDriver, bool> ElementExists(By locator)
+    {
+        return driver => driver.FindElement(locator) != null;
+    }
 
-        /// <summary>
-        /// A condition for validating whether a specified element found by a locator exists within the context of the page.
-        /// <para>
-        /// Note, the element may exist but may not be visible.
-        /// </para>
-        /// </summary>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>True if the element exists; otherwise, false.</returns>
-        public static Func<IWebDriver, bool> ElementExists(By locator)
-        {
-            return driver => driver.FindElement(locator) != null;
-        }
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator exists within the context of an element.
+    /// <para>
+    /// Note, the element may exist but may not be visible.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element exists; otherwise, false.</returns>
+    public static Func<TElement, bool> ElementExistsInElement<TElement>(By locator)
+        where TElement : IWebElement
+    {
+        return element => element.FindElement(locator) != null;
+    }
 
-        /// <summary>
-        /// A condition for validating whether a specified element found by a locator exists within the context of an element.
-        /// <para>
-        /// Note, the element may exist but may not be visible.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>True if the element exists; otherwise, false.</returns>
-        public static Func<TElement, bool> ElementExistsInElement<TElement>(By locator)
-            where TElement : IWebElement
-        {
-            return element => element.FindElement(locator) != null;
-        }
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator exists within the context of an element wrapper.
+    /// <para>
+    /// Note, the element may exist but may not be visible.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element exists; otherwise, false.</returns>
+    public static Func<IElementWrapper<TElement>, bool> ElementExistsInElementWrapper<TElement>(By locator)
+        where TElement : IWebElement
+    {
+        return wrapper => wrapper.Element.FindElement(locator) != null;
+    }
 
-        /// <summary>
-        /// A condition for validating whether a specified element found by a locator exists within the context of an element wrapper.
-        /// <para>
-        /// Note, the element may exist but may not be visible.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>True if the element exists; otherwise, false.</returns>
-        public static Func<IElementWrapper<TElement>, bool> ElementExistsInElementWrapper<TElement>(By locator)
-            where TElement : IWebElement
-        {
-            return wrapper => wrapper.Element.FindElement(locator) != null;
-        }
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator exists within the context of a page object.
+    /// <para>
+    /// Note, the element may exist but may not be visible.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element exists; otherwise, false.</returns>
+    public static Func<TPage, bool> ElementExistsInPage<TPage>(By locator)
+        where TPage : BasePage
+    {
+        return page => page.App.FindElement(locator) != null;
+    }
 
-        /// <summary>
-        /// A condition for validating whether a specified element found by a locator exists within the context of a page object.
-        /// <para>
-        /// Note, the element may exist but may not be visible.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
-        /// <param name="locator">The locator to find the element.</param>
-        /// <returns>True if the element exists; otherwise, false.</returns>
-        public static Func<TPage, bool> ElementExistsInPage<TPage>(By locator)
-            where TPage : BasePage
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is visible within the context of the page.
+    /// </summary>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is visible; otherwise, false.</returns>
+    public static Func<IWebDriver, bool> ElementIsVisible(By locator)
+    {
+        return driver =>
         {
-            return page => page.App.FindElement(locator) != null;
-        }
+            try
+            {
+                return driver.FindElement(locator).Displayed;
+            }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is visible within the context of an element.
+    /// </summary>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is visible; otherwise, false.</returns>
+    public static Func<TElement, bool> ElementIsVisibleInElement<TElement>(By locator)
+        where TElement : IWebElement
+    {
+        return element =>
+        {
+            try
+            {
+                return element.FindElement(locator).Displayed;
+            }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is visible within the context of an element wrapper.
+    /// </summary>
+    /// <typeparam name="TElement">The type of <see cref="IWebElement"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is visible; otherwise, false.</returns>
+    public static Func<IElementWrapper<TElement>, bool> ElementIsVisibleInElementWrapper<TElement>(By locator)
+        where TElement : IWebElement
+    {
+        return wrapper =>
+        {
+            try
+            {
+                return wrapper.Element.FindElement(locator).Displayed;
+            }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for validating whether a specified element found by a locator is visible within the context of a page object.
+    /// </summary>
+    /// <typeparam name="TPage">The type of <see cref="BasePage"/>.</typeparam>
+    /// <param name="locator">The locator to find the element.</param>
+    /// <returns>True if the element is visible; otherwise, false.</returns>
+    public static Func<TPage, bool> ElementIsVisibleInPage<TPage>(By locator)
+        where TPage : BasePage
+    {
+        return page =>
+        {
+            try
+            {
+                return page.App.FindElement(locator).Displayed;
+            }
+            catch (StaleElementReferenceException)
+            {
+                return false;
+            }
+        };
     }
 }

--- a/src/Legerity.Core/Helpers/WaitUntilConditions.cs
+++ b/src/Legerity.Core/Helpers/WaitUntilConditions.cs
@@ -15,7 +15,8 @@ public static class WaitUntilConditions
     /// <param name="title">The expected title, which must be an exact match.</param>
     /// <param name="comparison">The comparison for validating equality.</param>
     /// <returns>True if the title matches; otherwise, false.</returns>
-    public static Func<IWebDriver, bool> TitleIs(string title,
+    public static Func<IWebDriver, bool> TitleIs(
+        string title,
         StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
     {
         return driver => driver.Title.Equals(title, comparison);
@@ -37,7 +38,8 @@ public static class WaitUntilConditions
     /// <param name="url">The URL that the page should be on.</param>
     /// <param name="comparison">The comparison for validating equality.</param>
     /// <returns>True if the URL matches; otherwise, false.</returns>
-    public static Func<IWebDriver, bool> UrlIs(string url,
+    public static Func<IWebDriver, bool> UrlIs(
+        string url,
         StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
     {
         return driver => driver.Url.Equals(url, comparison);
@@ -193,6 +195,47 @@ public static class WaitUntilConditions
             catch (StaleElementReferenceException)
             {
                 return false;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for switching to a frame by its name when it is available.
+    /// </summary>
+    /// <param name="frameName">The name of the frame to switch to.</param>
+    /// <returns>The <see cref="IWebDriver"/> for the frame that has been switched to.</returns>
+    public static Func<IWebDriver, IWebDriver> FrameAvailableToSwitchTo(string frameName)
+    {
+        return driver =>
+        {
+            try
+            {
+                return driver.SwitchTo().Frame(frameName);
+            }
+            catch (NoSuchFrameException)
+            {
+                return null;
+            }
+        };
+    }
+
+    /// <summary>
+    /// A condition for switching to a frame by its name when it is available.
+    /// </summary>
+    /// <param name="frameLocator">The locator of the frame to switch to.</param>
+    /// <returns>The <see cref="IWebDriver"/> for the frame that has been switched to.</returns>
+    public static Func<IWebDriver, IWebDriver> FrameAvailableToSwitchTo(By frameLocator)
+    {
+        return driver =>
+        {
+            try
+            {
+                IWebElement frameElement = driver.FindElement(frameLocator);
+                return driver.SwitchTo().Frame(frameElement);
+            }
+            catch (NoSuchFrameException)
+            {
+                return null;
             }
         };
     }

--- a/src/Legerity.Web/Elements/Core/Form.cs
+++ b/src/Legerity.Web/Elements/Core/Form.cs
@@ -1,0 +1,46 @@
+namespace Legerity.Web.Elements.Core;
+
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+
+/// <summary>
+/// Defines a <see cref="IWebElement"/> wrapper for the core web Form control.
+/// </summary>
+public class Form : WebElementWrapper
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Form"/> class.
+    /// </summary>
+    /// <param name="element">
+    /// The <see cref="IWebElement"/> reference.
+    /// </param>
+    public Form(IWebElement element)
+        : base(element)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Form"/> class.
+    /// </summary>
+    /// <param name="element">
+    /// The <see cref="RemoteWebElement"/> reference.
+    /// </param>
+    public Form(RemoteWebElement element)
+        : base(element)
+    {
+    }
+
+    /// <summary>
+    /// Allows conversion of a <see cref="IWebElement"/> to the <see cref="Form"/> without direct casting.
+    /// </summary>
+    /// <param name="element">
+    /// The <see cref="IWebElement"/>.
+    /// </param>
+    /// <returns>
+    /// The <see cref="Form"/>.
+    /// </returns>
+    public static implicit operator Form(RemoteWebElement element)
+    {
+        return new Form(element);
+    }
+}

--- a/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
+++ b/src/Legerity.Web/Extensions/WebElementWrapperExtensions.cs
@@ -1,58 +1,68 @@
-namespace Legerity.Web.Extensions
+namespace Legerity.Web.Extensions;
+
+using System;
+using Legerity.Web.Elements;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for <see cref="WebElementWrapper"/> objects.
+/// </summary>
+public static class WebElementWrapperExtensions
 {
-    using System;
-    using Legerity.Web.Elements;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Support.UI;
-
     /// <summary>
-    /// Defines a collection of extensions for <see cref="WebElementWrapper"/> objects.
+    /// Attempts to wait until a specified element condition is met, with an optional timeout.
     /// </summary>
-    public static class WebElementWrapperExtensions
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <param name="exceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>Whether the wait was a success.</returns>
+    public static bool TryWaitUntil<TElementWrapper, TResult>(
+        this TElementWrapper element,
+        Func<TElementWrapper, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0,
+        Action<Exception> exceptionHandler = null)
+        where TElementWrapper : WebElementWrapper
     {
-        /// <summary>
-        /// Attempts to wait until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
-        /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
-        /// <returns>Whether the wait was a success.</returns>
-        public static bool TryWaitUntil<TElementWrapper>(
-            this TElementWrapper element,
-            Func<TElementWrapper, bool> condition,
-            TimeSpan? timeout = default,
-            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
-            where TElementWrapper : WebElementWrapper
+        try
         {
-            try
-            {
-                WaitUntil(element, condition, timeout);
-            }
-            catch (WebDriverTimeoutException ex)
-            {
-                timeoutExceptionHandler?.Invoke(ex);
-                return false;
-            }
-
-            return true;
+            WaitUntil(element, condition, timeout, retries);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            return false;
         }
 
-        /// <summary>
-        /// Waits until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(
-            this TElementWrapper element,
-            Func<TElementWrapper, bool> condition,
-            TimeSpan? timeout = default)
-            where TElementWrapper : WebElementWrapper
+        return true;
+    }
+
+    /// <summary>
+    /// Waits until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <typeparam name="TElementWrapper">The type of <see cref="WebElementWrapper"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>The <typeparamref name="TResult"/> of the wait until operation.</returns>
+    /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+    public static TResult WaitUntil<TElementWrapper, TResult>(
+        this TElementWrapper element,
+        Func<TElementWrapper, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0)
+        where TElementWrapper : WebElementWrapper
+    {
+        try
         {
-            new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>
+            return new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(_ =>
             {
                 try
                 {
@@ -60,9 +70,18 @@ namespace Legerity.Web.Extensions
                 }
                 catch (StaleElementReferenceException)
                 {
-                    return false;
+                    return default;
                 }
             });
+        }
+        catch (WebDriverException)
+        {
+            if (retries <= 0)
+            {
+                throw;
+            }
+
+            return WaitUntil(element, condition, timeout, retries - 1);
         }
     }
 }

--- a/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
+++ b/src/Legerity.Windows/Extensions/WindowsElementWrapperExtensions.cs
@@ -1,58 +1,68 @@
-namespace Legerity.Windows.Extensions
+namespace Legerity.Windows.Extensions;
+
+using System;
+using Legerity.Windows.Elements;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+/// <summary>
+/// Defines a collection of extensions for <see cref="WindowsElementWrapper"/> objects.
+/// </summary>
+public static class WindowsElementWrapperExtensions
 {
-    using System;
-    using Legerity.Windows.Elements;
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Support.UI;
-
     /// <summary>
-    /// Defines a collection of extensions for <see cref="WindowsElementWrapper"/> objects.
+    /// Attempts to wait until a specified element condition is met, with an optional timeout.
     /// </summary>
-    public static class WindowsElementWrapperExtensions
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <param name="exceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
+    /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>Whether the wait was a success.</returns>
+    public static bool TryWaitUntil<TElementWrapper, TResult>(
+        this TElementWrapper element,
+        Func<TElementWrapper, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0,
+        Action<Exception> exceptionHandler = null)
+        where TElementWrapper : WindowsElementWrapper
     {
-        /// <summary>
-        /// Attempts to wait until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <param name="timeoutExceptionHandler">The optional exception handler thrown if an error occurs as a result of timeout.</param>
-        /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
-        /// <returns>Whether the wait was a success.</returns>
-        public static bool TryWaitUntil<TElementWrapper>(
-            this TElementWrapper element,
-            Func<TElementWrapper, bool> condition,
-            TimeSpan? timeout = default,
-            Action<WebDriverTimeoutException> timeoutExceptionHandler = null)
-            where TElementWrapper : WindowsElementWrapper
+        try
         {
-            try
-            {
-                WaitUntil(element, condition, timeout);
-            }
-            catch (WebDriverTimeoutException ex)
-            {
-                timeoutExceptionHandler?.Invoke(ex);
-                return false;
-            }
-
-            return true;
+            WaitUntil(element, condition, timeout, retries);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            return false;
         }
 
-        /// <summary>
-        /// Waits until a specified element condition is met, with an optional timeout.
-        /// </summary>
-        /// <param name="element">The element to wait on.</param>
-        /// <param name="condition">The condition of the element to wait on.</param>
-        /// <param name="timeout">The optional timeout wait on the condition being true.</param>
-        /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
-        public static void WaitUntil<TElementWrapper>(
-            this TElementWrapper element,
-            Func<TElementWrapper, bool> condition,
-            TimeSpan? timeout = default)
-            where TElementWrapper : WindowsElementWrapper
+        return true;
+    }
+
+    /// <summary>
+    /// Waits until a specified element condition is met, with an optional timeout.
+    /// </summary>
+    /// <param name="element">The element to wait on.</param>
+    /// <param name="condition">The condition of the element to wait on.</param>
+    /// <param name="timeout">The optional timeout wait on the condition being true.</param>
+    /// <param name="retries">An optional count of retries after a timeout before accepting the failure.</param>
+    /// <typeparam name="TElementWrapper">The type of <see cref="WindowsElementWrapper"/>.</typeparam>
+    /// <typeparam name="TResult">The type of expected result from the wait condition.</typeparam>
+    /// <returns>The <typeparamref name="TResult"/> of the wait until operation.</returns>
+    /// <exception cref="WebDriverException">Thrown if the condition is not met in the allocated timeout period.</exception>
+    public static TResult WaitUntil<TElementWrapper, TResult>(
+        this TElementWrapper element,
+        Func<TElementWrapper, TResult> condition,
+        TimeSpan? timeout = default,
+        int retries = 0)
+        where TElementWrapper : WindowsElementWrapper
+    {
+        try
         {
-            new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(driver =>
+            return new WebDriverWait(element.ElementDriver, timeout ?? TimeSpan.Zero).Until(_ =>
             {
                 try
                 {
@@ -60,9 +70,18 @@ namespace Legerity.Windows.Extensions
                 }
                 catch (StaleElementReferenceException)
                 {
-                    return false;
+                    return default;
                 }
             });
+        }
+        catch (WebDriverException)
+        {
+            if (retries <= 0)
+            {
+                throw;
+            }
+
+            return WaitUntil(element, condition, timeout, retries - 1);
         }
     }
 }

--- a/tests/Legerity.Core.Tests/Legerity.Core.Tests.csproj
+++ b/tests/Legerity.Core.Tests/Legerity.Core.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Legerity.Core\Legerity.Core.csproj" />
+    <ProjectReference Include="..\..\src\Legerity.Web\Legerity.Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Legerity.Core.Tests/Pages/W3SchoolsPage.cs
+++ b/tests/Legerity.Core.Tests/Pages/W3SchoolsPage.cs
@@ -1,0 +1,38 @@
+namespace Legerity.Core.Tests.Pages;
+
+using Legerity.Extensions;
+using Legerity.Web.Elements.Core;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using Tests;
+
+internal class W3SchoolsPage : BasePage
+{
+    private readonly By contentFrameLocator = By.Id("iframeResult");
+    private readonly By acceptCookiesButtonLocator = By.Id("accept-choices");
+
+    public W3SchoolsPage(RemoteWebDriver app)
+        : base(app, BaseTestClass.ImplicitWait)
+    {
+    }
+
+    protected override By Trait => this.contentFrameLocator;
+
+    public Button AcceptCookiesButton => this.FindElement(this.acceptCookiesButtonLocator);
+
+    public RemoteWebElement ContentFrame => this.FindElement(this.contentFrameLocator);
+
+    public T AcceptCookies<T>() where T : W3SchoolsPage
+    {
+        this.WaitUntil(page => page.AcceptCookiesButton.IsVisible, this.WaitTimeout);
+        this.AcceptCookiesButton.Click();
+        return (T)this;
+    }
+
+    public T SwitchToContentFrame<T>() where T : W3SchoolsPage
+    {
+        this.WaitUntil(page => page.ContentFrame.Displayed, this.WaitTimeout);
+        this.App.SwitchTo().Frame(this.ContentFrame);
+        return (T)this;
+    }
+}

--- a/tests/Legerity.Core.Tests/Tests/ByAllTests.cs
+++ b/tests/Legerity.Core.Tests/Tests/ByAllTests.cs
@@ -1,0 +1,122 @@
+namespace Legerity.Core.Tests.Tests;
+
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Remote;
+using Pages;
+using Shouldly;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+internal class ByAllTests : BaseTestClass
+{
+    [Test]
+    public void ShouldFindElementByAll()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act
+        RemoteWebElement element = page.FindElement(new ByAll(By.TagName("p"), ByExtras.PartialText("Please select")));
+
+        // Assert
+        element.ShouldNotBeNull();
+        element.Text.ShouldBe("Please select your favorite Web language:");
+    }
+
+    [Test]
+    public void ShouldFindElementsByAll()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act
+        ReadOnlyCollection<RemoteWebElement> elements =
+            page.FindElements(new ByAll(By.TagName("p"), ByExtras.PartialText("Please select")));
+
+        // Assert
+        elements.ShouldNotBeNull();
+        elements.Count.ShouldBe(2);
+    }
+
+    [Test]
+    public void ShouldThrowNoSuchElementExceptionIfFindElementReturnsNoResult()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act & Assert
+        Should.Throw<NoSuchElementException>(() =>
+            page.FindElement(new ByAll(By.TagName("p"), ByExtras.PartialText("This text does not exist"))));
+    }
+
+    [Test]
+    public void ShouldReturnEmptyCollectionIfFindElementsReturnsNoResult()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act
+        ReadOnlyCollection<RemoteWebElement> elements =
+            page.FindElements(new ByAll(By.TagName("p"), ByExtras.PartialText("This text does not exist")));
+
+        // Assert
+        elements.ShouldNotBeNull();
+        elements.Count.ShouldBe(0);
+    }
+}

--- a/tests/Legerity.Core.Tests/Tests/ByNestedTests.cs
+++ b/tests/Legerity.Core.Tests/Tests/ByNestedTests.cs
@@ -1,0 +1,122 @@
+namespace Legerity.Core.Tests.Tests;
+
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using Legerity.Core.Tests.Pages;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Remote;
+using Shouldly;
+using Web.Extensions;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+internal class ByNestedTests : BaseTestClass
+{
+    [Test]
+    public void ShouldFindElementByNested()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act
+        RemoteWebElement element = page.FindElement(new ByNested(By.TagName("form"), By.TagName("input")));
+
+        // Assert
+        element.ShouldNotBeNull();
+        element.GetValue().ShouldBe("HTML");
+    }
+
+    [Test]
+    public void ShouldFindElementsByNested()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act
+        ReadOnlyCollection<RemoteWebElement> elements =
+            page.FindElements(new ByNested(By.TagName("form"), WebByExtras.InputType("radio")));
+
+        // Assert
+        elements.ShouldNotBeNull();
+        elements.Count.ShouldBe(6);
+    }
+
+    [Test]
+    public void ShouldThrowNoSuchElementExceptionIfFindElementReturnsNoResult()
+    {
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act & Assert
+        Should.Throw<NoSuchElementException>(
+            () => page.FindElement(new ByNested(By.TagName("form"), By.TagName("div"))));
+    }
+
+    [Test]
+    public void ShouldReturnEmptyCollectionIfFindElementsReturnsNoResult()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act
+        ReadOnlyCollection<RemoteWebElement> elements =
+            page.FindElements(new ByNested(By.TagName("form"), By.TagName("div")));
+
+        // Assert
+        elements.ShouldNotBeNull();
+        elements.Count.ShouldBe(0);
+    }
+}

--- a/tests/Legerity.Core.Tests/Tests/WaitUntilConditionsTests.cs
+++ b/tests/Legerity.Core.Tests/Tests/WaitUntilConditionsTests.cs
@@ -1,0 +1,114 @@
+namespace Legerity.Core.Tests.Tests;
+
+using System;
+using System.IO;
+using Extensions;
+using Helpers;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Remote;
+using Pages;
+using Web.Elements.Core;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+internal class WaitUntilConditionsTests : BaseTestClass
+{
+    [Test]
+    public void ShouldWaitUntilElementIsVisible()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act & Assert
+        app.WaitUntil(WaitUntilConditions.ElementIsVisible(By.TagName("input")), ImplicitWait);
+    }
+
+    [Test]
+    public void ShouldWaitUntilElementIsVisibleInElement()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        RemoteWebElement element = page.FindElement(By.TagName("form"));
+
+        // Act & Assert
+        element.WaitUntil(WaitUntilConditions.ElementIsVisibleInElement<RemoteWebElement>(By.TagName("input")),
+            ImplicitWait);
+    }
+
+    [Test]
+    public void ShouldWaitUntilElementIsVisibleInElementWrapper()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        Form form = page.FindElement(By.TagName("form"));
+
+        // Act & Assert
+        form.WaitUntil(WaitUntilConditions.ElementIsVisibleInElementWrapper<RemoteWebElement>(By.TagName("input")),
+            ImplicitWait);
+    }
+
+    [Test]
+    public void ShouldWaitUntilElementIsVisibleInPageObject()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act & Assert
+        page.WaitUntil(WaitUntilConditions.ElementIsVisibleInPage<W3SchoolsPage>(By.TagName("input")), ImplicitWait);
+    }
+}

--- a/tests/Legerity.Core.Tests/Tests/WaitUntilElementIsNotVisibleTests.cs
+++ b/tests/Legerity.Core.Tests/Tests/WaitUntilElementIsNotVisibleTests.cs
@@ -12,10 +12,10 @@ using Web.Elements.Core;
 
 [TestFixture]
 [Parallelizable(ParallelScope.Children)]
-internal class WaitUntilConditionsTests : BaseTestClass
+internal class WaitUntilElementIsNotVisibleTests : BaseTestClass
 {
     [Test]
-    public void ShouldWaitUntilElementIsVisible()
+    public void ShouldWaitUntilElementIsNotVisible()
     {
         // Arrange
         var options = new WebAppManagerOptions(
@@ -34,11 +34,11 @@ internal class WaitUntilConditionsTests : BaseTestClass
             .SwitchToContentFrame<W3SchoolsPage>();
 
         // Act & Assert
-        app.WaitUntil(WaitUntilConditions.ElementIsVisible(By.TagName("input")), ImplicitWait);
+        app.WaitUntil(WaitUntilConditions.ElementIsNotVisible(By.TagName("select")), ImplicitWait);
     }
 
     [Test]
-    public void ShouldWaitUntilElementIsVisibleInElement()
+    public void ShouldWaitUntilElementIsNotVisibleInElement()
     {
         // Arrange
         var options = new WebAppManagerOptions(
@@ -59,12 +59,12 @@ internal class WaitUntilConditionsTests : BaseTestClass
         RemoteWebElement element = page.FindElement(By.TagName("form"));
 
         // Act & Assert
-        element.WaitUntil(WaitUntilConditions.ElementIsVisibleInElement<RemoteWebElement>(By.TagName("input")),
+        element.WaitUntil(WaitUntilConditions.ElementIsNotVisibleInElement<RemoteWebElement>(By.TagName("select")),
             ImplicitWait);
     }
 
     [Test]
-    public void ShouldWaitUntilElementIsVisibleInElementWrapper()
+    public void ShouldWaitUntilElementIsNotVisibleInElementWrapper()
     {
         // Arrange
         var options = new WebAppManagerOptions(
@@ -85,12 +85,12 @@ internal class WaitUntilConditionsTests : BaseTestClass
         Form form = page.FindElement(By.TagName("form"));
 
         // Act & Assert
-        form.WaitUntil(WaitUntilConditions.ElementIsVisibleInElementWrapper<RemoteWebElement>(By.TagName("input")),
+        form.WaitUntil(WaitUntilConditions.ElementIsNotVisibleInElementWrapper<RemoteWebElement>(By.TagName("select")),
             ImplicitWait);
     }
 
     [Test]
-    public void ShouldWaitUntilElementIsVisibleInPageObject()
+    public void ShouldWaitUntilElementIsNotVisibleInPageObject()
     {
         // Arrange
         var options = new WebAppManagerOptions(
@@ -109,6 +109,6 @@ internal class WaitUntilConditionsTests : BaseTestClass
             .SwitchToContentFrame<W3SchoolsPage>();
 
         // Act & Assert
-        page.WaitUntil(WaitUntilConditions.ElementIsVisibleInPage<W3SchoolsPage>(By.TagName("input")), ImplicitWait);
+        page.WaitUntil(WaitUntilConditions.ElementIsNotVisibleInPage<W3SchoolsPage>(By.TagName("select")), ImplicitWait);
     }
 }

--- a/tests/Legerity.Core.Tests/Tests/WaitUntilElementIsVisibleTests.cs
+++ b/tests/Legerity.Core.Tests/Tests/WaitUntilElementIsVisibleTests.cs
@@ -1,0 +1,114 @@
+namespace Legerity.Core.Tests.Tests;
+
+using System;
+using System.IO;
+using Extensions;
+using Helpers;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Remote;
+using Pages;
+using Web.Elements.Core;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+internal class WaitUntilElementIsVisibleTests : BaseTestClass
+{
+    [Test]
+    public void ShouldWaitUntilElementIsVisible()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act & Assert
+        app.WaitUntil(WaitUntilConditions.ElementIsVisible(By.TagName("input")), ImplicitWait);
+    }
+
+    [Test]
+    public void ShouldWaitUntilElementIsVisibleInElement()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        RemoteWebElement element = page.FindElement(By.TagName("form"));
+
+        // Act & Assert
+        element.WaitUntil(WaitUntilConditions.ElementIsVisibleInElement<RemoteWebElement>(By.TagName("input")),
+            ImplicitWait);
+    }
+
+    [Test]
+    public void ShouldWaitUntilElementIsVisibleInElementWrapper()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        Form form = page.FindElement(By.TagName("form"));
+
+        // Act & Assert
+        form.WaitUntil(WaitUntilConditions.ElementIsVisibleInElementWrapper<RemoteWebElement>(By.TagName("input")),
+            ImplicitWait);
+    }
+
+    [Test]
+    public void ShouldWaitUntilElementIsVisibleInPageObject()
+    {
+        // Arrange
+        var options = new WebAppManagerOptions(
+            WebAppDriverType.Chrome,
+            Path.Combine(Environment.CurrentDirectory))
+        {
+            Url = "https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio",
+            ImplicitWait = ImplicitWait,
+            DriverOptions = new ChromeOptions()
+        };
+
+        RemoteWebDriver app = this.StartApp(options);
+
+        W3SchoolsPage page = new W3SchoolsPage(app)
+            .AcceptCookies<W3SchoolsPage>()
+            .SwitchToContentFrame<W3SchoolsPage>();
+
+        // Act & Assert
+        page.WaitUntil(WaitUntilConditions.ElementIsVisibleInPage<W3SchoolsPage>(By.TagName("input")), ImplicitWait);
+    }
+}


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to incorporate new By locator features as well as additional wait condition functionality.

For By locators, these include:

- `ByAll` that can be used in place of a `By` locator to locate elements that match all of the provided `By` locators. This is useful when you want to find an element that matches multiple criteria, such as a button that has a specific text.
  - `RemoteWebElement element = app.FindElement(new ByAll(By.TagName("button"), ByExtras.Text("Send Message")));`
- `ByNested` that can be used in place of a `By` locator to locate elements that are nested by a sequence of locators. This is useful when you want to find an element that is nested within other elements, such as a button that is inside a form, inside an ID'd element.
  - `RemoteWebElement element = app.FindElement(new ByNested(By.Id("PersonContainer"), By.TagName("form"), By.TagName("button")));`

New wait conditions include:

- `ElementIsVisible` to wait for an element to be visible with a specific locator at the driver
- `ElementIsVisibleInElement` to wait for an element to be visible with a specific locator within another element
- `ElementIsVisibleInElementWrapper` to wait for an element to be visible with a specific locator within an element wrapper
- `ElementIsVisibleInPage` to wait for an element to be visible with a specific locator within a page object
- `ElementIsNotVisible` to wait for an element to be hidden (not visible) with a specific locator at the driver
- `ElementIsNotVisibleInElement` to wait for an element to be hidden (not visible) with a specific locator within another element
- `ElementIsNotVisibleInElementWrapper` to wait for an element to be hidden (not visible) with a specific locator within an element wrapper
- `ElementIsNotVisibleInPage` to wait for an element to be hidden (not visible) with a specific locator within a page object
- `FrameAvailableToSwitchTo` to wait for a frame within the driver to be available and then switching the driver context to that frame

All `WaitUntil` methods within the platform have been updated to incorporate a retry mechanism, as well as supporting wait conditions that return values other than Booleans. These methods have also been update to return the result of the condition also.

## PR checklist

- [x] Have Legerity sample tests been added or updated, run locally, and all pass
- [x] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [x] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->