### PR TITLE
Update Windows DatePicker to only set day/month/year looping selector if different

### DIFF
--- a/src/Legerity.Windows/Elements/Core/DatePicker.cs
+++ b/src/Legerity.Windows/Elements/Core/DatePicker.cs
@@ -88,14 +88,37 @@ public class DatePicker : WindowsElementWrapper
     /// <exception cref="NoSuchElementException">Thrown when no element matches the expected locator.</exception>
     public virtual void SetDate(DateTime date)
     {
-        // Taps the time picker to show the popup.
+        DateTime? selectedDate = this.SelectedDate;
+        if (selectedDate.HasValue && selectedDate.Value.Date == date.Date)
+        {
+            return;
+        }
+
+        string selectedDay = selectedDate?.ToString("%d");
+        string selectedMonth = selectedDate?.ToString("MMMM");
+        string selectedYear = selectedDate?.ToString("yyyy");
+
+        // Taps the date picker to show the popup.
         this.Click();
 
-        // Finds the popup and changes the time.
+        // Finds the popup and changes the date.
         WindowsElementWrapper popup = this.Driver.FindElement(WindowsByExtras.AutomationId("DatePickerFlyoutPresenter"));
-        popup.FindElement(WindowsByExtras.AutomationId("DayLoopingSelector")).FindElementByName(date.ToString("%d")).Click();
-        popup.FindElement(WindowsByExtras.AutomationId("MonthLoopingSelector")).FindElementByName(date.ToString("MMMM")).Click();
-        popup.FindElement(WindowsByExtras.AutomationId("YearLoopingSelector")).FindElementByName(date.ToString("yyyy")).Click();
+
+        if (selectedDay != date.ToString("%d"))
+        {
+            popup.FindElement(WindowsByExtras.AutomationId("DayLoopingSelector")).FindElementByName(date.ToString("%d")).Click();
+        }
+
+        if (selectedMonth != date.ToString("MMMM"))
+        {
+            popup.FindElement(WindowsByExtras.AutomationId("MonthLoopingSelector")).FindElementByName(date.ToString("MMMM")).Click();
+        }
+
+        if (selectedYear != date.ToString("yyyy"))
+        {
+            popup.FindElement(WindowsByExtras.AutomationId("YearLoopingSelector")).FindElementByName(date.ToString("yyyy")).Click();
+        }
+
         popup.FindElement(WindowsByExtras.AutomationId("AcceptButton")).Click();
     }
 

--- a/tests/Legerity.Windows.Tests/Tests/DatePickerTests.cs
+++ b/tests/Legerity.Windows.Tests/Tests/DatePickerTests.cs
@@ -1,6 +1,7 @@
 namespace Legerity.Windows.Tests.Tests;
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using OpenQA.Selenium.Remote;
 using Pages;
@@ -14,11 +15,10 @@ internal class DatePickerTests : BaseTestClass
     {
     }
 
-    [Test]
-    public void ShouldSelectDate()
+    [TestCaseSource(nameof(DateTestCases))]
+    public void ShouldSelectDate(DateTime expectedDate)
     {
         // Arrange
-        DateTime expectedDate = DateTime.Now.AddDays(1).Date;
         RemoteWebDriver app = this.StartApp();
         DatePickerPage datePickerPage = new HomePage(app).NavigateTo<DatePickerPage>("DatePicker");
 
@@ -41,6 +41,14 @@ internal class DatePickerTests : BaseTestClass
         datePickerPage.SetSimpleDatePickerDate(expectedDate);
 
         // Assert
-        datePickerPage.SimpleDatePicker.Value.ShouldBe(expectedDate.ToString("MMMM dd, yyyy", CultureInfo.CurrentCulture));
+        datePickerPage.SimpleDatePicker.Value.ShouldBe(expectedDate.ToString("MMMM d, yyyy", CultureInfo.CurrentCulture));
+    }
+
+    private static IEnumerable<DateTime> DateTestCases()
+    {
+        // Ensures that all looping selectors are tested.
+        yield return DateTime.Now.AddDays(1).Date;
+        yield return DateTime.Now.AddMonths(1).Date;
+        yield return DateTime.Now.AddYears(1).Date;
     }
 }


### PR DESCRIPTION
## Resolves #203 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to the Windows `DatePicker` element to ensure that only the values that have changed in a day, month, or year are interacted with. This change speeds up the test run for this particular action as each element is no longer being interacted with unnecessarily. 

## PR checklist

- [x] Have Legerity sample tests been added or updated, run locally, and all pass
- [x] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [x] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->