### PR TITLE
Typo in element-wrappers.md

### DIFF
--- a/docs/articles/using-legerity/element-wrappers.md
+++ b/docs/articles/using-legerity/element-wrappers.md
@@ -69,7 +69,7 @@ while(Math.Abs(currentSliderValue - 3) > double.Epsilon)
 
 As you can see, the element wrapper makes it much easier to interact with the element, and also makes the code much more maintainable and readable.
 
-## Finding elements withing element wrappers
+## Finding elements within element wrappers
 
 Element wrappers also expose a `FindElement` method that allows you to find elements within the element wrapper. This is a common scenario where you have a complex UI element that contains other elements.
 


### PR DESCRIPTION
I was reading through the docs to better understand the project since im a beginner to open source and i found this little typo so i would "contribute" even if its one letter.

## Resolves #
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

## PR checklist

- [ ] Have Legerity sample tests been added or updated, run locally, and all pass
- [ ] Have added or updated support for platform specific element wrappers been reflected in the Page Object Generator
- [ ] Have code styling rules been run on all new source file changes
- [ ] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->
![withing](https://github.com/user-attachments/assets/16d0bbc7-32a6-4f1c-a8b2-d8dc55a34e80)
