### PR TITLE
fix(docs): correct typo in element-wrappers.md

### DIFF
--- a/docs/articles/using-legerity/element-wrappers.md
+++ b/docs/articles/using-legerity/element-wrappers.md
@@ -69,7 +69,7 @@ while(Math.Abs(currentSliderValue - 3) > double.Epsilon)
 
 As you can see, the element wrapper makes it much easier to interact with the element, and also makes the code much more maintainable and readable.
 
-## Finding elements withing element wrappers
+## Finding elements within element wrappers
 
 Element wrappers also expose a `FindElement` method that allows you to find elements within the element wrapper. This is a common scenario where you have a complex UI element that contains other elements.
 


### PR DESCRIPTION
## Overview
This PR fixes a typo in the documentation for element wrappers. The word "withing" was corrected to "within" in the section about finding elements within element wrappers.

## Checklist
- [x] Code changes are minimal and focused
- [x] No tests are needed for this documentation fix
- [x] Documentation has been updated

## Proof
The typo was in the H2 heading "Finding elements withing element wrappers" which has been corrected to "Finding elements within element wrappers". This is a simple typo fix that improves the readability of the documentation.

## Closes #279